### PR TITLE
Add handling for ephemeral messages in group conversations.

### DIFF
--- a/tests/unit/src/test/scala/com/waz/model/SyncJobDaoSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/SyncJobDaoSpec.scala
@@ -25,7 +25,7 @@ import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.otr.ClientId
 import com.waz.model.sync.SyncJob.SyncJobDao
 import com.waz.model.sync.SyncRequest._
-import com.waz.model.sync.{SyncJob, SyncRequest}
+import com.waz.model.sync.{ReceiptType, SyncJob, SyncRequest}
 import com.waz.testutils.Matchers._
 import com.waz.utils.JsonDecoder._
 import com.waz.utils.JsonEncoder._
@@ -110,7 +110,7 @@ class SyncJobDaoSpec extends FeatureSpec with Matchers with TableDrivenPropertyC
         PostLastRead(ConvId(), Instant.now),
         PostCleared(ConvId(), Instant.now),
         PostAssetStatus(ConvId(), MessageId(), EphemeralExpiration.FIVE_SECONDS, AssetStatus.UploadCancelled),
-        PostReceipt(ConvId(), MessageId(), UserId())
+        PostReceipt(ConvId(), MessageId(), UserId(), ReceiptType.Delivery)
       ) map { SyncJob(SyncId(), _) }
 
       SyncJobDao.insertOrReplace(requests)

--- a/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
@@ -21,6 +21,7 @@ import com.waz.api.EphemeralExpiration
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model._
 import com.waz.model.otr.ClientId
+import com.waz.model.sync.ReceiptType
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.sync._
 import org.threeten.bp.Instant
@@ -63,7 +64,7 @@ trait EmptySyncServiceTrait extends SyncServiceHandle {
   override def postInvitation(i: Invitation) = sid
   override def postTypingState(id: ConvId, t: Boolean) = sid
   override def postOpenGraphData(conv: ConvId, msg: MessageId, time: Instant) = sid
-  override def postReceipt(conv: ConvId, message: MessageId, user: UserId) = sid
+  override def postReceipt(conv: ConvId, message: MessageId, user: UserId, tpe: ReceiptType) = sid
 
   override def registerGcm() = sid
   override def deleteGcmToken(token: GcmId) = sid

--- a/zmessaging/src/main/java/com/waz/model/sync/ReceiptType.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/ReceiptType.java
@@ -1,0 +1,45 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model.sync;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ReceiptType {
+
+    Delivery("delivery"),
+    EphemeralExpired("ephemeral-expired");
+
+    public final String name;
+
+    ReceiptType(String name) {
+        this.name = name;
+    }
+
+    private static Map<String, ReceiptType> byName = new HashMap<>();
+    static {
+        for (ReceiptType value : ReceiptType.values()) {
+            byName.put(value.name, value);
+        }
+    }
+
+    public static ReceiptType fromName(String name) {
+        ReceiptType result = byName.get(name);
+        return (result == null) ? Delivery : result;
+    }
+}

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -151,8 +151,8 @@ object SyncRequest {
     override def merge(req: SyncRequest) = mergeHelper[PostOpenGraphMeta](req)(r => Merged(PostOpenGraphMeta(convId, messageId, editTime max r.editTime)))
   }
 
-  case class PostReceipt(convId: ConvId, messageId: MessageId, userId: UserId) extends RequestForConversation(Cmd.PostReceipt) {
-    override val mergeKey = (cmd, messageId)
+  case class PostReceipt(convId: ConvId, messageId: MessageId, userId: UserId, tpe: ReceiptType) extends RequestForConversation(Cmd.PostReceipt) {
+    override val mergeKey = (cmd, messageId, userId, tpe)
   }
 
   case class PostDeleted(convId: ConvId, messageId: MessageId) extends RequestForConversation(Cmd.PostDeleted) {
@@ -321,7 +321,7 @@ object SyncRequest {
         case Cmd.PostLiking            => PostLiking(convId, JsonDecoder[Liking]('liking))
         case Cmd.PostSessionReset      => PostSessionReset(convId, userId, decodeId[ClientId]('client))
         case Cmd.PostOpenGraphMeta     => PostOpenGraphMeta(convId, messageId, 'time)
-        case Cmd.PostReceipt           => PostReceipt(convId, messageId, userId)
+        case Cmd.PostReceipt           => PostReceipt(convId, messageId, userId, ReceiptType.fromName('type))
         case Cmd.Unknown               => Unknown
       }
     }
@@ -364,9 +364,10 @@ object SyncRequest {
           putId("message", messageId)
           o.put("time", time.toEpochMilli)
 
-        case PostReceipt(_, messageId, userId) =>
+        case PostReceipt(_, messageId, userId, tpe) =>
           putId("message", messageId)
           putId("user", userId)
+          o.put("type", tpe)
 
         case PostConnection(_, name, message) =>
           o.put("name", name)

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -286,6 +286,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
     // services listening for storage updates
     richmedia
     ephemeral
+    receipts
 
     tempFiles
     recordAndPlay

--- a/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -30,6 +30,7 @@ import com.waz.utils.events.Signal
 import org.threeten.bp.Instant
 import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.model.sync.ReceiptType
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -80,7 +81,7 @@ class EphemeralMessagesService(selfUserId: UserId, messages: MessagesContentUpda
       for {
         _ <- messages.deleteOnUserRequest(toRemove.map(_.id))
         // recalling message, this informs the sender that message is already expired
-        _ <- Future.traverse(toRemove) { m => sync.postRecalled(m.convId, MessageId(), m.id) }
+        _ <- Future.traverse(toRemove) { m => sync.postReceipt(m.convId, m.id, m.userId, ReceiptType.EphemeralExpired) }
         _ <- messages.messagesStorage.updateAll2(toObfuscate.map(_.id), obfuscate)
       } yield ()
     }

--- a/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/ReceiptService.scala
@@ -22,6 +22,7 @@ import com.waz.api.Message.Status.DELIVERED
 import com.waz.api.Message.Type._
 import com.waz.content.{ConversationStorage, MessagesStorage}
 import com.waz.model.ConversationData.ConversationType.OneToOne
+import com.waz.model.sync.ReceiptType
 import com.waz.model.{MessageId, UserId}
 import com.waz.sync.SyncServiceHandle
 import com.waz.threading.Threading
@@ -40,7 +41,7 @@ class ReceiptService(messages: MessagesStorage, convs: ConversationStorage, sync
     Future.traverse(msgs.iterator.filter(msg => msg.userId != selfUserId && confirmable(msg.msgType))) { msg =>
       convs.get(msg.convId).map(_.filter(_.convType == OneToOne)).flatMapSome { _ =>
         verbose(s"will send receipt for $msg")
-        sync.postReceipt(msg.convId, msg.id, msg.userId)
+        sync.postReceipt(msg.convId, msg.id, msg.userId, ReceiptType.Delivery)
       }
     }.logFailure()
   }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -70,7 +70,7 @@ trait SyncServiceHandle {
   def postInvitation(i: Invitation): Future[SyncId]
   def postTypingState(id: ConvId, typing: Boolean): Future[SyncId]
   def postOpenGraphData(conv: ConvId, msg: MessageId, editTime: Instant): Future[SyncId]
-  def postReceipt(conv: ConvId, message: MessageId, user: UserId): Future[SyncId]
+  def postReceipt(conv: ConvId, message: MessageId, user: UserId, tpe: ReceiptType): Future[SyncId]
 
   def registerGcm(): Future[SyncId]
   def deleteGcmToken(token: GcmId): Future[SyncId]
@@ -128,7 +128,7 @@ class AndroidSyncServiceHandle(context: Context, service: => SyncRequestService,
   def postLastRead(id: ConvId, time: Instant) = addRequest(PostLastRead(id, time), priority = Priority.Low, delay = timeouts.messages.lastReadPostDelay)
   def postCleared(id: ConvId, time: Instant) = addRequest(PostCleared(id, time))
   def postOpenGraphData(conv: ConvId, msg: MessageId, time: Instant) = addRequest(PostOpenGraphMeta(conv, msg, time), priority = Priority.Low)
-  def postReceipt(conv: ConvId, message: MessageId, user: UserId): Future[SyncId] = addRequest(PostReceipt(conv, message, user), priority = Priority.Optional)
+  def postReceipt(conv: ConvId, message: MessageId, user: UserId, tpe: ReceiptType): Future[SyncId] = addRequest(PostReceipt(conv, message, user, tpe), priority = Priority.Optional)
 
   def registerGcm() = addRequest(RegisterGcmToken, priority = Priority.Low, forceRetry = true)
   def deleteGcmToken(token: GcmId) = addRequest(DeleteGcmToken(token), priority = Priority.Low)
@@ -192,7 +192,7 @@ class AccountSyncHandler(zms: Signal[ZMessaging], otrClients: OtrClientsSyncHand
     case PostOpenGraphMeta(conv, msg, time)    => zms.openGraphSync.postMessageMeta(conv, msg, time)
     case PostRecalled(convId, msg, recall)     => zms.messagesSync.postRecalled(convId, msg, recall)
     case PostSessionReset(conv, user, client)  => zms.otrSync.postSessionReset(conv, user, client)
-    case PostReceipt(conv, msg, user)          => zms.messagesSync.postReceipt(conv, msg, user)
+    case PostReceipt(conv, msg, user, tpe)     => zms.messagesSync.postReceipt(conv, msg, user, tpe)
   }
 
   override def apply(req: SyncRequest): Future[SyncResult] =


### PR DESCRIPTION
This is not yet tested, feel free to try it out.

This is very basic implementation and has several limitations:
- obfuscated messages on sender will be removed when any recipient confirms deletion
- in case new user was just added to conv to which we are sending ephemeral message it may happen that new user will not receive the message, we would need to add handling on BE to support that properly