### PR TITLE
Fix BitmapSignal to use preview image when possible.

### DIFF
--- a/tests/integration/src/test/scala/com/waz/sync/client/AssetClientSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/sync/client/AssetClientSpec.scala
@@ -141,7 +141,7 @@ class AssetClientSpec extends FeatureSpec with Matchers with ProvisionedApiSpec 
     scenario("Load asset using BitmapSignal") {
       val data = AssetData(mime = Mime.Image.Png, sizeInBytes = image.length, metaData = Some(AssetMetaData.Image(Dim2(480, 492), Medium))).copyWithRemoteData(RemoteData(Some(asset.rId), asset.token))
 
-      val signal = BitmapSignal(data, BitmapRequest.Regular(600), zmessaging.imageLoader, zmessaging.imageCache)
+      val signal = BitmapSignal(data, BitmapRequest.Regular(600), zmessaging.imageLoader)
       var results = Seq.empty[BitmapResult]
       signal { res =>
         results = results :+ res

--- a/tests/unit/src/test/scala/com/waz/service/images/BitmapSignalSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/images/BitmapSignalSpec.scala
@@ -18,26 +18,24 @@
 package com.waz.service.images
 
 import android.graphics.{Bitmap => ABitmap}
-import android.support.v4.content.ContextCompat
 import com.waz.RobolectricUtils
-import com.waz.utils.wrappers.{Bitmap, URI}
 import com.waz.bitmap.gif.{Gif, GifReader}
 import com.waz.cache.LocalData
 import com.waz.model.AssetMetaData.Image
 import com.waz.model.AssetMetaData.Image.Tag.Medium
 import com.waz.model._
-import com.waz.service.assets.AssetService.BitmapResult.BitmapLoaded
 import com.waz.service.assets.AssetService.BitmapResult
+import com.waz.service.assets.AssetService.BitmapResult.BitmapLoaded
 import com.waz.threading.CancellableFuture
 import com.waz.ui.MemoryImageCache
 import com.waz.ui.MemoryImageCache.BitmapRequest
 import com.waz.ui.MemoryImageCache.BitmapRequest.Regular
+import com.waz.utils.wrappers.{Bitmap, URI}
 import org.robolectric.annotation.Config
 import org.scalatest.{BeforeAndAfter, FeatureSpec, Matchers, RobolectricTests}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.Try
 
 @Config(manifest = "/src/main/AndroidManifest.xml", reportSdk = 17)
 class BitmapSignalSpec extends FeatureSpec with Matchers with BeforeAndAfter with RobolectricTests with RobolectricUtils { test =>
@@ -50,8 +48,9 @@ class BitmapSignalSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   var gifResult: AssetData => Option[Gif] = { _ => None }
   var rawDataResult: AssetData => Option[LocalData] = { _ => None }
   var cachedDataResult: AssetData => Option[LocalData] = { _ => None }
+  var assetSource: AssetId => Option[AssetData] = { _ => None }
   var loadDelay: AssetData => FiniteDuration = { _ => Duration.Zero }
-  
+
   def mockBitmap(im: AssetData) = Some(Bitmap(ABitmap.createBitmap(im.dimensions.width, im.dimensions.height, ABitmap.Config.ARGB_8888)))
   def mockDelay(preview: FiniteDuration = Duration.Zero, medium: FiniteDuration = Duration.Zero)(im: AssetData) = im.tag match {
     case Medium => medium
@@ -81,70 +80,63 @@ class BitmapSignalSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
 
   class SignalListener(asset: AssetData, req: BitmapRequest) {
     var results = Seq.empty[BitmapResult]
-    val signal = new AssetBitmapSignal(asset, req, loader, imageCache)
+    val signal = new AssetBitmapSignal(asset, req, loader, { id => Future.successful(assetSource(id)) })
     val obs = signal { result => results = results :+ result }
     
     def medium = results.collectFirst { case BitmapLoaded(b, _) => b }
   }
 
   before {
-    Try { ContextCompat.getDrawable(testContext, android.R.color.transparent) } // force resource loading
     cachedBitmapResult = { _ => None }
     cachedGifResult = { _ => None }
     gifResult = { _ => None }
     bitmapResult = mockBitmap
     rawDataResult = { _ => None }
     cachedDataResult = { _ => None }
+    assetSource = { _ => None }
     loadDelay = mockDelay(medium = 500.millis)
   }
 
-  def checkLoaded(req: BitmapRequest, preview: Option[(Int, Int)] = None, full: Option[(Int, Int)] = None, delay: FiniteDuration = Duration.Zero)(data: AssetData) = {
+  def image(w: Int, h: Int, mime: Mime = Mime.Image.Png, preview: Option[AssetId] = None) =
+    AssetData(mime = mime, metaData = Some(AssetMetaData.Image(Dim2(w, h))), previewId = preview)
+
+  def checkLoaded(req: BitmapRequest, result: Option[(Int, Int)] = None, delay: FiniteDuration = Duration.Zero)(data: AssetData) = {
     val listener = new SignalListener(data, req)
     awaitUi(delay)
     withDelay {
       withClue(listener.results.mkString(", ")) {
-        listener.medium.map(b => (b.getWidth, b.getHeight)) shouldEqual full
+        listener.medium.map(b => (b.getWidth, b.getHeight)) shouldEqual result
       }
     }
   }
 
   feature("Wire asset loading") {
 
-    scenario("Load asset with invalid metadata") {
-      checkLoaded(Regular(500), Some((500, 500)), Some((996, 660)))(AssetData(metaData = Some(AssetMetaData.Image(Dim2(996, 660), Medium))))
-    }
-
-    scenario("Request small image when only preview is available") {
-      fail()
+    scenario("Request same size image without a preview") {
       // result should be reported as full image
-//      checkLoaded(Regular(64), None, Some((64,64)))(image("preview", 64, 64, 512, 512))
-//
-//      cachedBitmapResult = mockBitmap // result should be the same when loaded from cache
-//      checkLoaded(Regular(64), None, Some((64,64)))(image("preview", 64, 64, 512, 512))
+      checkLoaded(Regular(64), Some((64,64)))(image(64, 64))
+
+      cachedBitmapResult = mockBitmap // result should be the same when loaded from cache
+      checkLoaded(Regular(64), Some((64,64)))(image(64, 64))
     }
 
-    scenario("Load big image when only preview is available") {
-      fail()
-//      val data = AssetData(metaData = Some(AssetMetaData.Image(Dim2(64, 64), "preview")))
-//      checkLoaded(Regular(500), Some((500,500)), None)(image("preview", 64, 64, 512, 512))
-//
-//      cachedBitmapResult = mockBitmap // result should be the same when loaded from cache
-//      checkLoaded(Regular(500), Some((500,500)), None)(image("preview", 64, 64, 512, 512))
+    scenario("Load big size with small source image - no scaling") {
+      checkLoaded(Regular(500), Some((64,64)))(image(64, 64))
+
+      cachedBitmapResult = mockBitmap // result should be the same when loaded from cache
+      checkLoaded(Regular(500), Some((64,64)))(image(64, 64))
     }
 
-    scenario("Load image when both versions are available") {
-      fail()
-//      checkLoaded(Regular(500), Some((500,500)), Some((512, 512)))(image("preview", 64, 64, 512, 512), image("medium", 512, 512, 512, 512))
+    scenario("Load image from preview when small image is requested") {
+      val preview = image(64, 64)
+      assetSource = { _ => Some(preview) }
+      checkLoaded(Regular(65), Some((64, 64)))(image(512, 512, preview = Some(preview.id)))
     }
 
-    scenario("Only full image available") {
-      checkLoaded(Regular(500), None, Some((512, 512)))(AssetData(metaData = Some(AssetMetaData.Image(Dim2(512, 512), Medium))))
-    }
-
-    scenario("Loading full image, then preview") {
-      fail()
-//      loadDelay = mockDelay(preview = 500.millis)
-//      checkLoaded(Regular(500), None, Some((512, 512)), 1.second)(image("preview", 64, 64, 512, 512), image("medium", 512, 512, 512, 512))
+    scenario("Load full image when requested is bigger than preview") {
+      val preview = image(32, 32)
+      assetSource = { _ => Some(preview) }
+      checkLoaded(Regular(65), Some((512, 512)))(image(512, 512, preview = Some(preview.id)))
     }
   }
 
@@ -153,7 +145,7 @@ class BitmapSignalSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
     def gif = GifReader(gifStream).get
 
     scenario("Load gif from local source") {
-      lazy val asset = AssetData(AssetId(), metaData = Some(Image(Dim2(0, 0), Medium)), source = Some(URI.parse("content://test")), convId = Some(RConvId()))
+      lazy val asset = AssetData(AssetId(), mime = Mime.Image.Gif, metaData = Some(Image(Dim2(0, 0), Medium)), source = Some(URI.parse("content://test")), convId = Some(RConvId()))
       gifResult = { _ => Some(gif) }
       rawDataResult = { _ => Some(LocalData(gifStream, -1))}
       val listener = new SignalListener(asset, Regular(200))
@@ -162,21 +154,6 @@ class BitmapSignalSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
           listener.results.size should be > 10 // animated gif will produce several frames
         }
       }
-    }
-
-    scenario("Load local gif with preview") {
-      fail()
-//      lazy val asset = ImageAssetData(AssetId(), RConvId(), Seq(image("preview", 64, 64, 512, 512), ImageData("full", Mime.Unknown, 512, 512, 512, 512, 0, url = Some("content://test"))))
-//      gifResult = { _ => Some(gif) }
-//      rawDataResult = { _ => Some(LocalData(gifStream, -1))}
-//      loadDelay = { data => if (data.tag == "preview") Duration.Zero else 250.millis }
-//      val listener = new SignalListener(asset, Regular(200))
-//      withDelay {
-//        withClue(listener.results.mkString(", ")) {
-//          listener.preview.map(b => (b.getWidth, b.getHeight)) shouldEqual Some((200, 200)) // results should include preview
-//          listener.results.size should be > 10 // animated gif will produce several frames
-//        }
-//      }
     }
   }
 }

--- a/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/images/ImageLoaderSpec.scala
@@ -103,9 +103,9 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
     entry
   }
 
-  class SignalListener(req: BitmapRequest, assetData: AssetData =assetData) {
+  class SignalListener(req: BitmapRequest, assetData: AssetData = assetData) {
     var results = Seq.empty[BitmapResult]
-    val signal = new AssetBitmapSignal(assetData, req, service, service.memoryCache)
+    val signal = new AssetBitmapSignal(assetData, req, service, BitmapSignal.EmptyAssetStore)
     val obs = signal { result => results = results :+ result }
   }
 
@@ -216,7 +216,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       prepareDownload()
 
       var results = Seq.empty[BitmapResult]
-      val signal = new AssetBitmapSignal(assetData, BitmapRequest.Regular(300), service, service.memoryCache)
+      val signal = new AssetBitmapSignal(assetData, BitmapRequest.Regular(300), service, BitmapSignal.EmptyAssetStore)
       val obs = signal { result => results = results :+ result }
       withDelay(results.count(_ != BitmapResult.Empty) shouldEqual 1)
       obs.destroy()
@@ -227,7 +227,6 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
         results.filter(_ != BitmapResult.Empty) should have size 2
       }
     }
-
   }
 
   feature("Gif downloading") {
@@ -268,7 +267,7 @@ class ImageLoaderSpec extends FeatureSpec with Matchers with BeforeAndAfter with
       val asset = AssetData(metaData = Some(Image(Dim2(0, 0), Medium)), sizeInBytes = bytes.length, remoteId = Some(RAssetId()), data = Some(bytes), convId = Some(RConvId()))
 
       val bmp = Await.result(service.loadBitmap(asset, Regular(100)), 5.seconds)
-      //      TODO: fix ShadowIOBitmap to produce corrent image - this works on device
+      //      TODO: fix ShadowIOBitmap to produce correct image - this works on device
       //      bmp.getWidth shouldEqual 600
       //      bmp.getHeight shouldEqual 450
     }

--- a/zmessaging/src/main/scala/com/waz/api/impl/ImageAsset.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ImageAsset.scala
@@ -70,7 +70,7 @@ class ImageAsset(val id: AssetId)(implicit ui: UiModule) extends com.waz.api.Ima
   override def getHeight: Int = data.dimensions.height
 
   protected def getBitmap(req: BitmapRequest, callback: BitmapCallback): LoadHandle =
-    BitmapLoadHandle({ zms => BitmapSignal(data, req, zms.imageLoader, zms.imageCache) }, callback)
+    BitmapLoadHandle({ zms => BitmapSignal(data, req, zms.imageLoader, zms.assetsStorage.get) }, callback)
 
 
   override def isEmpty: Boolean = false
@@ -103,8 +103,8 @@ class LocalImageAsset(img: AssetData)(implicit ui: UiModule) extends ImageAsset(
 
   override def getBitmap(req: BitmapRequest, callback: BitmapCallback): LoadHandle = {
     new BitmapLoadHandle({
-      case None => BitmapSignal(data, req, ui.globalImageLoader, ui.imageCache)
-      case Some(zms) => BitmapSignal(data, req, zms.imageLoader, ui.imageCache)
+      case None => BitmapSignal(data, req, ui.globalImageLoader)
+      case Some(zms) => BitmapSignal(data, req, zms.imageLoader, zms.assetsStorage.get)
     }, callback)
   }
 
@@ -132,8 +132,8 @@ class LocalImageAssetWithPreview(preview: Option[AssetData], medium: AssetData)(
 
   override def getBitmap(req: BitmapRequest, callback: BitmapCallback): LoadHandle = req match {
       case Single(_, _) => new BitmapLoadHandle ({
-        case Some(zms) => BitmapSignal(preview.getOrElse(medium), req, zms.imageLoader, ui.imageCache)
-        case _ => BitmapSignal(preview.getOrElse(medium), req, ui.globalImageLoader, ui.imageCache)
+        case Some(zms) => BitmapSignal(preview.getOrElse(medium), req, zms.imageLoader, zms.assetsStorage.get)
+        case _ => BitmapSignal(preview.getOrElse(medium), req, ui.globalImageLoader)
       }, callback)
       case _ => super.getBitmap(req, callback)
     }
@@ -183,7 +183,7 @@ class LocalBitmapAsset(bitmap: Bitmap, orientation: Int = ExifInterface.ORIENTAT
 
   override def getBitmap(req: BitmapRequest, callback: BitmapCallback): LoadHandle = {
     verbose(s"get bitmap")
-    new BitmapLoadHandle(_ => Signal.future(imageData) flatMap { _ => BitmapSignal(data, req, ui.globalImageLoader, ui.imageCache) }, callback)
+    new BitmapLoadHandle(_ => Signal.future(imageData) flatMap { _ => BitmapSignal(data, req, ui.globalImageLoader) }, callback)
   }
 
   override def saveImageToGallery(callback: SaveCallback): Unit =


### PR DESCRIPTION
Removed code for old handling of preview images, we no londer report previews.
Added check for requested image size and preview availability.
When requested image is small and preview is big enough we want to only load preview image instead of full one.
This is especially usefull for chathead images, where smallProfile version is big enough in most cases.
Loading smaller previews is much faster and uses less memory, full images were exhausting memory image cache (causing even worse performance).