### PR TITLE
Update to newer version of cryptobox for actors app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val actors_app: Project = project.in(file("actors") / "remote_app")
       "org.robolectric" % "android-all" % RobolectricVersion,
       Deps.avs,
       "org.threeten" % "threetenbp" % "1.3",
-      "com.wire" % "cryptobox-jni-osx" % cryptoboxVersion,
+      "com.wire.cryptobox" % "cryptobox-jni" % "0.8.2",
       Deps.localytics,
       "com.android.support" % "support-v4" % supportLibVersion % Provided,
       "com.google.android.gms" % "play-services-base" % "7.8.0" % Provided exclude("com.android.support", "support-v4"),

--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -103,8 +103,8 @@ object SharedSettings {
       Deps.avs,
       Deps.cryptobox,
       "com.wire" % "avs-native" % avsVersion % Native,
-      "com.wire" % "cryptobox-jni-osx" % cryptoboxVersion % Native,
-      "com.wire" % "cryptobox-jni-linux-x86_64" % cryptoboxVersion % Native,
+      "com.wire.cryptobox" % "cryptobox-jni" % "0.8.2" classifier "darwin-x86_64",
+      "com.wire.cryptobox" % "cryptobox-jni" % "0.8.2" classifier "linux-x86_64",
       Deps.localytics,
       Deps.scalaCheck,
       Deps.wireMock


### PR DESCRIPTION
We need this version to run actors app together with a cryptobox we compiled for windows. This makes it possible for us to run tests for Windows Wrapper that uses the actors app.