### PR TITLE
[AN-5019] Fix NotificationData decoding.

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/NotificationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/NotificationData.scala
@@ -42,7 +42,7 @@ object NotificationData {
   implicit lazy val Decoder: JsonDecoder[NotificationData] = new JsonDecoder[NotificationData] {
     import JsonDecoder._
 
-    override def apply(implicit js: JSONObject): NotificationData = NotificationData(NotId('id), 'message, 'conv, 'user,
+    override def apply(implicit js: JSONObject): NotificationData = NotificationData(NotId('id: String), 'message, 'conv, 'user,
       NotificationCodec.decode('msgType), 'time, 'userName, 'ephemeral,
       decodeUserIdSeq('mentions), decodeOptId[MessageId]('referencedMessage), 'hasBeenDisplayed)
   }

--- a/zmessaging/src/main/scala/com/waz/model/Uid.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Uid.scala
@@ -281,6 +281,4 @@ object NotId {
   def apply(tpe: NotificationType, userId: UserId): NotId = NotId(s"$tpe-${userId.str}")
   def apply(id: (MessageId, UserId)): NotId = NotId(s"$LIKE-${id._1.str}-${id._2.str}")
   def apply(msgId: MessageId): NotId = NotId(msgId.str)
-  def apply(s: Symbol): NotId = NotId(s.toString)
-
 }


### PR DESCRIPTION
Decoder was not loading id correctly, `NotId` had constructor taking symbol, so implicit for string decoding would not be used, instead all notifications would have `'id` for id value. Due to this notifications map signal in storage would not return all notifications.
This caused several weird issues with notifications list, like missing notifications or randomly showing old ones.