### PR TITLE
Workaround for erased users pictures

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -194,8 +194,9 @@ class UserService(val selfUserId: UserId, usersStorage: UsersStorage, keyValueSe
    */
   def syncIfNeeded(users: UserData*): Future[Unit] =
     lastSlowSyncTimestamp flatMap {
-      case Some(time) => sync.syncUsersIfNotEmpty(users.filter(_.syncTimestamp < time).map(_.id))
-      case _ => Future.successful(())
+      //TODO: Remove empty picture check when not needed anymore
+      case Some(time) => sync.syncUsersIfNotEmpty(users.filter(user => user.syncTimestamp < time || user.picture.isEmpty).map(_.id))
+      case _ => sync.syncUsersIfNotEmpty(users.filter(_.picture.isEmpty).map(_.id))
     }
 
   def updateSyncedUsersPictures(users: UserInfo*): Future[_] = assets.updateAssets(users.flatMap(_.picture.getOrElse(Seq.empty[AssetData])))


### PR DESCRIPTION
There was a bug on production that erased users pictures in the database. While the bug has been fixed already, affected users won’t receive the picture unless the other users change it. This fix forces a syncUser if there is no picture info in the database.