### PR TITLE
[AN-5151] adds asset v3.1 receiving possibility

### DIFF
--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -26,7 +26,7 @@ object SharedSettings {
     lazy val avs = "com.wire" % "avs" % avsVersion
     lazy val avsAudio = "com.wire.avs" % "audio-notifications" % audioVersion
     lazy val cryptobox = "com.wire" % "cryptobox-android" % cryptoboxVersion
-    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.18.0"
+    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.19.0"
     lazy val backendApi = "com.wire" % "backend-api-proto" % "1.1"
     lazy val spotifyPlayer = "com.wire" % "spotify-player" % "1.0.0-beta13"
     lazy val spotifyAuth = "com.wire" % "spotify-auth" % "1.0.0-beta13"

--- a/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
@@ -146,7 +146,7 @@ class AssetMessageSpec extends FeatureSpec with BeforeAndAfter with Matchers wit
       }
 
       message.data.protos should beMatching {
-        case Seq(GenericMessage(_, GenericContent.Asset(AssetData(_, Mime.Audio.MP4, _, UploadDone, _, _, _, _, _, _, Some(Audio(d, _)), _, _, _, _, _, _), _))) if d.getSeconds == 4 => true
+        case Seq(GenericMessage(_, GenericContent.Asset(AssetData(_, Mime.Audio.MP4, _, UploadDone, _, _, _, _, _, _, _, Some(Audio(d, _)), _, _, _, _, _, _), _))) if d.getSeconds == 4 => true
       }
 
       errors shouldBe empty
@@ -183,7 +183,7 @@ class AssetMessageSpec extends FeatureSpec with BeforeAndAfter with Matchers wit
       }
 
       message.data.protos should beMatching {
-        case Seq(GenericMessage(_, GenericContent.Asset(AssetData(_, Mime.Audio.MP4, _, UploadDone, _, _, _, _, _, _, Some(Video(Dim2(1080, 1920), d)), _, _, _, _, _, _), _))) if d.getSeconds == 3 => true
+        case Seq(GenericMessage(_, GenericContent.Asset(AssetData(_, Mime.Audio.MP4, _, UploadDone, _, _, _, _, _, _, _, Some(Video(Dim2(1080, 1920), d)), _, _, _, _, _, _), _))) if d.getSeconds == 3 => true
       }
 
       errors shouldBe empty

--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -26,7 +26,7 @@ import android.net.Uri
 import com.waz.api.{InvitationTokenFactory, Invitations}
 import com.waz.model.AssetMetaData.Image.Tag.{Medium, Preview}
 import com.waz.model.ConversationData.{ConversationStatus, ConversationType}
-import com.waz.model.GenericContent.Text
+import com.waz.model.GenericContent.{EncryptionAlgorithm, Text}
 import com.waz.model.SearchQuery.{Recommended, TopPeople}
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.UserData.ConnectionStatus.{Accepted, PendingFromOther}
@@ -144,6 +144,7 @@ object Generators {
     token         <- optGen(arbitrary[AssetToken])
     otrKey        <- optGen(arbitrary[AESKey])
     sha           <- optGen(arbitrary[Sha256])
+    encryption    <- optGen(oneOf(EncryptionAlgorithm.AES_GCM, EncryptionAlgorithm.AES_CBC))
     name          <- optGen(alphaNumStr)
     previewId     <- optGen(arbitrary[AssetId])
     metaData      <- optGen(arbitrary[AssetMetaData])
@@ -151,7 +152,7 @@ object Generators {
     proxyPath     <- optGen(arbitrary[String])
     convId        <- optGen(arbitrary[RConvId])
     data <- optGen(arbitrary[Array[Byte]])
-  } yield AssetData(id, mime, sizeInBytes, status, remoteId, token, otrKey, sha, name, previewId, metaData, source, proxyPath, convId, data))
+  } yield AssetData(id, mime, sizeInBytes, status, remoteId, token, otrKey, sha, encryption, name, previewId, metaData, source, proxyPath, convId, data))
 
 
   implicit lazy val arbAssetStatus: Arbitrary[AssetStatus] = Arbitrary(frequency((2, oneOf[AssetStatus](AssetStatus.UploadNotStarted,

--- a/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderSpec.scala
@@ -61,7 +61,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       override def download[A <: DownloadRequest](req: A, force: Boolean)(implicit loader: downloads.Downloader[A], expires: Expiration): CancellableFuture[Option[CacheEntry]] = {
         downloadRequest = downloadRequest :+ req
         req match {
-          case WireAssetRequest(_, _, RemoteData(Some(id), _, _, _), _, _, _) => CancellableFuture.delayed(500.millis)(downloadResult.get(id))(Threading.Background)
+          case WireAssetRequest(_, _, RemoteData(Some(id), _, _, _, _), _, _, _) => CancellableFuture.delayed(500.millis)(downloadResult.get(id))(Threading.Background)
           case _ => CancellableFuture.successful(None)
         }
       }
@@ -128,7 +128,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       image.getWidth shouldEqual 240
 
       downloadRequest should beMatching({
-        case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _), Some(`convId`), _, _)) => true
+        case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _, _), Some(`convId`), _, _)) => true
       })
     }
 
@@ -155,7 +155,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       downloadRequest.size shouldEqual (REPEATS)
 
       downloadRequest.foreach{ _ should beMatching({
-        case WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _), Some(`convId`), _, _) => true
+        case WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _, _), Some(`convId`), _, _) => true
       })}
     }
   }
@@ -168,7 +168,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       assertResults(BitmapRequest.Regular(300)) { results =>
         results should have size 1
         downloadRequest should beMatching({
-          case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _), Some(`convId`), _, _)) => true
+          case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _, _), Some(`convId`), _, _)) => true
         })
       }
     }
@@ -194,7 +194,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       }
 
       downloadRequest should beMatching({
-        case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _), Some(`convId`), _, _)) => true
+        case Seq(WireAssetRequest(_, _, RemoteData(Some(`mediumId`), _, _, _, _), Some(`convId`), _, _)) => true
       })
     }
 

--- a/zmessaging/src/main/res/values/zms_preferences.xml
+++ b/zmessaging/src/main/res/values/zms_preferences.xml
@@ -32,6 +32,7 @@
     <string name="zms_assets_v3">PREF_KEY_SEND_WITH_ASSETS_V3</string>
     <string name="zms_calling_v3">PREF_KEY_CALLING_V3</string>
     <string name="zms_gcm_enabled">PREF_KEY_GCM_ENABLED</string>
+    <string name="zms_v31_assets_enabled">PREF_V31_ASSETS_ENABLED</string>
     <string name="zms_ws_foreground_service_enabled">PREF_KEY_WS_FOREGROUND_SERVICE_ENABLED</string>
 
     <!-- contact sharing -->

--- a/zmessaging/src/main/scala/com/waz/service/PreferenceService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/PreferenceService.scala
@@ -42,6 +42,7 @@ class PreferenceService(context: Context) {
   lazy val sendWithAssetsV3Key      = Try(context.getResources.getString(R.string.zms_assets_v3)).getOrElse("PREF_KEY_SEND_WITH_ASSETS_V3")
   lazy val callingV3Key             = Try(context.getResources.getString(R.string.zms_calling_v3)).getOrElse("PREF_KEY_CALLING_V3")
   lazy val gcmEnabledKey            = Try(context.getResources.getString(R.string.zms_gcm_enabled)).getOrElse("PREF_KEY_GCM_ENABLED")
+  lazy val v31AssetsEnabledKey      = Try(context.getResources.getString(R.string.zms_v31_assets_enabled)).getOrElse("PREF_V31_ASSETS_ENABLED")
   lazy val wsForegroundKey          = Try(context.getResources.getString(R.string.zms_ws_foreground_service_enabled)).getOrElse("PREF_KEY_WS_FOREGROUND_SERVICE_ENABLED")
 
   lazy val uiPreferences = uiPreferencesFrom(context)
@@ -51,6 +52,7 @@ class PreferenceService(context: Context) {
   def sendWithV3 = uiPreferences.getBoolean(sendWithAssetsV3Key, ZmsVersion.DEBUG) //false by default for production
   def callingV3  = uiPreferences.getString(callingV3Key,         if (ZmsVersion.DEBUG) "2" else "0") //0 (calling v2) by default for production, v3 (2) for debug
   def gcmEnabled = uiPreferences.getBoolean(gcmEnabledKey,       true) //true by default for production
+  def v31AssetsEnabled = uiPreferences.getBoolean(gcmEnabledKey, false)
 
   lazy val preferences = preferencesFrom(context)
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -273,7 +273,7 @@ class MessagesSyncHandler(context: Context, service: MessagesService, msgContent
                 Some(data) <- assets.getAssetData(asset.id)
                 res <- otrSync.postAssetDataV2(conv, key, proto, data, recipients = rcps)
               } yield res).flatMap {
-                case Right((r@RemoteData(_, _, _, sha), date)) =>
+                case Right((r@RemoteData(_, _, _, sha, _), date)) =>
                   val updated = asset.copyWithRemoteData(r)
                   CancellableFuture lift (for {
                     _ <- assets.storage.mergeOrCreateAsset(updated)


### PR DESCRIPTION
Uses generic-message-proto 1.19.0 which adds an optional enum, EncryptionAlgorithm, which can be either AES_CBC (the old one), or AES_GCM (the new one). 

The new algorithm is not implemented yet, so instead there is a new switch in PreferenceService, v31AssetsEnabled, by default set to false. Only if the switch was set to true and the AES_GCM was set in AssetData, the new algorithm would be used to decrypt received data.

Accidentally, the new generic-message-proto also incorporates one small change in Messages.Confirmation: messageId is changed to firstMessageId.