### PR TITLE
Add sync request to check for availability of usernames

### DIFF
--- a/tests/unit/src/test/scala/com/waz/api/impl/UsernamesSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/api/impl/UsernamesSpec.scala
@@ -17,76 +17,88 @@
  */
 package com.waz.api.impl
 
-import org.scalatest.{FeatureSpec, Matchers, RobolectricTests}
+import com.waz.RobolectricUtils
+import com.waz.api.{UsernameValidation, UsernamesRequestCallback}
+import com.waz.model.UserId
+import com.waz.testutils.{MockUiModule, MockZMessaging}
+import org.scalatest.{OptionValues, _}
 
 import scala.util.Random
 
-class UsernamesSpec extends FeatureSpec with Matchers  with RobolectricTests {
-  val email = "test@test.com"
-  val password = "password"
-  val wireMockPort = 9000 + Random.nextInt(3000)
+class UsernamesSpec extends FeatureSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with OptionValues with RobolectricTests with RobolectricUtils {
 
-  val usernames = new Usernames(null)
+  lazy val selfId = UserId()
+  lazy val zmessaging = new MockZMessaging(selfUserId = selfId)
+  implicit lazy val ui = new MockUiModule(zmessaging)
+  var usernames: Usernames = null
 
-    Random.setSeed(0)
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
 
-    scenario ("Username u should be invalid") {
-      usernames.isUsernameValid("u").isValid should be(false)
-    }
+    ui.onCreate(testContext)
+    ui.onResume()
 
-    scenario ("Username pokemon_master354 should be valid") {
-      usernames.isUsernameValid("pokemon_master354").isValid should be(true)
-    }
+    usernames = new Usernames()(ui)
+  }
 
-    scenario ("Username CatZ_MasteR should be invalid") {
-      usernames.isUsernameValid("CatZ_MasteR").isValid should be(false)
-    }
+  Random.setSeed(0)
 
-    scenario ("Username shiny+ufo should be invalid") {
-      usernames.isUsernameValid("shiny+ufo").isValid should be(false)
-    }
+  scenario ("Username u should be invalid") {
+    usernames.isUsernameValid("u").isValid should be(false)
+  }
 
-    scenario ("Username super_long_username_because_whatever should be invalid") {
-      usernames.isUsernameValid("super_long_username_because_whatever").isValid should be(false)
-    }
+  scenario ("Username pokemon_master354 should be valid") {
+    usernames.isUsernameValid("pokemon_master354").isValid should be(true)
+  }
 
-    scenario ("Username \uD83D\uDE3C孟利 should be invalid") {
-      usernames.isUsernameValid("\uD83D\uDE3C孟利").isValid should be(false)
-    }
+  scenario ("Username CatZ_MasteR should be invalid") {
+    usernames.isUsernameValid("CatZ_MasteR").isValid should be(false)
+  }
 
-    scenario ("Username generation with latin characters only") {
-      val genName = usernames.generateUsernameFromName("Wire", null)
-      genName should be("wire")
-    }
+  scenario ("Username shiny+ufo should be invalid") {
+    usernames.isUsernameValid("shiny+ufo").isValid should be(false)
+  }
 
-    scenario ("Username generation with latin characters and space") {
-      val genName = usernames.generateUsernameFromName("Wire Wireson", null)
-      genName should be("wirewireson")
-    }
+  scenario ("Username super_long_username_because_whatever should be invalid") {
+    usernames.isUsernameValid("super_long_username_because_whatever").isValid should be(false)
+  }
 
-    scenario ("Username generation with latin characters from extended alphabet") {
-      val genName = usernames.generateUsernameFromName("Æéÿüíøšłźçñ", null)
-      genName should be("aeyuioslzcn")
-    }
+  scenario ("Username \uD83D\uDE3C孟利 should be invalid") {
+    usernames.isUsernameValid("\uD83D\uDE3C孟利").isValid should be(false)
+  }
 
-    scenario ("Username generation with emojis only") {
-      val genName = usernames.generateUsernameFromName("\uD83D\uDE3C", null)
-      genName should be("")
-    }
+  scenario ("Username generation with latin characters only") {
+    val genName = usernames.generateUsernameFromName("Wire", null)
+    genName should be("wire")
+  }
 
-    scenario ("Username generation with cyrillic characters") {
-      val genName = usernames.generateUsernameFromName("Даша", null)
-      genName should be("")
-    }
+  scenario ("Username generation with latin characters and space") {
+    val genName = usernames.generateUsernameFromName("Wire Wireson", null)
+    genName should be("wirewireson")
+  }
 
-    scenario ("Username generation with arabic characters") {
-      val genName = usernames.generateUsernameFromName("داريا", null)
-      genName should be("")
-    }
+  scenario ("Username generation with latin characters from extended alphabet") {
+    val genName = usernames.generateUsernameFromName("Æéÿüíøšłźçñ", null)
+    genName should be("aeyuioslzcn")
+  }
 
-    scenario ("Username generation with chinese characters") {
-      val genName = usernames.generateUsernameFromName("孟利", null)
-      genName should be("")
-    }
+  scenario ("Username generation with emojis only") {
+    val genName = usernames.generateUsernameFromName("\uD83D\uDE3C", null)
+    genName should be("")
+  }
 
+  scenario ("Username generation with cyrillic characters") {
+    val genName = usernames.generateUsernameFromName("Даша", null)
+    genName should be("")
+  }
+
+  scenario ("Username generation with arabic characters") {
+    val genName = usernames.generateUsernameFromName("داريا", null)
+    genName should be("")
+  }
+
+  scenario ("Username generation with chinese characters") {
+    val genName = usernames.generateUsernameFromName("孟利", null)
+    genName should be("")
+  }
 }

--- a/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
@@ -77,5 +77,8 @@ trait EmptySyncServiceTrait extends SyncServiceHandle {
   override def syncPreKeys(user: UserId, clients: Set[ClientId]): Future[SyncId] = sid
   override def postSessionReset(conv: ConvId, user: UserId, client: ClientId): Future[SyncId] = sid
 
+  override def postValidateHandles(handles: Seq[Handle]): Future[SyncId] = sid
+
   private def sid = Future.successful(SyncId())
+
 }

--- a/zmessaging/src/main/java/com/waz/api/ValidatedUsernames.scala
+++ b/zmessaging/src/main/java/com/waz/api/ValidatedUsernames.scala
@@ -17,22 +17,6 @@
  */
 package com.waz.api
 
-import android.content.Context
-
-trait Usernames {
-  def isUsernameAvailable(username: String, callback: UsernamesRequestCallback) : Unit
-  def isUsernameValid(username: String) : UsernameValidation
-  def generateUsernameFromName(name: String, context: Context): String
-
-  def validateUsernames(usernames: Array[String])
-  def getValidatedUsernames: ValidatedUsernames
-}
-
-trait UsernamesRequestCallback{
-  def onUsernameRequestResult(usernameValidation: Array[UsernameValidation]) : Unit = {}
-  def onRequestFailed(errorCode: Integer)
-}
-
-case class UsernameValidation(username: String, reason: UsernameValidationError) {
-  def isValid(): Boolean = reason == UsernameValidationError.NONE
+trait ValidatedUsernames extends UiObservable {
+  def getValidations(usernames: Array[String]): Array[UsernameValidation]
 }

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -61,6 +61,7 @@ public enum SyncCommand {
     PostAssetStatus("post-asset-status"),
     PostOpenGraphMeta("post-og-meta"),
     PostReceipt("post-receipt"),
+    ValidateHandles("validate-handles"),
     Unknown("unknown");
 
     public final String name;

--- a/zmessaging/src/main/scala/com/waz/api/impl/User.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/User.scala
@@ -144,7 +144,7 @@ class User(val id: UserId, var data: UserData)(implicit ui: UiModule) extends co
 
   override def getUsername: String = data.handle.fold("")(_.string)
 
-  override def getCommonConnectionsCount = 0 //TODO: STUB
+  override def getCommonConnectionsCount = getCommonConnections.getTotalCount //TODO: STUB
 }
 
 object User {

--- a/zmessaging/src/main/scala/com/waz/api/impl/ValidatedHandles.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ValidatedHandles.scala
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.api.impl
+
+import com.waz.api.UsernameValidation
+import com.waz.model.Handle
+import com.waz.threading.Threading
+import com.waz.ui.UiModule
+import com.waz.utils.events.{EventContext, Signal}
+
+class ValidatedHandles()(implicit ui: UiModule) extends com.waz.api.ValidatedUsernames with UiObservable{
+  implicit val ec = EventContext.Global
+
+  ui.currentZms.flatMap{
+    case None => Signal.empty[Map[Handle, UsernameValidation]]
+    case Some(zms) => zms.handlesService.validatedHandles
+  }.onChanged.on(Threading.Ui){
+    _ => notifyChanged()
+  }
+
+  override def getValidations(usernames: Array[String]): Array[UsernameValidation] = {
+    ui.currentZms.flatMap{
+      case Some(zms) => zms.handlesService.getValidations(usernames.map(Handle(_)))
+      case _ => Signal(Seq[UsernameValidation]())
+    }.currentValue.getOrElse(Seq()).toArray
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
@@ -220,5 +220,5 @@ class ZMessagingApi(implicit val ui: UiModule) extends com.waz.api.ZMessagingApi
 
   override def getConnectionIndicator = new ConnectionIndicator()
 
-  override def getUsernames = ui.currentZms.map(zms => zms.get.account.usernamesClient).currentValue.get
+  override def getUsernames = new Usernames
 }

--- a/zmessaging/src/main/scala/com/waz/service/AccountService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountService.scala
@@ -147,7 +147,6 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
   lazy val netClient          = global.factory.client(credentialsHandler)
   lazy val usersClient        = global.factory.usersClient(netClient)
   lazy val credentialsClient  = global.factory.credentialsClient(netClient)
-  lazy val usernamesClient    = global.factory.usernamesClient(netClient)
 
   @volatile private var _userModule = Option.empty[UserModule]
 

--- a/zmessaging/src/main/scala/com/waz/service/HandlesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/HandlesService.scala
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.service
+
+import com.waz.api.UsernameValidation
+import com.waz.model.Handle
+import com.waz.utils.events.{Signal, SourceSignal}
+
+class HandlesService {
+  val validatedHandles: SourceSignal[Map[Handle, UsernameValidation]] = Signal(Map.empty[Handle, UsernameValidation])
+
+  def updateValidatedHandles(validations: Seq[UsernameValidation]): Unit = {
+    validatedHandles mutate {original =>
+      val newHandles = (validations map (validation => Handle(validation.username) -> validation)).toMap
+      val result = original.filter(pair => !newHandles.contains(pair._1)) ++ newHandles
+      result
+    }
+  }
+
+  def getValidations(handles: Seq[Handle]) : Signal[Seq[UsernameValidation]] = {
+    validatedHandles map (currentHandles => handles.filter(h => currentHandles.contains(h)).flatMap(h => currentHandles.get(h)))
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -67,8 +67,6 @@ class ZMessagingFactory(global: GlobalModule) {
   def userModule(userId: UserId, account: AccountService) = wire[UserModule]
 
   def zmessaging(clientId: ClientId, userModule: UserModule) = wire[ZMessaging]
-
-  def usernamesClient(client: ZNetClient) = new com.waz.api.impl.Usernames(client)
 }
 
 
@@ -175,7 +173,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   lazy val messagesClient     = wire[MessagesClient]
   lazy val openGraphClient    = wire[OpenGraphClient]
   lazy val otrClient          = wire[com.waz.sync.client.OtrClient]
-
+  lazy val handlesClient      = wire[HandlesClient]
 
   lazy val convsContent: ConversationsContentUpdater = wire[ConversationsContentUpdater]
   lazy val messagesContent: MessagesContentUpdater = wire[MessagesContentUpdater]
@@ -223,6 +221,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   lazy val recordAndPlay                         = wire[RecordAndPlayService]
   lazy val receipts                              = wire[ReceiptService]
   lazy val ephemeral                             = wire[EphemeralMessagesService]
+  lazy val handlesService                        = wire[HandlesService]
 
   lazy val assetSync        = wire[AssetSyncHandler]
   lazy val usersearchSync   = wire[UserSearchSyncHandler]
@@ -241,6 +240,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   lazy val lastReadSync     = wire[LastReadSyncHandler]
   lazy val clearedSync      = wire[ClearedSyncHandler]
   lazy val openGraphSync    = wire[OpenGraphSyncHandler]
+  lazy val handlesSync      = wire[HandlesSyncHandler]
 
   lazy val eventPipeline = new EventPipeline(Vector(otrService.eventTransformer), eventScheduler.enqueue)
 

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -81,6 +81,8 @@ trait SyncServiceHandle {
   def syncClientsLocation(): Future[SyncId]
   def syncPreKeys(user: UserId, clients: Set[ClientId]): Future[SyncId]
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId): Future[SyncId]
+
+  def postValidateHandles(handles: Seq[Handle]): Future[SyncId]
 }
 
 class AndroidSyncServiceHandle(context: Context, service: => SyncRequestService, timeouts: Timeouts) extends SyncServiceHandle {
@@ -140,6 +142,8 @@ class AndroidSyncServiceHandle(context: Context, service: => SyncRequestService,
   def syncPreKeys(user: UserId, clients: Set[ClientId]) = addRequest(SyncPreKeys(user, clients))
 
   def postSessionReset(conv: ConvId, user: UserId, client: ClientId) = addRequest(PostSessionReset(conv, user, client))
+
+  override def postValidateHandles(handles: Seq[Handle]): Future[SyncId] = addRequest(ValidateHandles(handles))
 }
 
 trait SyncHandler {
@@ -193,6 +197,7 @@ class AccountSyncHandler(zms: Signal[ZMessaging], otrClients: OtrClientsSyncHand
     case PostRecalled(convId, msg, recall)     => zms.messagesSync.postRecalled(convId, msg, recall)
     case PostSessionReset(conv, user, client)  => zms.otrSync.postSessionReset(conv, user, client)
     case PostReceipt(conv, msg, user, tpe)     => zms.messagesSync.postReceipt(conv, msg, user, tpe)
+    case ValidateHandles(handles)              => zms.handlesSync.validateHandles(handles)
   }
 
   override def apply(req: SyncRequest): Future[SyncResult] =

--- a/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.sync.client
+
+import com.waz.api.{UsernameValidation, UsernameValidationError}
+import com.waz.model.{Handle, UserData}
+import com.waz.threading.{CancellableFuture, Threading}
+import com.waz.utils.JsonDecoder
+import com.waz.znet.Response.{HttpStatus, Status, SuccessHttpStatus}
+import com.waz.znet._
+import com.waz.znet.ZNetClient._
+
+import scala.util.Try
+import scala.util.control.NonFatal
+
+object HandlesClient {
+  val checkMultipleAvailabilityPath = "/users"
+  val checkSingleAvailabilityPath = "/users/handles/"
+  val handlesQuery = "handles"
+}
+
+class HandlesClient(netClient: ZNetClient)  {
+  def getHandlesValidation(handles: Seq[Handle]): ErrorOrResponse[Option[Seq[UsernameValidation]]] = {
+    val uri = Request.query(HandlesClient.checkMultipleAvailabilityPath, (HandlesClient.handlesQuery, handles.map(_.toString).reduce(_ + "," + _)))
+    netClient.withErrorHandling("getHandlesValidation", Request.Get(uri)) {
+      case Response(SuccessHttpStatus(), UsersHandleResponseContent(Seq(unavailableHandles)), headers) =>
+        Some(handles map (u => UsernameValidation(u.toString, if (unavailableHandles.contains(u)) UsernameValidationError.ALREADY_TAKEN else UsernameValidationError.NONE)))
+      case Response(HttpStatus(Status.NotFound, _), _, _) => Some(handles.map(u => UsernameValidation(u.toString, UsernameValidationError.NONE)))
+    }(Threading.Background)
+  }
+}
+
+object UsersHandleResponseContent {
+  def unapply(response: ResponseContent): Option[Seq[String]] = {
+    try {
+      response match {
+        case JsonArrayResponse(js) => Try(JsonDecoder.array[UserData](js).map(user => user.handle.getOrElse(Handle("")).toString)).toOption
+        case _ => None
+      }
+    } catch {
+      case NonFatal(_) =>  None
+    }
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/sync/handler/HandlesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/HandlesSyncHandler.scala
@@ -1,0 +1,39 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.sync.handler
+
+import com.waz.model.Handle
+import com.waz.service.HandlesService
+import com.waz.sync.SyncResult
+import com.waz.sync.client.HandlesClient
+import com.waz.threading.Threading
+
+import scala.concurrent.Future
+
+class HandlesSyncHandler(handlesClient: HandlesClient, handlesService: HandlesService) {
+  import Threading.Implicits.Background
+
+  def validateHandles(handles: Seq[Handle]): Future[SyncResult] = {
+    handlesClient.getHandlesValidation(handles).future map {
+      case Right(data) =>
+        handlesService.updateValidatedHandles(data.getOrElse(Seq()))
+        SyncResult.Success
+      case Left(error) => SyncResult.Failure(Some(error), shouldRetry = true)
+    }
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
@@ -142,6 +142,7 @@ object JsonDecoder {
   implicit def decodePhoneNumber(s: Symbol)(implicit js: JSONObject): PhoneNumber = PhoneNumber(js.getString(s.name))
   implicit def decodeOptPhoneNumber(s: Symbol)(implicit js: JSONObject): Option[PhoneNumber] = opt(s, js => PhoneNumber(js.getString(s.name)))
   implicit def decodeOptHandle(s: Symbol)(implicit js: JSONObject): Option[Handle] = opt(s, js => Handle(js.getString(s.name)))
+  implicit def decodeHandleSeq(s: Symbol)(implicit js: JSONObject): Seq[Handle] = array[Handle](s)({ (arr, i) => Handle(arr.getString(i)) })
 
   implicit def decodeGcmSenderId(s: Symbol)(implicit js: JSONObject): GcmSenderId = GcmSenderId(js.getString(s.name))
 


### PR DESCRIPTION
Uses sync handler instead of a direct request to avoid letting the UI handle with failed requests.