### PR TITLE
Update spotify-auth dependency to publicly available maven artifact

### DIFF
--- a/external/build.sbt
+++ b/external/build.sbt
@@ -22,7 +22,7 @@ lazy val root = Project("wire-external", file("."))
     publish := { },
     publishLocal := { }
   )
-  .aggregate(icu4j, spotifyPlayer, spotifyAuth)
+  .aggregate(icu4j, spotifyPlayer)
 
 lazy val icu4j = project
   .settings(proguardSettings:_ *)
@@ -70,8 +70,6 @@ lazy val spotifySettings = commonSettings ++ Seq(
 )
 
 lazy val spotifyPlayer = project.settings(spotifySettings: _*).settings(name := "spotify-player")
-
-lazy val spotifyAuth = project.settings(spotifySettings: _*).settings(name := "spotify-auth")
 
 
 def cryptoboxDownloadUrl(version: String, artifact: String = "cryptobox-android", ext: String = "aar") =

--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -29,7 +29,7 @@ object SharedSettings {
     lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.18.0"
     lazy val backendApi = "com.wire" % "backend-api-proto" % "1.1"
     lazy val spotifyPlayer = "com.wire" % "spotify-player" % "1.0.0-beta13"
-    lazy val spotifyAuth = "com.wire" % "spotify-auth" % "1.0.0-beta13"
+    lazy val spotifyAuth = "com.spotify.android" % "auth" % "1.0.0-alpha"
     lazy val localytics = "com.localytics.android" % "library" % "3.8.0"
     lazy val hockeyApp = "net.hockeyapp.android" % "HockeySDK" % "3.7.2"
     lazy val supportV4 = "com.android.support" % "support-v4" % supportLibVersion


### PR DESCRIPTION
The replacement artifact is newer than the current artifact despite the version number.
The new dependency is Apache 2.0 licensed, whereas the old one is proprietary.
Also remove the library from external build script.