### PR TITLE
Gcm failure fallback

### DIFF
--- a/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
@@ -171,7 +171,7 @@ class CreateConversationSpec extends FeatureSpec with Matchers with OptionValues
         msg.getMembers.map(_.data.id) should contain theSameElementsAs auto1Members
       }
 
-      api.zmessaging.futureValue.value.push.onSlowSyncNeeded ! SlowSyncRequest(System.currentTimeMillis)
+      api.zmessaging.futureValue.value.pushSignals.onSlowSyncNeeded ! SlowSyncRequest(System.currentTimeMillis)
 
       awaitUi(1.second)
       withDelay {

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -59,8 +59,6 @@ import scala.util.Random
 trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket with MockedGcm { suite: Suite with Alerting with Informing =>
   private implicit val logTag: LogTag = logTagFor[MockedClientSuite]
 
-  val webSocketAlwaysOn = false
-
   @volatile private var pushService = Option.empty[PushService]
   @volatile protected var keyValueStoreOverrides = Map.empty[String, Option[String]]
 
@@ -78,7 +76,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
     val mockGcmState = Signal(GcmState(true, true))
   } with ZMessaging(clientId, userModule) {
 
-    override lazy val flowmanager: FlowManagerService = new MockedFlowManagerService(context, zNetClient, push, prefs, network)
+    override lazy val flowmanager: FlowManagerService = new MockedFlowManagerService(context, zNetClient, websocket, prefs, network)
     override lazy val mediamanager: MediaManagerService = new MockedMediaManagerService(context, prefs)
 
     override lazy val assetClient        = new AssetClient(zNetClient) {

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -32,6 +32,7 @@ import com.waz.model.otr.{Client, ClientId, SignalingKey}
 import com.waz.service
 import com.waz.service._
 import com.waz.service.call.FlowManagerService
+import com.waz.service.push.GcmService.GcmState
 import com.waz.service.push.PushService
 import com.waz.sync.client.AddressBookClient.UserAndContactIds
 import com.waz.sync.client.ConversationsClient.ConversationResponse
@@ -42,9 +43,9 @@ import com.waz.sync.client.OtrClient.{ClientKey, MessageResponse}
 import com.waz.sync.client.UserSearchClient.UserSearchEntry
 import com.waz.sync.client.VoiceChannelClient.JoinCallFailed
 import com.waz.sync.client._
-import com.waz.threading.CancellableFuture
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.threading.CancellableFuture.successful
-import com.waz.zms.GcmHandlerService
+import com.waz.utils.events.Signal
 import com.waz.znet.AuthenticationManager._
 import com.waz.znet.LoginClient.LoginResult
 import com.waz.znet.ZNetClient._
@@ -73,7 +74,9 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
     override lazy val otrClient: OtrClient = new MockedOtrClient(account.netClient)
   }
 
-  class MockedZMessaging(clientId: ClientId, userModule: UserModule) extends ZMessaging(clientId, userModule) {
+  class MockedZMessaging(clientId: ClientId, userModule: UserModule) extends {
+    val mockGcmState = Signal(GcmState(true, true))
+  } with ZMessaging(clientId, userModule) {
 
     override lazy val flowmanager: FlowManagerService = new MockedFlowManagerService(context, zNetClient, push, prefs, network)
     override lazy val mediamanager: MediaManagerService = new MockedMediaManagerService(context, prefs)
@@ -124,9 +127,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
       override def updateConnection(user: UserId, status: ConnectionStatus): ErrorOrResponse[Option[UserConnectionEvent]] = suite.updateConnection(user, status)
     }
 
-    override lazy val websocket: service.push.WebSocketClientService = new service.push.WebSocketClientService(context, lifecycle, zNetClient, network, gcmGlobal, global.backend, clientId, timeouts) {
-
-      override val webSocketAlwaysOn = suite.webSocketAlwaysOn
+    override lazy val websocket: service.push.WebSocketClientService = new service.push.WebSocketClientService(context, lifecycle, zNetClient, network, mockGcmState, global.backend, clientId, timeouts) {
 
       override def createWebSocketClient(clientId: ClientId): WebSocketClient = new WebSocketClient(context, zNetClient.client, Uri.parse(backend.pushUrl), zNetClient.auth) {
         override def close() = dispatcher {
@@ -186,7 +187,13 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
       verbose(s"push ignored, web socket not connected")
       false
   }
-  override def pushGcm(notification: PushNotification, userId: UserId) = Option(ZMessaging.currentAccounts).foreach(_ => new GcmHandlerService().handleNotification(notification, Some(userId)))
+  override def pushGcm(notification: PushNotification, userId: UserId) =
+    Option(ZMessaging.currentAccounts) foreach { accounts =>
+      accounts.getCurrentZms.foreach {
+        case Some(zms) if zms.selfUserId == userId => zms.gcm.handleNotification(notification)
+        case _ =>
+      }(Threading.Background)
+    }
 
   class MockedGlobalModule(context: Context, backend: BackendConfig, testClient: AsyncClient) extends GlobalModule(context, testBackend) {
     override lazy val client: AsyncClient = testClient

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedFlowManagerService.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedFlowManagerService.scala
@@ -20,16 +20,16 @@ package com.waz.mocked
 import android.content.Context
 import com.waz.api.VideoSendState
 import com.waz.model.{CallSessionId, CaptureDeviceData, RConvId, UserId}
-import com.waz.service.{NetworkModeService, PreferenceService}
 import com.waz.service.call.FlowManagerService
-import com.waz.service.push.PushService
+import com.waz.service.push.WebSocketClientService
+import com.waz.service.{NetworkModeService, PreferenceService}
 import com.waz.threading.SerialDispatchQueue
 import com.waz.znet.ZNetClient
 
 import scala.concurrent.Future
 
-class MockedFlowManagerService(context: Context, netClient: ZNetClient, push: PushService, prefs: PreferenceService, network: NetworkModeService)
-  extends FlowManagerService(context, netClient, push, prefs, network) { self =>
+class MockedFlowManagerService(context: Context, netClient: ZNetClient, websocket: WebSocketClientService, prefs: PreferenceService, network: NetworkModeService)
+  extends FlowManagerService(context, netClient, websocket, prefs, network) { self =>
 
   private implicit val dispatcher = new SerialDispatchQueue(name = "MockedFlowManagerService")
 

--- a/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
@@ -26,13 +26,14 @@ import com.waz.client.RegistrationClient
 import com.waz.model._
 import com.waz.model.otr.ClientId
 import com.waz.service._
+import com.waz.service.push.GcmService.GcmState
 import com.waz.service.push.WebSocketClientService
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
 import com.waz.testutils.{DefaultPatienceConfig, EmptySyncService, MockAccounts, MockGlobalModule, MockUiModule, MockZMessagingFactory}
 import com.waz.threading.CancellableFuture
 import com.waz.ui.UiModule
-import com.waz.utils.events.EventContext
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.{IoUtils, Json}
 import com.waz.znet.AuthenticationManager.{Cookie, Token}
 import com.waz.znet.ContentEncoder.{BinaryRequestContent, EmptyRequestContent, RequestContent}
@@ -90,7 +91,7 @@ class RegistrationSpec extends FeatureSpec with Matchers with OptionValues with 
               super.syncSelfUser()
             }
           }
-          override lazy val websocket = new WebSocketClientService(context, lifecycle, zNetClient, network, gcmGlobal, backend, clientId, timeouts) {
+          override lazy val websocket = new WebSocketClientService(context, lifecycle, zNetClient, network, Signal const GcmState(true, true), backend, clientId, timeouts) {
             override private[waz] def createWebSocketClient(clientId: ClientId): WebSocketClient = new WebSocketClient(context, zNetClient.client, Uri.parse("/"), zNetClient.auth) {
               override protected def connect(): CancellableFuture[WebSocket] = CancellableFuture.failed(new Exception("mock") with NoStackTrace)
             }

--- a/tests/unit/src/test/scala/com/waz/service/PushServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/PushServiceSpec.scala
@@ -56,7 +56,7 @@ class PushServiceSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       }
     }
 
-    override lazy val websocket = new WebSocketClientService(context, lifecycle, zNetClient, network, gcmGlobal, global.backend, clientId, timeouts) {
+    override lazy val websocket = new WebSocketClientService(context, lifecycle, zNetClient, network, mockGcmState, global.backend, clientId, timeouts) {
       override val connected = wsConnected
     }
 

--- a/tests/unit/src/test/scala/com/waz/service/PushServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/PushServiceSpec.scala
@@ -71,7 +71,7 @@ class PushServiceSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       override def loadLastNotification(client: ClientId) = CancellableFuture.delayed(clientDelay)(Right(lastNotification))
     }
 
-    push.onSlowSyncNeeded { _ => slowSyncRequested += 1 }
+    pushSignals.onSlowSyncNeeded { _ => slowSyncRequested += 1 }
   }
 
   lazy val service = zms.push

--- a/tests/unit/src/test/scala/com/waz/service/avs/FlowManagerServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/avs/FlowManagerServiceSpec.scala
@@ -47,7 +47,7 @@ class FlowManagerServiceSpec extends FeatureSpec with Matchers with OptionValues
       })
     }
 
-    override lazy val websocket: WebSocketClientService = new WebSocketClientService(context, lifecycle, zNetClient, network, gcmGlobal, global.backend, clientId, timeouts) {
+    override lazy val websocket: WebSocketClientService = new WebSocketClientService(context, lifecycle, zNetClient, network, mockGcmState, global.backend, clientId, timeouts) {
       override val connected = wsConnected
     }
   }

--- a/tests/unit/src/test/scala/com/waz/service/avs/FlowManagerServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/avs/FlowManagerServiceSpec.scala
@@ -41,7 +41,7 @@ class FlowManagerServiceSpec extends FeatureSpec with Matchers with OptionValues
   @volatile var notified = false
 
   lazy val zms = new MockZMessaging() {
-    override lazy val flowmanager: FlowManagerService = new FlowManagerService(context, zNetClient, push, prefs, network) {
+    override lazy val flowmanager: FlowManagerService = new FlowManagerService(context, zNetClient, websocket, prefs, network) {
       override lazy val flowManager = Some(new FlowManager(context, requestHandler) {
         override def networkChanged(): Unit = notified = true
       })

--- a/tests/unit/src/test/scala/com/waz/service/call/VoiceChannelServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/call/VoiceChannelServiceSpec.scala
@@ -96,7 +96,7 @@ class VoiceChannelServiceSpec extends FeatureSpec with Matchers with BeforeAndAf
         }
       }
 
-      override lazy val flowmanager: FlowManagerService = new FlowManagerService(context, zNetClient, push, prefs, network) {
+      override lazy val flowmanager: FlowManagerService = new FlowManagerService(context, zNetClient, websocket, prefs, network) {
         override lazy val flowManager = None
       }
 

--- a/tests/unit/src/test/scala/com/waz/service/push/LastNotificationIdServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/push/LastNotificationIdServiceSpec.scala
@@ -41,7 +41,7 @@ class LastNotificationIdServiceSpec extends FeatureSpec with Matchers with Robol
   val wsConnected = Signal(false)
 
   lazy val pushSignals = new PushServiceSignals {
-    override val pushConnected: Signal[Boolean] = wsConnected
+    override val pushConnected = wsConnected
   }
   lazy val eventsClient = new EventsClient(new EmptyClient) {
     override def loadLastNotification(client: ClientId) = CancellableFuture.delayed(100.millis)(Right(lastNotificationResponse))

--- a/tests/unit/src/test/scala/com/waz/service/push/WebSocketClientServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/push/WebSocketClientServiceSpec.scala
@@ -20,8 +20,10 @@ package com.waz.service.push
 import com.waz.RobolectricUtils
 import com.waz.model.otr.ClientId
 import com.waz.service._
+import com.waz.service.push.GcmService.GcmState
 import com.waz.testutils.DefaultPatienceConfig
 import com.waz.utils.events.EventContext.Implicits.global
+import com.waz.utils.events.Signal
 import com.waz.znet.ZNetClient.EmptyClient
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FeatureSpec, Matchers, RobolectricTests}
@@ -42,11 +44,8 @@ class WebSocketClientServiceSpec extends FeatureSpec with Matchers with Robolect
   lazy val network = new NetworkModeService(context)
   lazy val prefs = new PreferenceService(context)
   lazy val meta = new MetaDataService(context)
-  lazy val gcm = new GcmGlobalService(context, prefs, meta, BackendConfig.EdgeBackend) {
-    override lazy val gcmAvailable = true
-  }
 
-  lazy val service = new WebSocketClientService(context, lifecycle, new EmptyClient, network, gcm, BackendConfig.EdgeBackend, ClientId(), timeouts)
+  lazy val service = new WebSocketClientService(context, lifecycle, new EmptyClient, network, Signal const GcmState(true, true), BackendConfig.EdgeBackend, ClientId(), timeouts)
 
 
   feature("active client") {

--- a/tests/unit/src/test/scala/com/waz/sync/ConversationsSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/ConversationsSyncHandlerSpec.scala
@@ -68,7 +68,7 @@ class ConversationsSyncHandlerSpec extends FeatureSpec with Matchers with ScalaF
     lifecycle.acquireUi()
 
     override lazy val conversations: ConversationsService =
-      new ConversationsService(context, push, users, usersStorage, messagesStorage, membersStorage,
+      new ConversationsService(context, pushSignals, users, usersStorage, messagesStorage, membersStorage,
         convsStorage, convsContent, convsStats, sync, errors, messages, assets, db, messagesContent, kvStorage, eventScheduler) {
 
         override def updateConversations(conversations: Seq[ConversationResponse]) = Future.successful(Nil)

--- a/tests/unit/src/test/scala/com/waz/sync/otr/OtrSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/otr/OtrSyncHandlerSpec.scala
@@ -56,7 +56,7 @@ class OtrSyncHandlerSpec extends FeatureSpec with Matchers with BeforeAndAfter w
 
   lazy val zms = new MockZMessaging(selfUserId = selfUser.id, clientId = clientId) {
 
-    override lazy val otrService: OtrService = new OtrService(selfUserId, clientId, otrClientsService, push, cryptoBox, membersStorage, convsContent, sync, cache, metadata, otrClientsStorage) {
+    override lazy val otrService: OtrService = new OtrService(selfUserId, clientId, otrClientsService, pushSignals, cryptoBox, membersStorage, convsContent, sync, cache, metadata, otrClientsStorage) {
       override def encryptMessage(convId: ConvId, msg: GenericMessage, useFakeOnError: Boolean, previous: EncryptedContent, recipients: Option[Set[UserId]]): Future[EncryptedContent] = {
         encryptMsgRequests = encryptMsgRequests :+ (convId, msg, useFakeOnError)
         Future successful encryptedContent

--- a/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
@@ -27,6 +27,7 @@ import com.waz.model.UserData.ConnectionStatus
 import com.waz.model._
 import com.waz.model.otr.{Client, ClientId}
 import com.waz.service._
+import com.waz.service.push.GcmService.GcmState
 import com.waz.service.push.WebSocketClientService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.OtrClient
@@ -93,7 +94,9 @@ class MockAccountService(val accounts: Accounts = new MockAccounts)(implicit ec:
 
 class MockUserModule(val mockAccount: MockAccountService = new MockAccountService(), userId: UserId = UserId()) extends UserModule(userId, mockAccount)
 
-class MockZMessaging(val mockUser: MockUserModule = new MockUserModule(), clientId: ClientId = ClientId()) extends ZMessaging(clientId, mockUser) { zms =>
+class MockZMessaging(val mockUser: MockUserModule = new MockUserModule(), clientId: ClientId = ClientId()) extends {
+  val mockGcmState = Signal(GcmState(true, true))
+} with ZMessaging(clientId, mockUser) { zms =>
   def this(selfUserId: UserId) = this(new MockUserModule(userId = selfUserId), ClientId())
   def this(selfUserId: UserId, clientId: ClientId) = this(new MockUserModule(userId = selfUserId), clientId)
   def this(account: MockAccountService, selfUserId: UserId) = this(new MockUserModule(account, userId = selfUserId), ClientId())
@@ -101,7 +104,6 @@ class MockZMessaging(val mockUser: MockUserModule = new MockUserModule(), client
   override lazy val sync: SyncServiceHandle = new EmptySyncService
   import Threading.Implicits.Background
 
-  var webSocketAlwaysOn = false
   var timeout = 5.seconds
 
   storage.usersStorage.put(selfUserId, UserData(selfUserId, "test name", Some(EmailAddress("test@test.com")), None, searchKey = SearchKey("test name"), connection = ConnectionStatus.Self))
@@ -120,10 +122,7 @@ class MockZMessaging(val mockUser: MockUserModule = new MockUserModule(), client
     }
   }
 
-  override lazy val websocket: WebSocketClientService = new WebSocketClientService(context, lifecycle, zNetClient, network, gcmGlobal, backend, clientId, timeouts) {
-
-    override val webSocketAlwaysOn = zms.webSocketAlwaysOn
-
+  override lazy val websocket: WebSocketClientService = new WebSocketClientService(context, lifecycle, zNetClient, network, mockGcmState, backend, clientId, timeouts) {
     override private[waz] def createWebSocketClient(clientId: ClientId): WebSocketClient = new WebSocketClient(context, zNetClient.client, Uri.parse("http://"), zNetClient.auth) {
       override protected def connect(): CancellableFuture[WebSocket] = CancellableFuture.failed(new Exception("mock"))
     }

--- a/zmessaging/src/main/scala/com/waz/service/GlobalNotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalNotificationService.scala
@@ -29,14 +29,14 @@ import com.waz.api.impl.ActiveChannel
 import com.waz.bitmap
 import com.waz.bitmap.BitmapUtils
 import com.waz.model._
-import com.waz.service.push.NotificationService.Notification
 import com.waz.service.ZMessaging.EmptyNotificationsHandler
 import com.waz.service.assets.AssetService.BitmapRequest.Regular
 import com.waz.service.assets.AssetService.BitmapResult
 import com.waz.service.images.BitmapSignal
+import com.waz.service.push.NotificationService.Notification
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import com.waz.utils.events.{EventContext, Signal}
-import com.waz.zms.GcmHandlerService
+import com.waz.zms.PushService
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -122,7 +122,7 @@ object GlobalNotificationService {
   class NotificationsList(context: Context, notifications: Seq[GcmNotification]) extends GcmNotificationsList {
 
     lazy val gcmNotifications = notifications.asJava
-    lazy val clearIntent = PendingIntent.getService(context, 9730, GcmHandlerService.clearNotificationsIntent(context), PendingIntent.FLAG_UPDATE_CURRENT)
+    lazy val clearIntent = PendingIntent.getService(context, 9730, PushService.clearNotificationsIntent(context), PendingIntent.FLAG_UPDATE_CURRENT)
 
     override def getNotifications: util.Collection[GcmNotification] = gcmNotifications
 

--- a/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
@@ -48,8 +48,6 @@ class MetaDataService(context: Context) {
 
   lazy val internalBuild = metaData.getBoolean("INTERNAL", false)
 
-  lazy val gcmEnabled = metaData.getBoolean("GCM_ENABLED", true)
-
   // rough check for device type, used in otr client info
   lazy val deviceClass = {
     val dm = context.getResources.getDisplayMetrics

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -27,7 +27,7 @@ import com.waz.model._
 import com.waz.service.push.PushService.SlowSyncRequest
 import com.waz.service.UserService._
 import com.waz.service.assets.AssetService
-import com.waz.service.push.PushService
+import com.waz.service.push.PushServiceSignals
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.UserSearchClient.UserSearchEntry
 import com.waz.sync.client.UsersClient
@@ -38,7 +38,7 @@ import com.waz.utils.events.{AggregatingSignal, EventContext, Signal}
 import scala.collection.breakOut
 import scala.concurrent.{Awaitable, Future}
 
-class UserService(val selfUserId: UserId, usersStorage: UsersStorage, keyValueService: KeyValueStorage, push: PushService,
+class UserService(val selfUserId: UserId, usersStorage: UsersStorage, keyValueService: KeyValueStorage, push: PushServiceSignals,
                   assets: AssetService, usersClient: UsersClient, sync: SyncServiceHandle) {
 
   private implicit val logTag: LogTag = logTagFor[UserService]

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -36,7 +36,7 @@ import com.waz.service.invitations.InvitationService
 import com.waz.service.media._
 import com.waz.service.messages._
 import com.waz.service.otr._
-import com.waz.service.push.{GcmService, NotificationService, PushService, WebSocketClientService}
+import com.waz.service.push._
 import com.waz.service.tracking.{TrackingEventsService, TrackingService}
 import com.waz.sync.client._
 import com.waz.sync.handler._
@@ -182,6 +182,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   lazy val assetLoader     = wire[AssetLoader]
   lazy val imageLoader     = wire[ImageLoader]
 
+  lazy val pushSignals                           = wire[PushServiceSignals]
   lazy val push: PushService                     = wire[PushService]
   lazy val gcm: GcmService                       = wire[GcmService]
   lazy val errors                                = wire[ErrorsService]

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -148,6 +148,8 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   def searchQueryCache  = storage.searchQueryCache
   def commonConnections = storage.commonConnections
 
+  def gcmState          = gcm.gcmState
+
   lazy val messagesStorage: MessagesStorage = wire[MessagesStorage]
   lazy val msgAndLikes: MessageAndLikesStorage = wire[MessageAndLikesStorage]
 

--- a/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -26,7 +26,7 @@ import com.waz.call._
 import com.waz.log.LogHandler
 import com.waz.model._
 import com.waz.service._
-import com.waz.service.push.PushService
+import com.waz.service.push.WebSocketClientService
 import com.waz.threading.SerialDispatchQueue
 import com.waz.utils._
 import com.waz.utils.events._
@@ -43,7 +43,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
-class FlowManagerService(context: Context, netClient: ZNetClient, push: PushService, prefs: PreferenceService, network: NetworkModeService) {
+class FlowManagerService(context: Context, netClient: ZNetClient, websocket: WebSocketClientService, prefs: PreferenceService, network: NetworkModeService) {
   import FlowManagerService._
 
   val MetricsUrlRE = "/conversations/([a-z0-9-]*)/call/metrics/complete".r
@@ -80,7 +80,7 @@ class FlowManagerService(context: Context, netClient: ZNetClient, push: PushServ
   lazy val lastNetworkModeChange = Signal(Instant.MIN)
   lazy val lastWebsocketConnect = Signal(Instant.MIN)
 
-  push.pushConnected { if (_) lastWebsocketConnect ! Instant.now() }
+  websocket.connected { if (_) lastWebsocketConnect ! Instant.now() }
   network.networkMode { _ => lastNetworkModeChange ! Instant.now() }
 
   lazy val aggregatedInstants = new AggregatingSignal[Instant, Option[(Instant, Instant)]](lastWebsocketConnect.onChanged, Future.successful(None), {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationEventsService.scala
@@ -20,7 +20,6 @@ package com.waz.service.conversation
 import com.waz.ZLog._
 import com.waz.model._
 import com.waz.service.messages.MessagesService
-import com.waz.service.push.PushService
 import com.waz.service.{EventPipeline, EventScheduler, UserService}
 import com.waz.sync.SyncServiceHandle
 import com.waz.threading.SerialDispatchQueue
@@ -28,7 +27,7 @@ import com.waz.utils._
 
 import scala.concurrent.Future
 
-class ConversationEventsService(push: PushService, convs: ConversationsContentUpdater, messages: MessagesService, users: UserService, sync: SyncServiceHandle, pipeline: EventPipeline) {
+class ConversationEventsService(convs: ConversationsContentUpdater, messages: MessagesService, users: UserService, sync: SyncServiceHandle, pipeline: EventPipeline) {
 
   private implicit val tag: LogTag = logTagFor[ConversationEventsService]
   private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationEventsDispatcher")

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -30,7 +30,7 @@ import com.waz.model._
 import com.waz.service._
 import com.waz.service.assets.AssetService
 import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
-import com.waz.service.push.PushService
+import com.waz.service.push.PushServiceSignals
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.ConversationsClient.ConversationResponse
 import com.waz.threading.Threading
@@ -43,7 +43,7 @@ import scala.concurrent.Future
 import scala.concurrent.Future.successful
 import scala.util.control.NoStackTrace
 
-class ConversationsService(context: Context, push: PushService, users: UserService, usersStorage: UsersStorage,
+class ConversationsService(context: Context, push: PushServiceSignals, users: UserService, usersStorage: UsersStorage,
                            messagesStorage: MessagesStorage, membersStorage: MembersStorage,
                            convsStorage: ConversationStorage, val content: ConversationsContentUpdater, listState: ConversationsListStateService,
                            sync: SyncServiceHandle, errors: ErrorsService,

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrService.scala
@@ -31,7 +31,7 @@ import com.waz.model._
 import com.waz.model.otr._
 import com.waz.service._
 import com.waz.service.conversation.ConversationsContentUpdater
-import com.waz.service.push.PushService
+import com.waz.service.push.PushServiceSignals
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.OtrClient
 import com.waz.sync.client.OtrClient.EncryptedContent
@@ -49,7 +49,7 @@ import scala.concurrent.duration._
 import scala.util.{Success, Try}
 import scala.{PartialFunction => =/>}
 
-class OtrService(selfUserId: UserId, clientId: ClientId, val clients: OtrClientsService, push: PushService,
+class OtrService(selfUserId: UserId, clientId: ClientId, val clients: OtrClientsService, push: PushServiceSignals,
                  cryptoBox: CryptoBoxService, members: MembersStorage, convs: ConversationsContentUpdater,
                  sync: SyncServiceHandle, cache: CacheService, metadata: MetaDataService, clientsStorage : OtrClientsStorage) {
 

--- a/zmessaging/src/main/scala/com/waz/service/push/GcmGlobalService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/GcmGlobalService.scala
@@ -30,7 +30,7 @@ import com.waz.service.push.GcmGlobalService.{GcmRegistration, GcmSenderId}
 import com.waz.service.{BackendConfig, MetaDataService, PreferenceService}
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils.LoggedTry
-import com.waz.utils.events.EventContext
+import com.waz.utils.events.{EventContext, Signal}
 
 import scala.util.control.NonFatal
 
@@ -53,6 +53,9 @@ class GcmGlobalService(context: Context, prefs: PreferenceService, metadata: Met
   }
 
   lazy val gcmAvailable = metadata.gcmEnabled && gcmCheckResult == ConnectionResult.SUCCESS
+
+  // current GCM state, true if GCM is registered and working (we are getting notifications on it)
+  val gcmActive = Signal[Boolean]()
 
   def getGcmRegistration: CancellableFuture[GcmRegistration] = withPreferences(GcmRegistration(_)) map { reg =>
     if (reg.version == appVersion) reg

--- a/zmessaging/src/main/scala/com/waz/service/push/GcmGlobalService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/GcmGlobalService.scala
@@ -52,7 +52,7 @@ class GcmGlobalService(context: Context, prefs: PreferenceService, metadata: Met
       ConnectionResult.DEVELOPER_ERROR
   }
 
-  lazy val gcmAvailable = metadata.gcmEnabled && gcmCheckResult == ConnectionResult.SUCCESS
+  lazy val gcmAvailable = gcmCheckResult == ConnectionResult.SUCCESS
 
   def getGcmRegistration: CancellableFuture[GcmRegistration] = withPreferences(GcmRegistration(_)) map { reg =>
     if (reg.version == appVersion) reg

--- a/zmessaging/src/main/scala/com/waz/service/push/GcmService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/GcmService.scala
@@ -18,23 +18,88 @@
 package com.waz.service.push
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
+import com.waz.content.KeyValueStorage
 import com.waz.model._
+import com.waz.service._
 import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.push.GcmGlobalService.GcmRegistration
-import com.waz.service._
 import com.waz.sync.SyncServiceHandle
-import com.waz.sync.client.PushNotification
+import com.waz.sync.client.{EventsClient, PushNotification}
+import com.waz.utils._
 import com.waz.utils.events.EventContext
+import org.threeten.bp.Instant
 
-import scala.concurrent.Future
 import scala.collection.breakOut
+import scala.concurrent.Future
 
-class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, convsContent: ConversationsContentUpdater, eventPipeline: EventPipeline, sync: SyncServiceHandle, lifecycle: ZmsLifecycle) {
-
+class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, keyVale: KeyValueStorage, convsContent: ConversationsContentUpdater, eventsClient: EventsClient, eventPipeline: EventPipeline, sync: SyncServiceHandle, lifecycle: ZmsLifecycle) {
+  import GcmService._
   implicit val dispatcher = gcmGlobalService.dispatcher
 
-  private implicit val tag: LogTag = logTagFor[GcmService]
   private implicit val ev = EventContext.Global
+
+  val lastReceivedConvEventTime = keyVale.keyValuePref[Instant]("last_received_conv_event_time", Instant.EPOCH)
+  val lastFetchedConvEventTime = keyVale.keyValuePref[Instant]("last_fetched_conv_event_time", Instant.ofEpochMilli(1))
+  val lastFetchedLocalTime = keyVale.keyValuePref[Instant]("last_fetched_local_time", Instant.EPOCH)
+  val lastRegistrationTime = keyVale.keyValuePref[Instant]("gcm_registration_time", Instant.EPOCH)
+  val registrationRetryCount = keyVale.keyValuePref[Int]("gcm_registration_retry_count", 0)
+
+  /**
+    * Current GCM state, true if we are receiving notifications on it.
+    * We are only comparing timestamps of conversation events,
+    * considering events received on GCM and fetched by EventsClient.
+    * Events are fetched only on app start, when websocket is off (meaning GCM was considered active),
+    * this means that this state should rarely change.
+    */
+  val gcmState = for {
+    lastFetched <- lastFetchedConvEventTime.signal
+    lastReceived <- lastReceivedConvEventTime.signal
+    localFetchTime <- lastFetchedLocalTime.signal
+    lastRegistered <- lastRegistrationTime.signal
+  } yield {
+    verbose(s"gcmState, fetched: $lastFetched, received: $lastReceived, fetchTime: $localFetchTime, register: $lastReceived")
+    GcmState(lastFetched <= lastReceived, localFetchTime <= lastRegistered)
+  }
+
+  eventsClient.onNotificationsPageLoaded.on(dispatcher) { notifications =>
+    if (notifications.notifications.nonEmpty) {
+      val last = notifications.notifications.maxBy(_.lastConvEventTime).lastConvEventTime
+      if (last != Instant.EPOCH) {
+        lastFetchedConvEventTime := last
+        lastFetchedLocalTime := Instant.now
+      }
+    }
+  }
+
+  val shouldReRegister = for {
+    state <- gcmState
+    loggedIn <- lifecycle.loggedIn
+    time <- lastRegistrationTime.signal
+    retries <- registrationRetryCount.signal
+  } yield {
+    verbose(s"should re-register, available: ${gcmGlobalService.gcmAvailable}, loggedIn: $loggedIn, state: $state, lastTry: $time, retries: $retries")
+    gcmGlobalService.gcmAvailable && loggedIn && !state.active && RegistrationRetryBackoff.delay(retries).elapsedSince(time)
+  }
+
+  gcmState {
+    case GcmState(true, _) => registrationRetryCount := 0
+    case _ =>
+  }
+
+  shouldReRegister {
+    case true =>
+      verbose(s"shouldReRegister == true")
+      for {
+        retries <- registrationRetryCount()
+        _ <- registrationRetryCount := retries + 1
+        _ <- gcmGlobalService.unregister()
+        _ <- ensureGcmRegistered()
+      } yield ()
+
+    case false =>
+      verbose(s"shouldReRegister == false")
+  }
 
   def gcmSenderId = gcmGlobalService.gcmSenderId
 
@@ -69,21 +134,30 @@ class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, convs
   def register(post: GcmRegistration => Future[Boolean]): Future[Option[GcmRegistration]] =
     gcmGlobalService.registerGcm(accountId).future flatMap {
       case Some(reg) => post(reg) flatMap {
-        case true => gcmGlobalService.updateRegisteredUser(reg.token, accountId).future map (Some(_))
+        case true =>
+          lastRegistrationTime := Instant.now
+          gcmGlobalService.updateRegisteredUser(reg.token, accountId).future map { Some(_) }
         case false => Future.successful(Some(reg))
       }
       case None => Future.successful(None)
     }
 
   def handleNotification(n: PushNotification): Future[Any] = {
-    // TODO: mark GCM active
-    verbose(s"handleNotification($n")
-    val (callStateEvents, otherEvents) = n.events.partition(_.isInstanceOf[CallStateEvent])
 
-    // call state events can not be directly dispatched like the other events because they might be stale
-    syncCallStateForConversations(callStateEvents.map(_.withCurrentLocalTime()))
+    val time = n.lastConvEventTime
+    if (time != Instant.EPOCH) lastReceivedConvEventTime := time
 
-    eventPipeline(otherEvents.map(_.withCurrentLocalTime()))
+    lifecycle.lifecycleState.head flatMap {
+      case LifecycleState.UiActive | LifecycleState.Active => Future.successful(()) // no need to process GCM when ui is active
+      case _ =>
+        verbose(s"handleNotification($n")
+        val (callStateEvents, otherEvents) = n.events.partition(_.isInstanceOf[CallStateEvent])
+
+        // call state events can not be directly dispatched like the other events because they might be stale
+        syncCallStateForConversations(callStateEvents.map(_.withCurrentLocalTime()))
+
+        eventPipeline(otherEvents.map(_.withCurrentLocalTime()))
+    }
   }
 
   private def syncCallStateForConversations(events: Seq[Event]): Unit = {
@@ -93,5 +167,15 @@ class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, convs
         sync.syncCallState(conv.id, fromFreshNotification = true)
       }
     }
+  }
+}
+
+object GcmService {
+  import scala.concurrent.duration._
+
+  val RegistrationRetryBackoff = new ExponentialBackoff(5.minutes, 30.days)
+
+  case class GcmState(received: Boolean, justRegistered: Boolean) {
+    def active = received || justRegistered
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -41,7 +41,7 @@ import scala.concurrent.Future
 
 class NotificationService(selfUserId: UserId, messages: MessagesStorage, lifecycle: ZmsLifecycle,
     storage: NotificationStorage, usersStorage: UsersStorage, convs: ConversationStorage, reactionStorage: LikingsStorage,
-    push: PushService, kv: KeyValueStorage, timeouts: Timeouts) {
+    kv: KeyValueStorage, timeouts: Timeouts) {
 
   import NotificationService._
   import com.waz.utils.events.EventContext.Implicits.global

--- a/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushService.scala
@@ -52,7 +52,8 @@ class PushService(context: Context, keyValue: KeyValueStorage, client: EventsCli
     //      maybe this would be enough for some conversations and we would not need to sync so much
     processHistoryEvents(notifications.notifications, new Date)
 
-    if (notifications.lastIdWasFound) debug("got missing notifications, great") else {
+    if (notifications.lastIdWasFound) debug("got missing notifications, great")
+    else {
       info(s"server couldn't provide all missing notifications, will schedule slow sync, after processing available events")
       onSlowSyncNeeded ! SlowSyncRequest(System.currentTimeMillis(), lostHistory = true)
     }

--- a/zmessaging/src/main/scala/com/waz/service/push/WebSocketClientService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WebSocketClientService.scala
@@ -24,13 +24,14 @@ import ImplicitTag._
 import com.waz.api.NetworkMode
 import com.waz.model.otr.ClientId
 import com.waz.service._
+import com.waz.service.push.GcmService.GcmState
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils.events.{EventContext, Signal}
 import com.waz.znet.{WebSocketClient, ZNetClient}
 
 import scala.concurrent.Future
 
-class WebSocketClientService(context: Context, lifecycle: ZmsLifecycle, netClient: ZNetClient, val network: NetworkModeService, gcm: GcmGlobalService, backend: BackendConfig, clientId: ClientId, timeouts: Timeouts) {
+class WebSocketClientService(context: Context, lifecycle: ZmsLifecycle, netClient: ZNetClient, val network: NetworkModeService, gcmState: Signal[GcmState], backend: BackendConfig, clientId: ClientId, timeouts: Timeouts) {
   import LifecycleState._
   private implicit val ec = EventContext.Global
   private implicit val dispatcher = new SerialDispatchQueue(name = "WebSocketClientService")
@@ -47,9 +48,9 @@ class WebSocketClientService(context: Context, lifecycle: ZmsLifecycle, netClien
   }
 
   // true if websocket should be active,
-  val wsActive = gcm.gcmActive flatMap {
-    case true => lifecycleActive // GCM is working, so we only need to use websocket when UI is active
-    case false => lifecycle.loggedIn // GCM is not active, keep websocket whenever user is logged in
+  val wsActive = gcmState flatMap {
+    case st if st.active => lifecycleActive // GCM is working, so we only need to use websocket when UI is active
+    case _               => lifecycle.loggedIn // GCM is not active, keep websocket whenever user is logged in
   }
 
   val client = wsActive map {

--- a/zmessaging/src/main/scala/com/waz/sync/client/EventsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/EventsClient.scala
@@ -20,7 +20,7 @@ package com.waz.sync.client
 import com.waz.ZLog._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.otr.ClientId
-import com.waz.model.{Event, OtrEvent, Uid}
+import com.waz.model.{ConversationEvent, Event, OtrEvent, Uid}
 import com.waz.threading.Threading
 import com.waz.utils.JsonDecoder
 import com.waz.utils.JsonDecoder._
@@ -29,6 +29,7 @@ import com.waz.znet.Response.{ErrorStatus, HttpStatus, Status, SuccessHttpStatus
 import com.waz.znet.ZNetClient.{ErrorOr, ErrorOrResponse}
 import com.waz.znet.{JsonObjectResponse, _}
 import org.json.JSONObject
+import org.threeten.bp.Instant
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -82,6 +83,15 @@ case class PushNotification(id: Uid, events: Seq[Event], transient: Boolean = fa
   def hasEventForClient(clientId: ClientId) = events.exists {
     case ev: OtrEvent => clientId == ev.recipient
     case _ => true
+  }
+
+  def lastConvEventTime = {
+    var max = 0L
+    events foreach {
+      case e: ConversationEvent => max = math.max(max, e.time.getTime)
+      case _ =>
+    }
+    Instant ofEpochMilli max
   }
 }
 

--- a/zmessaging/src/main/scala/com/waz/zms/GcmHandlerService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/GcmHandlerService.scala
@@ -17,22 +17,21 @@
  */
 package com.waz.zms
 
-import android.content.{Context, Intent}
+import android.content.Intent
 import android.util.Base64
+import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
-import com.waz.model._
 import com.waz.service.ZMessaging
+import com.waz.service.push.GcmGlobalService.GcmSenderId
 import com.waz.sync.client.PushNotification
 import com.waz.threading.Threading
+import com.waz.utils.LoggedTry
 import org.json.JSONObject
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
-import scala.util.Try
 
 class GcmHandlerService extends FutureService with ZMessagingService {
-
-  private implicit val logTag: LogTag = logTagFor[GcmHandlerService]
   import Threading.Implicits.Background
 
   lazy val gcm = ZMessaging.currentGlobal.gcmGlobal
@@ -45,77 +44,41 @@ class GcmHandlerService extends FutureService with ZMessagingService {
 
     verbose(s"onIntent with extras: $extrasToString")
 
-    if (intent.getAction == ActionClear) {
+    def getNotification = Future {
+      intent match {
+        case FromExtra(from) if from != gcm.gcmSenderId =>
+          info(s"received gcm notification is from unexpected sender, will ignore it")
+          None
+        case ContentAndMac(content, mac) =>
+          Some((content, mac))
+        case _ =>
+          error(s"Received GCM notification, but some required extra field is missing, intent extras: $extrasToString")
+          None
+      }
+    }
+
+    def decryptNotification(content: Array[Byte], mac: Array[Byte]) =
       accounts.getCurrentZms flatMap {
-        case Some(zms) => zms.notifications.clearNotifications()
-        case None => Future.successful(())
+        case Some(zms) =>
+          zms.otrService.decryptGcm(content, mac) map {
+            case Some(EncryptedGcm(notification)) => Some((zms, notification))
+            case resp =>
+              warn(s"gcm decoding failed: $resp")
+              None
+          }
+        case None =>
+          warn("no current zmessaging instance")
+          Future successful None
       }
-    } else if (intent.hasExtra("from") && intent.getStringExtra("from") != gcm.gcmSenderId.str) {
-      info(s"received gcm notification is from unexpected sender, will ignore it")
-      Future.successful(())
-    } else if (intent.hasExtra(TypeExtra) && intent.hasExtra(ContentExtra) && intent.hasExtra(MacExtra) && (intent.getStringExtra(TypeExtra) == "otr" || intent.getStringExtra(TypeExtra) == "cipher")) {
-      val content = intent.getStringExtra(ContentExtra)
-      val mac = intent.getStringExtra(MacExtra)
-      accounts.getCurrentZms.map {
-        case Some(zms) => zms.otrService.decryptGcm(Base64.decode(content, Base64.NO_WRAP | Base64.NO_CLOSE), Base64.decode(mac, Base64.NO_WRAP | Base64.NO_CLOSE)) map {
-          case Some(EncryptedGcm(notification)) => handleNotification(notification, None)
-          case resp => warn(s"gcm decoding failed: $resp")
+
+    getNotification flatMap {
+      case Some((content, mac)) =>
+        decryptNotification(content, mac) flatMap {
+          case Some((zms, notification)) => zms.gcm.handleNotification(notification)
+          case None => Future.successful(())
         }
-        case None => warn("no current zmessaging instance")
-      }
-    } else if (intent.hasExtra(ContentExtra) && intent.hasExtra(UserExtra)) {
-      val content = intent.getStringExtra(ContentExtra)
-      val userId = intent.getStringExtra(UserExtra)
-      Future {
-        (PushNotification.NotificationDecoder(new JSONObject(content)), UserId(userId))
-      } flatMap {
-        case (notification, user) => handleNotification(notification, Some(user))
-      }
-    } else {
-      error(s"Received GCM notification, but some required extra field is missing, intent extras: $extrasToString")
-      Future.successful(())
-    }
-  }
-
-  def handleNotification(n: PushNotification, user: Option[UserId]): Future[Any] = {
-    verbose(s"handleNotification($n")
-    handleGcmNotification(user) { zms =>
-      val (callStateEvents, otherEvents) = n.events.partition(_.isInstanceOf[CallStateEvent])
-
-      // call state events can not be directly dispatched like the other events because they might be stale
-      handleCallStateNotifications(zms, callStateEvents.map(_.withCurrentLocalTime()))
-
-      zms.eventPipeline(otherEvents.map(_.withCurrentLocalTime()))
-    }
-  }
-
-  private def handleCallStateNotifications(zms: ZMessaging, events: Seq[Event]): Unit = events foreach {
-    case e: CallStateEvent =>
-      zms.convsContent.processConvWithRemoteId(e.convId, retryAsync = false) { conv =>
-        zms.sync.syncCallState(conv.id, fromFreshNotification = true)
-      }
-
-    case _ => () // ignore all other events
-  }
-
-  def handleGcmNotification[A](user: Option[UserId])(body: ZMessaging => Future[A]) = {
-    accounts.getCurrentZms flatMap {
-      case Some(zms) =>
-        zms.users.getSelfUserId flatMap {
-          case Some(userId) if user.forall(_ == userId) =>
-            if (zms.push.pushConnected.currentValue.contains(true)) {
-              debug(s"PushService is connected, ignoring GCM")
-              Future.successful(())
-            } else {
-              body(zms)
-            }
-          case current =>
-            error(s"Received GCM notification but current ZMessaging user is different from intended user, will re-register")
-            gcm.unregister() flatMap { _ => zms.sync.registerGcm() }
-        }
-      case _ =>
-        error(s"Received GCM notification but no ZMessaging is available, will unregister from Play Services")
-        gcm.unregister()
+      case None =>
+        Future.successful(())
     }
   }
 }
@@ -124,13 +87,21 @@ object GcmHandlerService {
   val ContentExtra = "data"
   val TypeExtra = "type"
   val MacExtra = "mac"
-  val UserExtra = "user"
 
-  val ActionClear = "com.wire.gcm.CLEAR_NOTIFICATIONS"
+  object FromExtra {
+    def unapply(intent: Intent): Option[GcmSenderId] = Option(intent.getStringExtra("from")) map GcmSenderId
+  }
 
-  def clearNotificationsIntent(context: Context) = new Intent(context, classOf[GcmHandlerService]).setAction(ActionClear)
+  object ContentAndMac {
+    def unapply(intent: Intent): Option[(Array[Byte], Array[Byte])] =
+      (Option(intent.getStringExtra(TypeExtra)), Option(intent.getStringExtra(ContentExtra)), Option(intent.getStringExtra(MacExtra))) match {
+        case (Some("otr" | "cipher"), Some(content), Some(mac)) =>
+          LoggedTry.local { (Base64.decode(content, Base64.NO_WRAP | Base64.NO_CLOSE), Base64.decode(mac, Base64.NO_WRAP | Base64.NO_CLOSE)) } .toOption
+        case _ => None
+      }
+  }
 
   object EncryptedGcm {
-    def unapply(js: JSONObject): Option[PushNotification] = Try { PushNotification.NotificationDecoder(js.getJSONObject("data")) }.toOption
+    def unapply(js: JSONObject): Option[PushNotification] = LoggedTry.local { PushNotification.NotificationDecoder(js.getJSONObject("data")) }.toOption
   }
 }


### PR DESCRIPTION
Added `GcmService.gcmState` which determines if GCM is working (we are receiving notifications through it).
Changed WebSocket handling to enable always on socket connection always when GCM is not active, not only when play services are not available. 
This way we should get notification for new messages even if GCM is unreliable/broken.
