### PR TITLE
Fix issue with past participants

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/KeyValueStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/KeyValueStorage.scala
@@ -43,6 +43,9 @@ class KeyValueStorage(context: Context, storage: ZmsDatabase) extends CachedStor
   def lastSlowSyncTimestamp = decodePref(LastSlowSyncTimeKey, java.lang.Long.parseLong)
   def lastSlowSyncTimestamp_=(time: Long): Unit = setPref(LastSlowSyncTimeKey, String.valueOf(time))
 
+  def shouldSyncConversations = decodePref(ShouldSyncConversations, java.lang.Boolean.parseBoolean)
+  def shouldSyncConversations_=(should: Boolean): Unit = setPref(ShouldSyncConversations, String.valueOf(should))
+
   def keyValuePref[A: PrefCodec](key: String, default: A) = new KeyValuePref[A](this, key, default)
 }
 
@@ -51,6 +54,7 @@ object KeyValueStorage {
   val Verified = "verified"
   val SelectedConvId = "selected_conv_id"
   val SpotifyRefreshToken = "spotify_refresh_token"
+  val ShouldSyncConversations = "should_sync_conversations"
 
   class KeyValuePref[A](storage: KeyValueStorage, key: String, val default: A)(implicit val trans: PrefCodec[A], implicit val dispatcher: ExecutionContext) extends Preference[A] {
     def apply(): Future[A] = storage.decodePref(key, trans.decode).map(_.getOrElse(default))

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -54,7 +54,7 @@ class ZMessagingDB(context: Context, dbName: String) extends DaoDB(context.getAp
 }
 
 object ZMessagingDB {
-  val DbVersion = 83
+  val DbVersion = 84
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao,
@@ -127,6 +127,9 @@ object ZMessagingDB {
     },
     Migration(82, 83) { db =>
       MessageDataMigration.v83(db)
+    },
+    Migration(83, 84){ db =>
+      db.execSQL("INSERT INTO KeyValues (key, value) VALUES ('should_sync_conversations', 'true')")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -75,6 +75,13 @@ class ConversationsService(context: Context, push: PushServiceSignals, users: Us
     } yield ()
   }
 
+  kvService.shouldSyncConversations.map{
+    case Some(true) =>
+      sync.syncConversations()
+      kvService.shouldSyncConversations = false
+    case _ =>
+  }
+
   errors.onErrorDismissed {
     case ErrorData(_, ErrorType.CANNOT_CREATE_GROUP_CONVERSATION_WITH_UNCONNECTED_USER, _, _, Some(convId), _, _, _, _) =>
       deleteConversation(convId)

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -116,8 +116,13 @@ object ConversationsClient {
   object ConversationResponse {
     import com.waz.utils.JsonDecoder._
 
-    def memberDecoder(convId: ConvId) = new JsonDecoder[ConversationMemberData] {
-      override def apply(implicit js: JSONObject) = ConversationMemberData('id, convId)
+    def memberDecoder(convId: ConvId) = new JsonDecoder[Option[ConversationMemberData]] {
+      override def apply(implicit js: JSONObject) = {
+        if (decodeOptInt('status).forall(s => ConversationStatus(s) == ConversationStatus.Active))
+          Some(ConversationMemberData('id, convId))
+        else
+          None
+      }
     }
 
     def conversationData(js: JSONObject, self: JSONObject) = {
@@ -147,7 +152,7 @@ object ConversationsClient {
 
         val conversation = conversationData(js, self)
 
-        ConversationResponse(conversation, array(members.getJSONArray("others"))(memberDecoder(conversation.id)))
+        ConversationResponse(conversation, array(members.getJSONArray("others"))(memberDecoder(conversation.id)).flatten)
       }
     }
 


### PR DESCRIPTION
The backend is still sending past participants and we were ignoring the
status. It also forces conversation sync after migration to restore the
damaged ones.