### PR TITLE
[AN-4298] GCM notifications handling fix

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/push/GcmService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/GcmService.scala
@@ -46,7 +46,7 @@ class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, keyVa
 
   private implicit val ev = EventContext.Global
 
-  val notificationsToProcess = Signal(false)
+  val notificationsToProcess = Signal(Set[Uid]())
 
   override val gcmAvailable = gcmGlobalService.gcmAvailable
 
@@ -175,7 +175,7 @@ class GcmService(accountId: AccountId, gcmGlobalService: GcmGlobalService, keyVa
         verbose(s"addNotification: $n")
         // call state events can not be directly dispatched like the other events because they might be stale
         syncCallStateForConversations(n.events.collect { case e: CallStateEvent => e }.map(_.withCurrentLocalTime()))
-        Future.successful(notificationsToProcess ! true)
+        Future.successful(notificationsToProcess.mutate(_ + n.id))
     }
   }
 


### PR DESCRIPTION
GCM notification ids are kept in a set instead of just having a boolean
flag to better keep track of the notifications that got processed and
not. It also prevents getting stuck in a processing state in case of
processing failure.

Ticket: https://wearezeta.atlassian.net/browse/AN-4298