### PR TITLE
Remove Edge from Remote Actor and SharedSettings.InternalBackendPasswords

### DIFF
--- a/actors/remote_app/src/it/scala/com/waz/RemoteActorAppSpec.scala
+++ b/actors/remote_app/src/it/scala/com/waz/RemoteActorAppSpec.scala
@@ -36,7 +36,7 @@ class RemoteActorAppSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
     import scala.sys.process._
     val serialized = Serialization.serializedActorPath(coordinatorActor)
 
-    val cmd = s"java -jar ${appJar.getAbsolutePath} remote_actor $serialized edge true"
+    val cmd = s"java -jar ${appJar.getAbsolutePath} remote_actor $serialized staging true"
     val outputFile = new File(s"target/logcat/RemoteActorAppSpec_remote")
     outputFile.getParentFile.mkdirs()
     val printWriter = new PrintWriter(outputFile)

--- a/env-credentials.sbt
+++ b/env-credentials.sbt
@@ -3,4 +3,4 @@ import SharedSettings._
 def getEnv(key: String) = Option(System.getenv(key)).getOrElse("")
 
 emailTestUser in ThisBuild := EmailTestUser(getEnv("TEST_EMAIL"), getEnv("TEST_PASSWD"))
-internalBackend in ThisBuild := InternalBackendPasswords(getEnv("EDGE_PASSWD"), getEnv("STAGING_ENV"))
+internalBackend in ThisBuild := InternalBackendPasswords(getEnv("STAGING_ENV"))

--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -14,7 +14,7 @@ import scala.util.matching.Regex
 object SharedSettings {
 
   case class EmailTestUser(email: String, password: String)
-  case class InternalBackendPasswords(edge: String, staging: String)
+  case class InternalBackendPasswords(staging: String)
 
   val avsVersion = "2.8.61"
   val audioVersion = "1.195.0"
@@ -123,7 +123,7 @@ object SharedSettings {
           |  def backend(backend: BackendConfig) = ("wire-staging", %s)
           |  def email = ("%s", "%s")
           |}
-        """.stripMargin.format("\"\"\"" + (internalBackend in Test).value.staging + "\"\"\"", "\"\"\"" + (internalBackend in Test).value.edge + "\"\"\"", (emailTestUser in Test).value.email, (emailTestUser in Test).value.password)
+        """.stripMargin.format("\"\"\"" + (internalBackend in Test).value.staging + "\"\"\"", (emailTestUser in Test).value.email, (emailTestUser in Test).value.password)
       IO.write(file, content)
       Seq(file)
     }


### PR DESCRIPTION
Fix 1:  Remove Edge backend from SharedSettings and RemoteActor.

**Please be careful:**
When merge it, you also need to update credentials.sbt in Jenkins, otherwise it will raise exception immediately.

Fix 2: (From @deanrobertcook )
Fix the WebSocket cannot be disconnected when Account logout. 