### PR TITLE
Add a blacklist of URIs to use as Asset cache keys

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/handler/AssetSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/AssetSyncHandler.scala
@@ -68,10 +68,10 @@ class AssetSyncHandler(cache: CacheService, convs: ConversationsContentUpdater, 
   //for v2
   def postSelfImageAsset(convId: RConvId, id: AssetId): Future[SyncResult] =
     (for {
-      asset <- assets.storage.get(id)
-      data <- cache.getEntry(CacheKey.fromAssetId(id))
+      Some(asset) <- assets.storage.get(id)
+      data        <- cache.getEntry(asset.cacheKey)
     } yield (asset, data)) flatMap {
-      case (Some(a), Some(d)) => postImageData(convId, a, d, nativePush = false)
+      case (a, Some(d)) => postImageData(convId, a, d, nativePush = false)
       case _ => Future.successful(SyncResult.Failure(None))
     }
 


### PR DESCRIPTION
We still want to be able to use asset uris as cache keys to prevent duplicate entries of the same asset in cache storage, however some URIs do not provide a unique point of access, and for these we should then default to using the asset id as the cache key.