### PR TITLE
makes CachedStorage return an asset instead of None if the update was not necessary

### DIFF
--- a/zmessaging/src/main/scala/com/waz/utils/CachedStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/CachedStorage.scala
@@ -251,7 +251,7 @@ class CachedStorage[K, V](cache: LruCache[K, Option[V]], db: Database)(implicit 
 
   protected def updateInternal(key: K, updater: V => V)(current: V): Future[Option[(V, V)]] = {
     val updated = updater(current)
-    if (updated == current) Future.successful(None)
+    if (updated == current) Future.successful(Some((current, updated)))
     else {
       cache.put(key, Some(updated))
       returning(db { save(Seq(updated))(_) } .future.map { _ => Some((current, updated)) }) { _ =>


### PR DESCRIPTION
Until recently comparing two AssetData always returned false which forced unnecessary updates in CachedStorage. I changed that but it uncovered another error: When two AssetData were the same, the update method returned None, whereas everyone expected to have a tuple: the old and the new AssetData (even if they were the same). This PR fixes that.