### PR TITLE
Removed the method addLocalSentMessage

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -77,14 +77,6 @@ class MessagesContentUpdater(context: Context, val messagesStorage: MessagesStor
     } yield res
   }
 
-  def addLocalSentMessage(msg: MessageData) = Serialized.future("add local message", msg.convId) {
-    verbose(s"addLocalSentMessage: $msg")
-    lastSentEventTime(msg.convId) flatMap { t =>
-      verbose(s"adding local sent message to storage, $t")
-      messagesStorage.addMessage(msg.copy(state = Status.SENT, time = t.plusMillis(1), localTime = Instant.now))
-    }
-  }
-
   private def nextLocalTime(convId: ConvId) =
     messagesStorage.getLastMessage(convId) flatMap {
       case Some(msg) => Future successful msg.time

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -469,7 +469,7 @@ class MessagesService(selfUserId: UserId, val content: MessagesContentUpdater, e
   def addOtrUnverifiedMessage(convId: ConvId, users: Seq[UserId], change: VerificationChange): Future[Option[MessageData]] = {
       val msgType = if (change == ClientUnverified) Message.Type.OTR_UNVERIFIED else Message.Type.OTR_DEVICE_ADDED
       withSelfUserFuture { selfUser =>
-        addLocalSentMessage(MessageData(MessageId(), convId, msgType, selfUser, members = users.toSet)) map { Some(_) }
+        addLocalMessage(MessageData(MessageId(), convId, msgType, selfUser, members = users.toSet), Status.SENT) map { Some(_) }
       }
     }
 


### PR DESCRIPTION
The addLocalSentMessage method was being used only once and it was
messing with the order of the local messages. Using the addLocalMessage
with Status.SENT does the desired effect.