### PR TITLE
AN-5163 bugfix. Android-free unit tests in AssetSyncHandler. 

### DIFF
--- a/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
@@ -38,7 +38,7 @@ import com.waz.model.{GenericContent, Mime, AssetStatus => _, MessageContent => 
 import com.waz.provision.ActorMessage._
 import com.waz.service.conversation.ConversationsUiService.LargeAssetWarningThresholdInBytes
 import com.waz.service.{UserModule, ZMessaging, ZMessagingFactory}
-import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.{OtrSyncHandler, OtrSyncHandlerImpl}
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
 import com.waz.testutils.{DefaultPatienceConfig, FeigningAsyncClient, TestResourceContentProvider}
@@ -666,7 +666,7 @@ class AssetMessageSpec extends FeatureSpec with BeforeAndAfter with Matchers wit
     override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging =
       new ApiZMessaging(clientId, user) {
 
-        override lazy val otrSync = new OtrSyncHandler(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
+        override lazy val otrSync = new OtrSyncHandlerImpl(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
           override def postOtrMessage(convId: ConvId, remoteId: RConvId, message: GenericMessage, recipients: Option[Set[UserId]], nativePush: Boolean = true): Future[Either[ErrorResponse, Date]] =
             super.postOtrMessage(convId, remoteId, message).andThen { case Success(r) if r.isRight => otrMessageSyncs :+=(remoteId, message, r) }(Threading.Background)
         }

--- a/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
@@ -23,16 +23,13 @@ import akka.pattern.ask
 import com.waz.api.MessageContent.Image
 import com.waz.api._
 import com.waz.api.impl.LocalImageAsset
-import com.waz.cache.{CacheEntry, LocalData}
-import com.waz.model.{RConvId, UserId}
+import com.waz.cache.CacheEntry
 import com.waz.model.otr.ClientId
 import com.waz.provision.ActorMessage.{AwaitSyncCompleted, Login, Successful}
 import com.waz.service._
-import com.waz.sync.client.AssetClient
-import com.waz.sync.client.AssetClient.{OtrAssetMetadata, OtrAssetResponse}
+import com.waz.sync.client.AssetClientImpl
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
-import com.waz.threading.CancellableFuture
 import com.waz.utils.IoUtils
 import com.waz.znet.Request
 import com.waz.znet.ZNetClient.ErrorOrResponse
@@ -109,7 +106,7 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
   override lazy val zmessagingFactory = new ZMessagingFactory(globalModule) {
     override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging =
       new ZMessaging(clientId, user) {
-        override lazy val assetClient = new AssetClient(zNetClient) {
+        override lazy val assetClient = new AssetClientImpl(zNetClient) {
 
           override def loadAsset(req: Request[Unit]): ErrorOrResponse[CacheEntry] = {
             downloads.incrementAndGet()

--- a/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
@@ -28,7 +28,7 @@ import com.waz.model.otr.ClientId
 import com.waz.model.{ConvId, GenericMessage, RConvId, UserId}
 import com.waz.provision.ActorMessage.{AwaitSyncCompleted, Login, SendText, Successful}
 import com.waz.service._
-import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.{OtrSyncHandler, OtrSyncHandlerImpl}
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, Matchers}
@@ -63,7 +63,7 @@ class LastReadSpec extends FeatureSpec with Matchers with BeforeAndAfterAll with
     override def zmessaging(clientId: ClientId, userModule: UserModule): ZMessaging = new ApiZMessaging(clientId, userModule) {
 
 
-      override lazy val otrSync: OtrSyncHandler = new OtrSyncHandler(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
+      override lazy val otrSync: OtrSyncHandler = new OtrSyncHandlerImpl(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
         override def postOtrMessage(convId: ConvId, remoteId: RConvId, message: GenericMessage, recipients: Option[Set[UserId]], nativePush: Boolean = true): Future[Either[ErrorResponse, Date]] = {
           if (convId.str == self.str)
             message match {

--- a/tests/integration/src/test/scala/com/waz/messages/VideoMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/VideoMessageSpec.scala
@@ -196,8 +196,8 @@ class VideoMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   override val provisionFile: String = "/two_users_connected.json"
 
   override lazy val globalModule = new ApiSpecGlobal {
-    override lazy val cache = new CacheService(context, storage, new CacheStorageImpl(storage, context)) {
-      override def addStream[A](key: CacheKey, in: => InputStream, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None, length: Int = -1, execution: ExecutionContext = Background)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry] =
+    override lazy val cache = new CacheServiceImpl(context, storage, new CacheStorageImpl(storage, context)) {
+      override def addStream(key: CacheKey, in: => InputStream, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None, length: Int = -1, execution: ExecutionContext = Background)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry] =
         super.addStream(key, in, mime, name, cacheLocation, length, execution)(timeout).andThen {
           case Success(entry) if isDownloadingFromProvider(key) =>
             val path = entry.cacheFile.getAbsolutePath

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrIntegrationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrIntegrationSpec.scala
@@ -230,7 +230,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
       awaitUi(1.second)
       val asset = msgs.getLastMessage.getImage
       val asset1 = asset.data.copy(id = AssetId()) // create asset copy to make sure it is not cached
-      zmessaging.assets.storage.updateAsset(asset1.id, _ => asset1)
+      zmessaging.assets.updateAsset(asset1.id, _ => asset1)
 
       val a = api.ui.images.getImageAsset(asset1.id)
 

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -75,7 +75,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
     override lazy val flowmanager: DefaultFlowManagerService = new MockedFlowManagerService(context, zNetClient, websocket, prefs, network)
     override lazy val mediamanager: DefaultMediaManagerService = new MockedMediaManagerService(context, prefs)
 
-    override lazy val assetClient        = new AssetClient(zNetClient) {
+    override lazy val assetClient        = new AssetClientImpl(zNetClient) {
       override def postImageAssetData(asset: AssetData, data: LocalData, nativePush: Boolean = true, convId: RConvId): ErrorOrResponse[RAssetId] = suite.postImageAssetData(asset, convId, data, nativePush)
     }
 

--- a/tests/unit/src/test/scala/com/waz/cache/CacheServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/cache/CacheServiceSpec.scala
@@ -41,11 +41,12 @@ class CacheServiceSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   lazy val cacheDir = Robolectric.application.getCacheDir
 
   lazy val storage = new GlobalDatabase(Robolectric.application)
-  lazy val service = CacheService(Robolectric.application, storage)
+  lazy val cacheStorage = CacheStorage(storage, Robolectric.application)
+  lazy val service = CacheService(Robolectric.application, storage, cacheStorage)
 
   after {
     Thread.sleep(1000) // because some operations (deleting) are scheduled on background
-    service.cacheStorage.list().map { es => service.cacheStorage.remove(es.map(_.key)) }.await()
+    cacheStorage.list().map { es => cacheStorage.remove(es.map(_.key)) }.await()
   }
 
   feature("Create") {

--- a/tests/unit/src/test/scala/com/waz/service/AssetServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/AssetServiceSpec.scala
@@ -27,7 +27,7 @@ import com.waz.model.AssetMetaData.Image.Tag.Medium
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.{Mime, _}
 import com.waz.service.assets.AssetService
-import com.waz.sync.client.AssetClient
+import com.waz.sync.client.{AssetClient, AssetClientImpl}
 import com.waz.testutils.Matchers._
 import com.waz.testutils.{MockZMessaging, RoboPermissionProvider}
 import com.waz.threading.CancellableFuture
@@ -51,7 +51,7 @@ class AssetServiceSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   val asset = AssetData(convId = Some(RConvId()), sizeInBytes = mediumFile.length(), metaData = Some(AssetMetaData.Image(Dim2(240, 246), Medium)), remoteId = Some(RAssetId()))
 
   lazy val zms = new MockZMessaging() { self =>
-    override lazy val assetClient: AssetClient = new AssetClient(zNetClient) {
+    override lazy val assetClient: AssetClient = new AssetClientImpl(zNetClient) {
       override def loadAsset(req: Request[Unit]) = CancellableFuture.successful(loadImageResult)
     }
     permissions.setProvider(new RoboPermissionProvider)

--- a/tests/unit/src/test/scala/com/waz/service/assets/DownloaderServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/assets/DownloaderServiceSpec.scala
@@ -205,7 +205,7 @@ class DownloaderServiceSpec extends FeatureSpec with Matchers with BeforeAndAfte
 
   val database = stub[Database]
   val cacheStorage = stub[CacheStorage]
-  val cacheService = new CacheService(context, database, cacheStorage)
+  val cacheService = CacheService(context, database, cacheStorage)
   val result = new CacheEntry(CacheEntryData(CacheKey("...")), cacheService)
 
   private def createDownloader(ctx: Context = testContext,

--- a/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderAndroidFreeSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderAndroidFreeSpec.scala
@@ -85,7 +85,7 @@ class ImageLoaderAndroidFreeSpec extends FeatureSpec with AndroidFreeSpec with B
   val context = stub[Context]
   val database = stub[Database]
   val cacheStorage = stub[CacheStorage]
-  val cacheService = new CacheService(context, database, cacheStorage)
+  val cacheService = CacheService(context, database, cacheStorage)
   val memoryImageCache = new MemoryImageCache(stub[Cache[Key, Entry]])
   val bitmapDecoder = new BitmapDecoder
   val permissionsService = new PermissionsService(context)
@@ -156,7 +156,7 @@ class ImageLoaderAndroidFreeSpec extends FeatureSpec with AndroidFreeSpec with B
         val cacheStorage = mock[CacheStorage]
         (cacheStorage.get _).expects(*).returning(Future(Option(CacheEntryData(asset.cacheKey))))
 
-        val loader = new ImageLoader(context, new CacheService(context, database, cacheStorage), memoryImageCache, bitmapDecoder, permissionsService, assetLoader)
+        val loader = new ImageLoader(context, CacheService(context, database, cacheStorage), memoryImageCache, bitmapDecoder, permissionsService, assetLoader)
 
         val req = Regular(asset.width)
         waitForResult { loader.hasCachedData(asset) } should be(true)
@@ -197,7 +197,7 @@ class ImageLoaderAndroidFreeSpec extends FeatureSpec with AndroidFreeSpec with B
           (memoryCache.put _).expects(key, *).twice().onCall { (key: Key, value: Entry) => value }
         }
 
-        val loader = new ImageLoader(context, new CacheService(context, database, fileCache), new MemoryImageCache(memoryCache), bitmapDecoder, permissionsService, assetLoader) {
+        val loader = new ImageLoader(context, CacheService(context, database, fileCache), new MemoryImageCache(memoryCache), bitmapDecoder, permissionsService, assetLoader) {
           override def getImageMetadata(data: LocalData, mirror: Boolean) = CancellableFuture {
             Metadata(bmp.getWidth, bmp.getHeight, Mime.Image.Bmp.str)
           }
@@ -227,7 +227,7 @@ class ImageLoaderAndroidFreeSpec extends FeatureSpec with AndroidFreeSpec with B
           (assetLoader.downloadAssetData _).expects(asset.loadRequest).returning( CancellableFuture { Some(new CacheEntry(cacheEntryData, cacheService)) } )
         }
 
-        val loader = new ImageLoader(context, new CacheService(context, database, fileCache), new MemoryImageCache(memoryCache), bitmapDecoder, permissionsService, assetLoader) {
+        val loader = new ImageLoader(context, CacheService(context, database, fileCache), new MemoryImageCache(memoryCache), bitmapDecoder, permissionsService, assetLoader) {
           override def getImageMetadata(data: LocalData, mirror: Boolean): CancellableFuture[Metadata] = CancellableFuture {
             Metadata(bmp.getWidth, bmp.getHeight, Mime.Image.Bmp.str)
           }

--- a/tests/unit/src/test/scala/com/waz/sync/PostMessageHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/PostMessageHandlerSpec.scala
@@ -32,7 +32,7 @@ import com.waz.service._
 import com.waz.sync.client.MessagesClient.OtrMessage
 import com.waz.sync.client.OtrClient.ClientMismatch
 import com.waz.sync.handler.AssetSyncHandler
-import com.waz.sync.otr.OtrSyncHandler
+import com.waz.sync.otr.{OtrSyncHandler, OtrSyncHandlerImpl}
 import com.waz.sync.queue.ConvLock
 import com.waz.testutils.Matchers._
 import com.waz.testutils.MockZMessaging
@@ -73,7 +73,7 @@ class PostMessageHandlerSpec extends FeatureSpec with Matchers with BeforeAndAft
 
     usersStorage.addOrOverwrite(UserData(test.userId, "selfUser"))
 
-    override lazy val otrSync: OtrSyncHandler = new OtrSyncHandler(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
+    override lazy val otrSync: OtrSyncHandler = new OtrSyncHandlerImpl(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
       override def postOtrMessage(convId: ConvId, remoteId: RConvId, message: GenericMessage, recipients: Option[Set[UserId]], nativePush: Boolean) = postMessageResponse
     }
 
@@ -81,7 +81,7 @@ class PostMessageHandlerSpec extends FeatureSpec with Matchers with BeforeAndAft
       override def updateNetworkMode(): Unit = ()
     }
 
-    override lazy val assetSync = new AssetSyncHandler(cache, convsContent, convEvents, assetClient, assets, imageLoader, otrSync, prefs) {
+    override lazy val assetSync = new AssetSyncHandler(cache, assetClient, assets, otrSync) {
       override def uploadAssetData(assetId: AssetId, public: Boolean): ErrorOrResponse[Option[AssetData]] = CancellableFuture successful postImageResult
     }
 

--- a/tests/unit/src/test/scala/com/waz/sync/handler/AssetSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/AssetSyncHandlerSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.sync.handler
+
+import java.io.{File, InputStream}
+
+import com.waz.cache._
+import com.waz.model.AssetData.RemoteData
+import com.waz.model.AssetStatus.{UploadDone, UploadInProgress, UploadNotStarted}
+import com.waz.model.GenericContent.EncryptionAlgorithm
+import com.waz.model.{Sha256, _}
+import com.waz.service.assets.AssetService
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.client.AssetClient
+import com.waz.sync.otr.OtrSyncHandler
+import com.waz.threading.CancellableFuture
+import com.waz.utils.sha2
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen.resultOf
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfter, FeatureSpec, Matchers}
+
+import scala.annotation.tailrec
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+/**
+  * Created by admin on 03/05/17.
+  */
+class AssetSyncHandlerSpec extends FeatureSpec with AndroidFreeSpec with BeforeAndAfter with Matchers with MockFactory {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val TIMEOUT = 5.seconds
+  val ARB_DATA_SIZE = 10
+  private def waitForResult[T](f: => Future[T]): T = Await.result(f, TIMEOUT)
+
+  val assetClient = stub[AssetClient]
+
+  def sideEffect[A](f: => A): Gen[A] = Gen.resultOf[Unit, A](_ => f)
+  implicit lazy val arbAssetId: Arbitrary[AssetId] = Arbitrary(sideEffect(AssetId()))
+
+  lazy val arbAssetData: Arbitrary[AssetData] = Arbitrary(for {
+    id            <- arbitrary[AssetId]
+    mime          <- Gen.oneOf(Mime.Image.supported.toSeq) // no audio mime types
+    sizeInBytes   <- Gen.posNum[Long]
+  } yield AssetData(id, mime, sizeInBytes, UploadNotStarted))
+
+  implicit lazy val arbRAssetDataId: Arbitrary[RAssetId] = Arbitrary(sideEffect(RAssetId()))
+  implicit lazy val arbAssetToken: Arbitrary[AssetToken] = Arbitrary(resultOf(AssetToken))
+  implicit lazy val arbOtrKey: Arbitrary[AESKey] = Arbitrary(sideEffect(AESKey()))
+  implicit lazy val arbSha256: Arbitrary[Sha256] = Arbitrary(arbitrary[Array[Byte]].map(b => Sha256(sha2(b))))
+
+  implicit def optGen[T](implicit gen: Gen[T]): Gen[Option[T]] = Gen.frequency((1, Gen.const(None)), (2, gen.map(Some(_))))
+
+  lazy val arbRemoteData: Arbitrary[RemoteData] = Arbitrary(for {
+    remoteId      <- optGen(arbitrary[RAssetId])
+    token         <- optGen(arbitrary[AssetToken])
+    otrKey        <- optGen(arbitrary[AESKey])
+    sha           <- optGen(arbitrary[Sha256])
+  } yield RemoteData(remoteId, token, otrKey, sha, Some(EncryptionAlgorithm.AES_GCM)))
+
+  @tailrec
+  private def sample[T](arb: Arbitrary[T]): T = arb.arbitrary.sample match {
+    case None => sample(arb)
+    case Some(data) => data
+  }
+
+  private def arbitraryAssetData: List[AssetData] = (1 to 10).map(_ => sample(arbAssetData)).toList
+
+  feature("upload image") {
+    scenario("upload full image") {
+      arbitraryAssetData.foreach { asset =>
+        val remoteData = sample(arbRemoteData)
+        val assetUploadStarted = asset.copy(status = UploadInProgress)
+        val assetWithRemoteData = assetUploadStarted.copyWithRemoteData(remoteData)
+        val assetUploadDone = assetWithRemoteData.copy(status = UploadDone)
+
+        val assets = mock[AssetService]
+        val otrSync = mock[OtrSyncHandler]
+        val cacheService = mock[CacheService]
+
+        val cacheEntry = new CacheEntry(CacheEntryData(assetWithRemoteData.cacheKey), cacheService)
+
+        inSequence {
+          (assets.updateAsset _).expects(asset.id, *).returns(Future(Some(assetUploadStarted)))
+          (assets.getLocalData _).expects(asset.id).returns(CancellableFuture(Some(LocalData.Empty)))
+          (otrSync.uploadAssetDataV3 _).expects(LocalData.Empty, *, asset.mime).returns(CancellableFuture(Right(remoteData)))
+          (assets.updateAsset _).expects(asset.id, *).returns(Future(Some(assetWithRemoteData)))
+
+          // an ugly way to mock a method with implicit parameters
+          (cacheService.addStream(_: CacheKey, _: InputStream, _: Mime, _: Option[String], _: Option[File], _: Int, _: ExecutionContext)(_: Expiration))
+            .expects(assetWithRemoteData.cacheKey, *, assetWithRemoteData.mime, assetWithRemoteData.name, *, *, *, *).returns(Future(cacheEntry))
+        }
+
+        val handler = new AssetSyncHandler(cacheService, assetClient, assets, otrSync)
+        waitForResult {handler.uploadAssetData(asset.id)}.right.get shouldEqual Some(assetUploadDone)
+      }
+    }
+  }
+
+}

--- a/tests/unit/src/test/scala/com/waz/sync/handler/AssetSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/AssetSyncHandlerSpec.scala
@@ -40,9 +40,6 @@ import scala.annotation.tailrec
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
-/**
-  * Created by admin on 03/05/17.
-  */
 class AssetSyncHandlerSpec extends FeatureSpec with AndroidFreeSpec with BeforeAndAfter with Matchers with MockFactory {
 
   import scala.concurrent.ExecutionContext.Implicits.global

--- a/tests/unit/src/test/scala/com/waz/sync/handler/ImageAssetSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/ImageAssetSyncHandlerSpec.scala
@@ -31,7 +31,7 @@ import com.waz.model.ConversationData.ConversationType
 import com.waz.model._
 import com.waz.service.ZMessaging
 import com.waz.sync.SyncResult
-import com.waz.sync.client.AssetClient
+import com.waz.sync.client.{AssetClient, AssetClientImpl}
 import com.waz.testutils.MockZMessaging
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.IoUtils
@@ -60,7 +60,7 @@ class ImageAssetSyncHandlerSpec extends FeatureSpec with Matchers with BeforeAnd
     convsStorage.insert(conv)
     usersStorage.insert(selfUser)
 
-    override lazy val assetClient: AssetClient = new AssetClient(zNetClient) {
+    override lazy val assetClient: AssetClient = new AssetClientImpl(zNetClient) {
       override def postImageAssetData(asset: AssetData, data: LocalData, nativePush: Boolean = true, convId: RConvId) = {
         postImageRequest = Some((asset, convId, data))
         CancellableFuture.successful(postImageResponse(asset, convId))
@@ -95,7 +95,7 @@ class ImageAssetSyncHandlerSpec extends FeatureSpec with Matchers with BeforeAnd
 
   scenario("post full image data") {
     val asset = generateImageAsset()
-    Await.ready(service.assets.storage.mergeOrCreateAsset(asset), 1.second)
+    Await.ready(service.assets.mergeOrCreateAsset(asset), 1.second)
     val file = Await.result(cache.getEntry(asset.cacheKey), 10.seconds).value.cacheFile
 
     file should exist

--- a/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
@@ -27,17 +27,71 @@ import com.waz.cache.CacheEntryData.CacheEntryDao
 import com.waz.content.Database
 import com.waz.model._
 import com.waz.threading.CancellableFuture.CancelException
+import com.waz.threading.Threading.Implicits.Background
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.crypto.AESUtils
+import com.waz.utils.events.Signal
 import com.waz.utils.{IoUtils, returning}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-class CacheService(context: Context, storage: Database, val cacheStorage: CacheStorage) {
+trait CacheService {
+  def createManagedFile(key: Option[AESKey] = None)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): CacheEntry
+  def createForFile(key: CacheKey = CacheKey(),
+                    mime: Mime = Mime.Unknown,
+                    name: Option[String] = None,
+                    cacheLocation: Option[File] = None,
+                    length: Option[Long] = None)
+                   (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+  def addData(key: CacheKey, data: Array[Byte])(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+  def addStream(key: CacheKey,
+                in: => InputStream,
+                mime: Mime = Mime.Unknown,
+                name: Option[String] = None,
+                cacheLocation: Option[File] = None,
+                length: Int = -1,
+                execution: ExecutionContext = Background)
+               (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
+  // TODO: This one is used only in tests. Get rid of it.
+  def addFile(key: CacheKey,
+              src: File,
+              moveFile: Boolean = false,
+              mime: Mime = Mime.Unknown,
+              name: Option[String] = None,
+              cacheLocation: Option[File] = None)
+             (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
+  def entryFile(path: File, fileId: Uid): File
+  def intCacheDir: File
+  def cacheDir: File
+  def remove(key: CacheKey): Future[Unit]
+  def remove(entry: CacheEntry): Future[Unit]
+  def insert(entry: CacheEntry): Future[CacheEntry]
+  def move(key: CacheKey,
+           entry: LocalData,
+           mime: Mime = Mime.Unknown,
+           name: Option[String] = None,
+           cacheLocation: Option[File] = None)
+          (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+  def getEntry(key: CacheKey): Future[Option[CacheEntry]]
+
+  def getOrElse(key: CacheKey, default: => Future[CacheEntry]) = getEntry(key) flatMap {
+    case Some(entry) => Future successful entry
+    case _ => default
+  }
+
+  def deleteExpired(): CancellableFuture[Unit]
+  def optSignal(cacheKey: CacheKey): Signal[Option[CacheEntry]]
+}
+
+class CacheServiceImpl(context: Context, storage: Database, cacheStorage: CacheStorage) extends CacheService {
   import CacheService._
   import Threading.Implicits.Background
+
+  private implicit val logTag: LogTag = logTagFor[CacheService]
 
   // create new cache entry for file, return the entry immediately
   def createManagedFile(key: Option[AESKey] = None)(implicit timeout: Expiration = CacheService.DefaultExpiryTime) = {
@@ -54,7 +108,7 @@ class CacheService(context: Context, storage: Database, val cacheStorage: CacheS
   def addData(key: CacheKey, data: Array[Byte])(implicit timeout: Expiration = CacheService.DefaultExpiryTime) =
     add(CacheEntryData(key, Some(data), timeout = timeout.timeout))
 
-  def addStream[A](key: CacheKey, in: => InputStream, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None, length: Int = -1, execution: ExecutionContext = Background)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry] =
+  def addStream(key: CacheKey, in: => InputStream, mime: Mime = Mime.Unknown, name: Option[String] = None, cacheLocation: Option[File] = None, length: Int = -1, execution: ExecutionContext = Background)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry] =
     if (length > 0 && length <= CacheService.DataThreshold) {
       Future(IoUtils.toByteArray(in))(execution).flatMap(addData(key, _))
     } else {
@@ -149,11 +203,6 @@ class CacheService(context: Context, storage: Database, val cacheStorage: CacheS
     }
   }
 
-  def getOrElse(key: CacheKey, default: => Future[CacheEntry]) = getEntry(key) flatMap {
-    case Some(entry) => Future successful entry
-    case _ => default
-  }
-
   def remove(key: CacheKey): Future[Unit] = cacheStorage.remove(key)
 
   def remove(entry: CacheEntry): Future[Unit] = {
@@ -173,13 +222,20 @@ class CacheService(context: Context, storage: Database, val cacheStorage: CacheS
     }.map { _ foreach (entry => entry.path foreach { path => entryFile(path, entry.fileId).delete() }) }
   }
 
-  private[cache] def entryFile(path: File, fileId: Uid) = CacheStorage.entryFile(path, fileId)
+  def entryFile(path: File, fileId: Uid) = CacheStorage.entryFile(path, fileId)
+
+  def insert(entry: CacheEntry) = cacheStorage.insert(entry.data).map(d => new CacheEntry(d, this))
+
+  def optSignal(cacheKey: CacheKey): Signal[Option[CacheEntry]] = cacheStorage.optSignal(cacheKey).map {
+    case Some(data) => Some(new CacheEntry(data, this))
+    case None => None
+  }
 }
 
 object CacheService {
-  private implicit val logTag: LogTag = logTagFor[CacheService]
 
-  def apply(context: Context, storage: Database): CacheService = new CacheService(context, storage, CacheStorage(storage, context))
+  def apply(context: Context, storage: Database, cacheStorage: CacheStorage) = new CacheServiceImpl(context, storage, cacheStorage)
+  def apply(context: Context, storage: Database): CacheService = CacheService(context, storage, CacheStorage(storage, context))
 
   val DataThreshold = 4 * 1024 // amount of data stored in db instead of a file
   val TemDataExpiryTime = 12.hours

--- a/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheService.scala
@@ -37,50 +37,62 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
+import com.waz.ZLog.ImplicitTag._
+
 trait CacheService {
   def createManagedFile(key: Option[AESKey] = None)(implicit timeout: Expiration = CacheService.DefaultExpiryTime): CacheEntry
-  def createForFile(key: CacheKey = CacheKey(),
-                    mime: Mime = Mime.Unknown,
-                    name: Option[String] = None,
-                    cacheLocation: Option[File] = None,
-                    length: Option[Long] = None)
-                   (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
+  def createForFile(key:              CacheKey        = CacheKey(),
+                    mime:             Mime            = Mime.Unknown,
+                    name:             Option[String]  = None,
+                    cacheLocation:    Option[File]    = None,
+                    length:           Option[Long]    = None)
+                   (implicit timeout: Expiration      = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
   def addData(key: CacheKey, data: Array[Byte])(implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
-  def addStream(key: CacheKey,
-                in: => InputStream,
-                mime: Mime = Mime.Unknown,
-                name: Option[String] = None,
-                cacheLocation: Option[File] = None,
-                length: Int = -1,
-                execution: ExecutionContext = Background)
-               (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
+  def addStream(key:              CacheKey,
+                in:               => InputStream,
+                mime:             Mime              = Mime.Unknown,
+                name:             Option[String]    = None,
+                cacheLocation:    Option[File]      = None,
+                length:           Int               = -1,
+                execution:        ExecutionContext  = Background)
+               (implicit timeout: Expiration        = CacheService.DefaultExpiryTime): Future[CacheEntry]
 
   // TODO: This one is used only in tests. Get rid of it.
-  def addFile(key: CacheKey,
-              src: File,
-              moveFile: Boolean = false,
-              mime: Mime = Mime.Unknown,
-              name: Option[String] = None,
-              cacheLocation: Option[File] = None)
-             (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+  def addFile(key:              CacheKey,
+              src:              File,
+              moveFile:         Boolean         = false,
+              mime:             Mime            = Mime.Unknown,
+              name:             Option[String]  = None,
+              cacheLocation:    Option[File]    = None)
+             (implicit timeout: Expiration      = CacheService.DefaultExpiryTime): Future[CacheEntry]
 
   def entryFile(path: File, fileId: Uid): File
+
   def intCacheDir: File
+
   def cacheDir: File
+
   def remove(key: CacheKey): Future[Unit]
+
   def remove(entry: CacheEntry): Future[Unit]
+
   def insert(entry: CacheEntry): Future[CacheEntry]
-  def move(key: CacheKey,
-           entry: LocalData,
-           mime: Mime = Mime.Unknown,
-           name: Option[String] = None,
-           cacheLocation: Option[File] = None)
-          (implicit timeout: Expiration = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
+  def move(key:              CacheKey,
+           entry:            LocalData,
+           mime:             Mime           = Mime.Unknown,
+           name:             Option[String] = None,
+           cacheLocation:    Option[File]   = None)
+          (implicit timeout: Expiration     = CacheService.DefaultExpiryTime): Future[CacheEntry]
+
   def getEntry(key: CacheKey): Future[Option[CacheEntry]]
 
   def getOrElse(key: CacheKey, default: => Future[CacheEntry]) = getEntry(key) flatMap {
     case Some(entry) => Future successful entry
-    case _ => default
+    case _           => default
   }
 
   def deleteExpired(): CancellableFuture[Unit]
@@ -90,8 +102,6 @@ trait CacheService {
 class CacheServiceImpl(context: Context, storage: Database, cacheStorage: CacheStorage) extends CacheService {
   import CacheService._
   import Threading.Implicits.Background
-
-  private implicit val logTag: LogTag = logTagFor[CacheService]
 
   // create new cache entry for file, return the entry immediately
   def createManagedFile(key: Option[AESKey] = None)(implicit timeout: Expiration = CacheService.DefaultExpiryTime) = {

--- a/zmessaging/src/main/scala/com/waz/cache/LocalData.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/LocalData.scala
@@ -106,7 +106,7 @@ class CacheEntry(val data: CacheEntryData, service: CacheService) extends LocalD
 
   override def toString: LogTag = s"CacheEntry($data)"
 
-  def updatedWithLength(len: Long)(implicit ec: ExecutionContext): Future[CacheEntry] = service.cacheStorage.insert(data.copy(length = Some(len))).map(d => new CacheEntry(d, service))
+  def updatedWithLength(len: Long)(implicit ec: ExecutionContext): Future[CacheEntry] = service.insert(new CacheEntry(data.copy(length = Some(len)), service))
 }
 
 object CacheEntry {

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -75,7 +75,7 @@ class GlobalModule(val context: Context, val backend: BackendConfig) { global =>
 
   lazy val globalClient = new ZNetClient(global, "", "")
   lazy val imageLoader = {
-    val client = new AssetClient(new ZNetClient(this, "", ""))
+    val client = AssetClient(new ZNetClient(this, "", ""))
     val loader: AssetLoader = AssetLoader(context, downloader, new AssetDownloader(client, cache), streamLoader, videoLoader, pcmAudioLoader, cache)
     new ImageLoader(context, cache, imageCache, bitmapDecoder, permissions, loader) { override def tag = "Global" }
   }

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -26,7 +26,7 @@ import com.waz.content.{DefaultMembersStorage, UsersStorage, ZmsDatabase, _}
 import com.waz.model._
 import com.waz.model.otr.ClientId
 import com.waz.service.EventScheduler.{Interleaved, Parallel, Sequential, Stage}
-import com.waz.service.assets.{AssetLoaderImpl, AssetService, RecordAndPlayService}
+import com.waz.service.assets.{AssetLoader, AssetService, RecordAndPlayService}
 import com.waz.service.call._
 import com.waz.service.conversation._
 import com.waz.service.downloads.AssetDownloader
@@ -179,7 +179,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   lazy val messagesContent: MessagesContentUpdater = wire[MessagesContentUpdater]
 
   lazy val assetDownloader = wire[AssetDownloader]
-  lazy val assetLoader     = wire[AssetLoaderImpl]
+  lazy val assetLoader     = wire[AssetLoader]
   lazy val imageLoader     = wire[ImageLoader]
 
   lazy val pushSignals                            = wire[PushServiceSignals]

--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetLoader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetLoader.scala
@@ -79,7 +79,7 @@ object AssetLoader {
   def apply(context: Context, downloader: DownloaderService, assetDownloader: Downloader[AssetRequest],
             streamDownloader: Downloader[AssetFromInputStream], videoDownloader: Downloader[VideoAsset],
             unencodedAudioDownloader: Downloader[UnencodedAudioAsset], cache: CacheService
-           ) =
+           ): AssetLoader =
     new AssetLoaderImpl(context, downloader, assetDownloader, streamDownloader, videoDownloader, unencodedAudioDownloader, cache)
 
 }

--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -24,6 +24,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.os.Environment
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Permission
 import com.waz.api.ProgressIndicator.State
 import com.waz.api.impl.ProgressIndicator.ProgressData
@@ -54,13 +55,32 @@ import scala.concurrent.Future.successful
 import scala.concurrent.duration._
 import scala.util.Random
 
-class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, cache: CacheService, context: Context,
+trait AssetService {
+  def assetSignal(id: AssetId): Signal[(AssetData, api.AssetStatus)]
+  def downloadProgress(id: AssetId): Signal[ProgressIndicator.ProgressData]
+  def cancelDownload(id: AssetId): Future[Unit]
+  def uploadProgress(id: AssetId): Signal[ProgressIndicator.ProgressData]
+  def cancelUpload(id: AssetId, msg: MessageId): Future[Unit]
+  def markUploadFailed(id: AssetId, status: AssetStatus.Syncable): Future[Any] // should be: Future[SyncId]
+  def addImageAsset(image: com.waz.api.ImageAsset, convId: RConvId, isSelf: Boolean): Future[AssetData]
+  def updateAssets(data: Seq[AssetData]): Future[Set[AssetData]]
+  def getLocalData(id: AssetId): CancellableFuture[Option[LocalData]]
+  def getAssetData(id: AssetId): Future[Option[AssetData]]
+  def addAsset(a: AssetForUpload, conv: RConvId): Future[AssetData]
+  def saveAssetToDownloads(id: AssetId): Future[Option[File]]
+  def saveAssetToDownloads(asset: AssetData): Future[Option[File]]
+  def updateAsset(id: AssetId, updater: AssetData => AssetData): Future[Option[AssetData]]
+  def getContentUri(id: AssetId): CancellableFuture[Option[URI]]
+  def mergeOrCreateAsset(newData: AssetData): Future[Option[AssetData]]
+  def removeAssets(ids: Iterable[AssetId]): Future[Unit]
+}
+
+class AssetServiceImpl(storage: AssetsStorage, generator: ImageAssetGenerator, cache: CacheService, context: Context,
     loader: AssetLoader, messages: MessagesStorage, downloader: DownloaderService, errors: ErrorsService,
     permissions: PermissionsService, streamLoader: Downloader[AssetFromInputStream], assetDownloader: AssetDownloader,
     metaService: MetaDataService, sync: SyncServiceHandle, media: GlobalRecordAndPlayService,
-    prefs: PreferenceService) {
+    prefs: PreferenceService) extends AssetService {
 
-  import AssetService._
   import com.waz.threading.Threading.Implicits.Background
   import com.waz.utils.events.EventContext.Implicits.global
 
@@ -91,9 +111,9 @@ class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, c
     case _ => Signal.empty[(AssetData, api.AssetStatus)]
   }
 
-  def assetStatusSignal(status: AssetStatus, cacheKey: CacheKey) = status match {
+  private def assetStatusSignal(status: AssetStatus, cacheKey: CacheKey) = status match {
     case UploadDone => //only if the asset is uploaded, check for a cache entry. Upload state takes precedence over download state
-      cache.cacheStorage.optSignal(cacheKey).map(_.isDefined) flatMap {
+      cache.optSignal(cacheKey).map(_.isDefined) flatMap {
         case true =>
           verbose(s"uploaded asset also has cache entry, must be downloaded. For key: $cacheKey")
           Signal const api.AssetStatus.DOWNLOAD_DONE
@@ -155,7 +175,9 @@ class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, c
   def updateAssets(data: Seq[AssetData]) =
     storage.updateOrCreateAll(data.map(d => d.id -> { (_: Option[AssetData]) => d })(collection.breakOut))
 
-  def getAssetData(id: AssetId): CancellableFuture[Option[LocalData]] =
+  def updateAsset(id: AssetId, updater: AssetData => AssetData): Future[Option[AssetData]] = storage.updateAsset(id, updater)
+
+  def getLocalData(id: AssetId): CancellableFuture[Option[LocalData]] =
     CancellableFuture lift storage.get(id) flatMap {
       case None => CancellableFuture successful None
       case Some(asset) => loader.getAssetData(asset.loadRequest) map { res =>
@@ -163,6 +185,12 @@ class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, c
         res
       }
     }
+
+  def getAssetData(id: AssetId): Future[Option[AssetData]] = storage.get(id)
+
+  def mergeOrCreateAsset(assetData: AssetData): Future[Option[AssetData]] = storage.mergeOrCreateAsset(assetData)
+
+  def removeAssets(ids: Iterable[AssetId]): Future[Unit] = storage.remove(ids)
 
   def addAsset(a: AssetForUpload, conv: RConvId): Future[AssetData] = {
     val uri = a match {
@@ -226,9 +254,9 @@ class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, c
     } yield returning(updated)(a => verbose(s"Generated preview and meta data for ${asset.id}"))
   }
 
-  def markDownloadFailed(id: AssetId) = storage.updateAsset(id, _.copy(status = DownloadFailed))
+  private def markDownloadFailed(id: AssetId) = storage.updateAsset(id, _.copy(status = DownloadFailed))
 
-  def markDownloadDone(id: AssetId) = storage.updateAsset(id, _.copy(status = UploadDone))
+  private def markDownloadDone(id: AssetId) = storage.updateAsset(id, _.copy(status = UploadDone))
 
   def getContentUri(id: AssetId): CancellableFuture[Option[URI]] =
     CancellableFuture.lift(storage.get(id)) .flatMap {
@@ -304,7 +332,13 @@ class AssetService(val storage: AssetsStorage, generator: ImageAssetGenerator, c
 }
 
 object AssetService {
-  private implicit val logTag: LogTag = logTagFor[AssetService]
+
+  def apply(storage: AssetsStorage, generator: ImageAssetGenerator, cache: CacheService, context: Context,
+    loader: AssetLoader, messages: MessagesStorage, downloader: DownloaderService, errors: ErrorsService,
+    permissions: PermissionsService, streamLoader: Downloader[AssetFromInputStream], assetDownloader: AssetDownloader,
+    metaService: MetaDataService, sync: SyncServiceHandle, media: GlobalRecordAndPlayService,
+    prefs: PreferenceService): AssetService =
+    new AssetServiceImpl(storage, generator, cache, context, loader, messages, downloader, errors, permissions, streamLoader, assetDownloader, metaService, sync, media, prefs)
 
   val SaveImageDirName = "Wire"
 

--- a/zmessaging/src/main/scala/com/waz/service/messages/DefaultMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/DefaultMessagesService.scala
@@ -22,7 +22,7 @@ import com.waz.api.Message.{Status, Type}
 import com.waz.api.{ErrorResponse, Message, Verification}
 import com.waz.content.{EditHistoryStorage, ReactionsStorage}
 import com.waz.model.AssetMetaData.Image.Tag.{Medium, Preview}
-import com.waz.model.AssetStatus.UploadCancelled
+import com.waz.model.AssetStatus.{UploadCancelled, UploadFailed}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.GenericContent._
 import com.waz.model.{IdentityChangedError, MessageId, _}
@@ -138,6 +138,9 @@ class DefaultMessagesService(selfUserId: UserId, val content: MessagesContentUpd
           val asset = a.copy(id = AssetId(id.str), remoteId = Some(rId), convId = convId, data = decryptAssetData(a, data))
           verbose(s"Received asset v2 image: $asset")
           assets.mergeOrCreateAsset(asset)
+        case (Asset(a, _), _) if a.status == UploadFailed && a.isImage =>
+          verbose(s"Received a message about a failed image upload: $id. Dropping")
+          Future successful None
         case (Asset(a, preview), _ ) =>
           val asset = a.copy(id = AssetId(id.str))
           verbose(s"Received asset without remote data - we will expect another update: $asset")

--- a/zmessaging/src/main/scala/com/waz/service/messages/DefaultMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/DefaultMessagesService.scala
@@ -100,8 +100,8 @@ class DefaultMessagesService(selfUserId: UserId, val content: MessagesContentUpd
 
     //ensure we always save the preview to the same id (GenericContent.Asset.unapply always creates new assets and previews))
     def saveAssetAndPreview(asset: AssetData, preview: Option[AssetData]) = {
-      assets.storage.mergeOrCreateAsset(asset).flatMap {
-        case Some(asset) => preview.fold(Future.successful(Option.empty[AssetData]))(p => assets.storage.mergeOrCreateAsset(p.copy(id = asset.previewId.getOrElse(p.id))))
+      assets.mergeOrCreateAsset(asset).flatMap {
+        case Some(asset) => preview.fold(Future.successful(Option.empty[AssetData]))(p => assets.mergeOrCreateAsset(p.copy(id = asset.previewId.getOrElse(p.id))))
         case _ => Future.successful(Option.empty[AssetData])
       }
     }
@@ -137,7 +137,7 @@ class DefaultMessagesService(selfUserId: UserId, val content: MessagesContentUpd
         case (ImageAsset(a@AssetData.IsImageWithTag(Medium)), Some(rId)) =>
           val asset = a.copy(id = AssetId(id.str), remoteId = Some(rId), convId = convId, data = decryptAssetData(a, data))
           verbose(s"Received asset v2 image: $asset")
-          assets.storage.mergeOrCreateAsset(asset)
+          assets.mergeOrCreateAsset(asset)
         case (Asset(a, preview), _ ) =>
           val asset = a.copy(id = AssetId(id.str))
           verbose(s"Received asset without remote data - we will expect another update: $asset")
@@ -169,7 +169,7 @@ class DefaultMessagesService(selfUserId: UserId, val content: MessagesContentUpd
     if (toRemove.isEmpty) Future.successful(())
     else for {
       _ <- Future.traverse(toRemove)(id => content.messagesStorage.remove(MessageId(id.str)))
-      _ <- assets.storage.remove(toRemove)
+      _ <- assets.removeAssets(toRemove)
     } yield ()
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -67,7 +67,8 @@ class OtrSyncHandlerImpl(client: OtrClient, msgClient: MessagesClient, assetClie
     service.clients.getSelfClient flatMap {
       case Some(otrClient) =>
         postEncryptedMessage(convId, message, recipients = recipients) {
-          case (content, retry) if content.estimatedSize < MaxContentSize => msgClient.postMessage(remoteId, OtrMessage(otrClient.id, content, nativePush = nativePush), ignoreMissing(retry), recipients)
+          case (content, retry) if content.estimatedSize < MaxContentSize =>
+            msgClient.postMessage(remoteId, OtrMessage(otrClient.id, content, nativePush = nativePush), ignoreMissing(retry), recipients)
           case (content, retry) =>
             verbose(s"Message content too big, will post as External. Estimated size: ${content.estimatedSize}")
             postExternalMessage(otrClient.id, convId, remoteId, message, recipients, nativePush)

--- a/zmessaging/src/main/scala/com/waz/znet/ZNetClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/ZNetClient.scala
@@ -92,16 +92,19 @@ class ZNetClient(credentials: CredentialsHandler,
     withErrorHandling(name, r) { case Response(SuccessHttpStatus(), _, _) => () } (ec)
 
   def withErrorHandling[A, T](name: String, r: Request[A])(pf: PartialFunction[Response, T])(implicit ec: ExecutionContext): ErrorOrResponse[T] =
-    apply(r) .map (pf .andThen (Right(_)) .orElse(errorHandling(name))) (ec)
+    apply(r).map(pf.andThen(Right(_)).orElse(errorHandling(name)))(ec)
+
 
   def chainedWithErrorHandling[A, T](name: String, r: Request[A])(pf: PartialFunction[Response, ErrorOrResponse[T]])(implicit ec: ExecutionContext): ErrorOrResponse[T] =
-    apply(r) .flatMap (pf .orElse (errorHandling(name) andThen CancellableFuture.successful)) (ec)
+    apply(r).flatMap(pf.orElse(errorHandling(name) andThen CancellableFuture.successful))(ec)
+
 
   def withFutureErrorHandling[A, T](name: String, r: Request[A])(pf: PartialFunction[Response, T])(implicit ec: ExecutionContext): ErrorOr[T] =
-    apply(r).future .map (pf .andThen (Right(_)) .orElse (errorHandling(name))) .recover { case NonFatal(e) => Left(ErrorResponse.internalError("future failed: " + e.getMessage)) }
+    apply(r).future.map(pf.andThen(Right(_)).orElse(errorHandling(name))).recover { case NonFatal(e) => Left(ErrorResponse.internalError("future failed: " + e.getMessage)) }
+
 
   def chainedFutureWithErrorHandling[A, T](name: String, r: Request[A])(pf: PartialFunction[Response, ErrorOr[T]])(implicit ec: ExecutionContext): ErrorOr[T] =
-    apply(r).future .flatMap (pf .orElse (errorHandling(name) andThen Future.successful)) (ec) .recover { case NonFatal(e) => Left(ErrorResponse.internalError("future failed: " + e.getMessage)) }
+    apply(r).future.flatMap(pf.orElse(errorHandling(name) andThen Future.successful))(ec).recover { case NonFatal(e) => Left(ErrorResponse.internalError("future failed: " + e.getMessage)) }
 
   def close(): Future[Unit] = Future {
     closed = true
@@ -141,7 +144,7 @@ class ZNetClient(credentials: CredentialsHandler,
             retry(handle, status.status == Status.RateLimiting)
           case Success(response)  => done(handle, response)
           case Failure(exc: CancelException) => done(handle, Response(Cancelled))
-          case Failure(exc)        => done(handle, Response(Response.InternalError(exc.getMessage, Some(exc))))
+          case Failure(exc) => done(handle, Response(Response.InternalError(exc.getMessage, Some(exc))))
         }
       }
     } else {
@@ -245,10 +248,10 @@ object ZNetClient {
     case Response(ConnectionError(msg), _, _) =>
       Left(ErrorResponse(ErrorResponse.ConnectionErrorCode, s"request '$name' connection failed: $msg", "connection-error"))
     case Response(ErrorStatus(), ErrorResponse(code, msg, label), _) =>
-      warn(s"Error response to $name query: ${ErrorResponse(code, msg, label)}")
+      warn(s"$name response to $name query: ${ErrorResponse(code, msg, label)}")
       Left(ErrorResponse(code, msg, label))
     case resp @ Response(ErrorStatus(), body, headers) =>
-      warn(s"$name query failed: $resp, body: $body, headers: $headers")
+      warn(s"Error $name query failed: $resp, body: $body, headers: $headers")
       Left(ErrorResponse(resp.status.status, resp.toString, "internal-error"))
     case resp @ Response(_, _, _) =>
       error(s"Unexpected response to $name query: $resp")


### PR DESCRIPTION
The current version of AN-5163 fix prevents the receiver from displaying a dark container and the sender from displaying an invalid "Delivered" footer. However, the sender has to tap "Retry" in order to retry sending. It would be nice to have automatic retries.