### PR TITLE
AsyncClient: Android-free tests and Request refactoring

### DIFF
--- a/actors/android_app/src/main/scala/com/waz/androidactors/RemoteActorService.scala
+++ b/actors/android_app/src/main/scala/com/waz/androidactors/RemoteActorService.scala
@@ -99,7 +99,7 @@ class RemoteActorService(context: Context) {
       dbs.listFiles() foreach { db =>
         println(s"deleting db: $db, res:" + db.delete())
       }
-      currentActor ! actorSystem.actorOf(RemoteProcessActor.props(context, name, None, backend, TestClientWrapper), name.replaceAll("\\s+", "_"))
+      currentActor ! actorSystem.actorOf(RemoteProcessActor.props(context, name, None, backend, TestClientWrapper()), name.replaceAll("\\s+", "_"))
     }
   }
 

--- a/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
+++ b/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
@@ -31,7 +31,7 @@ import com.waz.api._
 import com.waz.api.impl.{AccentColor, DoNothingAndProceed, ZMessagingApi}
 import com.waz.content.GlobalPreferences.CallingV3Key
 import com.waz.content.Preferences.PrefKey
-import com.waz.content.{Database, GlobalDatabase, GlobalPreferences}
+import com.waz.content.{Database, GlobalDatabase}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.VoiceChannelData.ChannelState
@@ -56,14 +56,14 @@ object DeviceActor {
   def props(deviceName: String,
             application: Context,
             backend: BackendConfig = BackendConfig.StagingBackend,
-            wrapper: ClientWrapper) =
+            wrapper: Future[ClientWrapper]) =
   Props(new DeviceActor(deviceName, application, backend, wrapper)).withDispatcher("ui-dispatcher")
 }
 
 class DeviceActor(val deviceName: String,
                   val application: Context,
                   backend: BackendConfig = BackendConfig.StagingBackend,
-                  wrapper: ClientWrapper) extends Actor with ActorLogging {
+                  wrapper: Future[ClientWrapper]) extends Actor with ActorLogging {
 
   import ActorMessage._
 
@@ -78,7 +78,7 @@ class DeviceActor(val deviceName: String,
   lazy val globalModule = new GlobalModule(application, backend) { global =>
     ZMessaging.currentGlobal = this
     override lazy val storage: Database = new GlobalDatabase(application, Random.nextInt().toHexString)
-    override lazy val clientWrapper: ClientWrapper = wrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = wrapper
 
     override lazy val metadata: MetaDataService = new MetaDataService(context) {
       override val cryptoBoxDirName: String = "otr_" + Random.nextInt().toHexString

--- a/actors/base/src/main/scala/com/waz/provision/RemoteProcessActor.scala
+++ b/actors/base/src/main/scala/com/waz/provision/RemoteProcessActor.scala
@@ -24,13 +24,14 @@ import com.waz.service.BackendConfig
 import com.waz.znet.ClientWrapper
 import org.threeten.bp.Instant.now
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class RemoteProcessActor(application: Context,
                          processName: String,
                          coordinator: Option[ActorRef],
                          backend: BackendConfig = BackendConfig.StagingBackend,
-                         wrapper: ClientWrapper) extends FSM[RemoteProcessActor.State, Option[ActorRef]] with ActorLogging {
+                         wrapper: Future[ClientWrapper]) extends FSM[RemoteProcessActor.State, Option[ActorRef]] with ActorLogging {
 
   import ActorMessage._
   import RemoteProcessActor._
@@ -85,7 +86,7 @@ object RemoteProcessActor {
             processName: String,
             mainCoordinatorRef: Option[ActorRef],
             backend: BackendConfig = BackendConfig.StagingBackend,
-            wrapper: ClientWrapper) =
+            wrapper: Future[ClientWrapper]) =
     Props(new RemoteProcessActor(context, processName, mainCoordinatorRef, backend, wrapper))
 
   trait State

--- a/actors/base/src/main/scala/com/waz/znet/TestClientWrapper.scala
+++ b/actors/base/src/main/scala/com/waz/znet/TestClientWrapper.scala
@@ -23,6 +23,7 @@ import javax.net.ssl._
 import com.koushikdutta.async.http.AsyncHttpClientMiddleware.GetSocketData
 import com.koushikdutta.async.http.spdy.SpdyMiddleware
 import com.koushikdutta.async.http.{SSLEngineSNIConfigurator, _}
+import com.koushikdutta.async._
 import com.waz.threading.Threading
 import com.waz.utils._
 
@@ -32,10 +33,10 @@ import scala.concurrent.Future
  * Replaces ssl context, trust managers and verifiers for Robolectric testing.
  * Default ssl implementation in AndroidAsync doesn't work correctly when run in RoboTests, so we need to hack it a bit.
   */
-object TestClientWrapper extends ClientWrapper {
+object TestClientWrapper {
   import Threading.Implicits.Background
 
-  def apply(client: AsyncHttpClient): Future[AsyncHttpClient] = Future {
+  def apply(client: AsyncHttpClient): Future[ClientWrapper] = Future {
 
     def prepareSSlMiddleware() = new SpdyMiddleware(client) {
 
@@ -68,7 +69,9 @@ object TestClientWrapper extends ClientWrapper {
     client.insertMiddleware(prepareSSlMiddleware())
     client.insertMiddleware(new HttpTransportMiddleware)
 
-    client
+    new ClientWrapperImpl(client)
   }
+
+  def apply(): Future[ClientWrapper] = apply(new AsyncHttpClient(new AsyncServer))
 }
 

--- a/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
@@ -55,7 +55,7 @@ class CreateConversationSpec extends FeatureSpec with Matchers with OptionValues
 
   lazy val allUserIds = Seq("auto1", "auto2", "auto3", "auto4", "auto5", "auto6") map provisionedUserId
 
-  lazy val auto6 = new ConnectionsClient(new ZNetClient(provisionedEmail("auto6"), "auto6_pass", new AsyncClient(wrapper = TestClientWrapper)))
+  lazy val auto6 = new ConnectionsClient(new ZNetClient(provisionedEmail("auto6"), "auto6_pass", new AsyncClient(wrapper = TestClientWrapper())))
 
   lazy val auto4Id = Await.result(auto4.zmessaging.currentValue.flatten.get.users.getSelfUser, 15.seconds).get.id
 

--- a/tests/integration/src/test/scala/com/waz/provision/InternalBackendClient.scala
+++ b/tests/integration/src/test/scala/com/waz/provision/InternalBackendClient.scala
@@ -39,9 +39,17 @@ class InternalBackendClient(client: AsyncClient, backend: BackendConfig) {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val (user, password) = InternalCredentials.backend(backend)
+  private val baseUri = Some(URI.parse(backend.baseUrl))
 
   def activateEmail(email: EmailAddress): ErrorOrResponse[Unit] = {
-    client(URI.parse(Request.query(backend.baseUrl + "/i/users/activation-code", "email" -> email.str)), headers = basicAuthHeader, timeout = AsyncClient.DefaultTimeout) flatMap {
+    val request = Request.Get(
+      Request.query("/i/users/activation-code", "email" -> email.str),
+      baseUri = baseUri,
+      headers = basicAuthHeader,
+      timeout = AsyncClient.DefaultTimeout
+    )
+
+    client(request) flatMap {
       case Response(SuccessHttpStatus(), CodeExtractor(code), headers) => verifyEmail(email, ConfirmationCode(code))
       case Response(_, ErrorResponse(status, message, label), _) => CancellableFuture.successful(Left(ErrorResponse(status, message, label)))
       case other => CancellableFuture.successful(Left(ErrorResponse(other.status.status, other.toString, "unknown")))
@@ -51,26 +59,44 @@ class InternalBackendClient(client: AsyncClient, backend: BackendConfig) {
   def getPhoneActivationCode(phone: PhoneNumber): ErrorOrResponse[ConfirmationCode] = getPhoneConfirmationCode(phone, "activation")
   def getPhoneLoginCode(phone: PhoneNumber): ErrorOrResponse[ConfirmationCode] = getPhoneConfirmationCode(phone, "login")
 
-  private def verifyEmail(email: EmailAddress, code: ConfirmationCode): ErrorOrResponse[Unit] =
-    client(URI.parse(backend.baseUrl + "/activate"), Request.PostMethod, verifyRequestBody(email, code), timeout = AsyncClient.DefaultTimeout) map {
+  private def verifyEmail(email: EmailAddress, code: ConfirmationCode): ErrorOrResponse[Unit] = {
+    val request = Request.Post("/activate", data = verifyRequestBody(email, code), baseUri = baseUri, timeout = AsyncClient.DefaultTimeout)
+    client(request) map {
       case Response(SuccessHttpStatus(), _, _) => Right(())
       case Response(_, ErrorResponse(status, msg, label), _) => Left(ErrorResponse(status, msg, label))
       case other => Left(ErrorResponse(other.status.status, other.toString, "unknown"))
     }
+  }
 
-  private def getPhoneConfirmationCode(phone: PhoneNumber, kindOfCode: String): ErrorOrResponse[ConfirmationCode] =
-    client(URI.parse(Request.query(backend.baseUrl + s"/i/users/$kindOfCode-code", "phone" -> phone.str)), headers = basicAuthHeader, timeout = AsyncClient.DefaultTimeout) map {
+  private def getPhoneConfirmationCode(phone: PhoneNumber, kindOfCode: String): ErrorOrResponse[ConfirmationCode] = {
+    val request = Request.Get(
+      Request.query(s"/i/users/$kindOfCode-code", "phone" -> phone.str),
+      baseUri = baseUri,
+      headers = basicAuthHeader,
+      timeout = AsyncClient.DefaultTimeout
+    )
+
+    client(request) map {
       case Response(SuccessHttpStatus(), CodeExtractor(code), headers) => Right(ConfirmationCode(code))
       case Response(_, ErrorResponse(status, message, label), _) => Left(ErrorResponse(status, message, label))
       case other => Left(ErrorResponse(other.status.status, other.toString, "unknown"))
     }
+  }
 
-  def getInvitationToken(inviter: UserId, invitation: InvitationId): ErrorOrResponse[PersonalInvitationToken] =
-    client(URI.parse(Request.query(s"${backend.baseUrl}/i/users/invitation-code", "inviter" -> inviter.str, "invitation_id" -> invitation.str)), headers = basicAuthHeader, timeout = AsyncClient.DefaultTimeout) map {
-      case Response(SuccessHttpStatus(), CodeExtractor(code), headers) => Right(PersonalInvitationToken(code))
+  def getInvitationToken(inviter: UserId, invitation: InvitationId): ErrorOrResponse[PersonalInvitationToken] = {
+    val request = Request.Get(
+      Request.query("/i/users/invitation-code", "inviter" -> inviter.str, "invitation_id" -> invitation.str),
+      baseUri = baseUri,
+      headers = basicAuthHeader,
+      timeout = AsyncClient.DefaultTimeout
+    )
+
+    client(request) map {
+      case Response(SuccessHttpStatus(), CodeExtractor(code), _) => Right(PersonalInvitationToken(code))
       case Response(_, ErrorResponse(status, message, label), _) => Left(ErrorResponse(status, message, label))
       case other => Left(ErrorResponse(other.status.status, other.toString, "unknown"))
     }
+  }
 
   private def basicAuthHeader: String Map String = {
     val auth = user + ":" + password

--- a/tests/integration/src/test/scala/com/waz/service/RemoteZmsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/RemoteZmsSpec.scala
@@ -17,10 +17,9 @@
  */
 package com.waz.service
 
-import android.content.{Context, SharedPreferences}
 import com.waz.api._
 import com.waz.api.impl.{EmailCredentials, ZMessagingApi}
-import com.waz.content.{Database, GlobalDatabase, GlobalPreferences}
+import com.waz.content.{Database, GlobalDatabase}
 import com.waz.model.{MessageContent => _, _}
 import com.waz.testutils.Implicits._
 import com.waz.threading.Threading
@@ -75,7 +74,7 @@ class RemoteZms(ui: UiModule) extends ZMessagingApi()(ui) {
 trait RemoteZmsSpec extends RobolectricTests with BeforeAndAfterAll { suite: Suite with ApiSpec =>
 
   def globalModule(dataTag: String = Random.nextInt().toHexString): GlobalModule =  new GlobalModule(context, testBackend) { global =>
-    override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
     override lazy val client: AsyncClient = testClient
     override lazy val timeouts: Timeouts = suite.timeouts
 

--- a/tests/integration/src/test/scala/com/waz/sync/client/OpenGraphClientSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/sync/client/OpenGraphClientSpec.scala
@@ -41,7 +41,7 @@ class OpenGraphClientSpec extends FeatureSpec with Matchers with ProvisionedApiS
   scenario("Fetch header of large website, should stop download early") {
     lazy val LargeWebsiteLink = URI.parse("http://unicode.org/emoji/charts/full-emoji-list.html")
 
-    val resp = zmessaging.zNetClient(new Request[Unit](absoluteUri = Some(LargeWebsiteLink), requiresAuthentication = false, decoder = Some(OpenGraphClient.ResponseDecoder))).await()
+    val resp = zmessaging.zNetClient(new Request[Unit](baseUri = Some(LargeWebsiteLink), requiresAuthentication = false, decoder = Some(OpenGraphClient.ResponseDecoder))).await()
 
     resp should beMatching({
       case Response(SuccessStatus(), StringResponse(html), _) if html.length < 10 * 1024 => info(s"response size: ${html.length}")

--- a/tests/integration/src/test/scala/com/waz/users/AddressBookSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/users/AddressBookSpec.scala
@@ -146,7 +146,7 @@ class AddressBookSpec extends FeatureSpec with Matchers with BeforeAndAfter with
   val uuids = (1 to 8) map (_ => randomUUID())
   val emails = uuids map (id => EmailAddress(s"android.test+$id@wire.com"))
 
-  def newClient = new RegistrationClient(new AsyncClient(wrapper = TestClientWrapper), testBackend)
+  def newClient = new RegistrationClient(new AsyncClient(wrapper = TestClientWrapper()), testBackend)
 
   override lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
     override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(clientId, user) {

--- a/tests/integration/src/test/scala/com/waz/users/RegistrationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/users/RegistrationSpec.scala
@@ -52,7 +52,7 @@ class RegistrationSpec extends FeatureSpec with Matchers with GivenWhenThen with
 
   lazy val userId = AccountId()
 
-  lazy val client = new RegistrationClient(new AsyncClient(wrapper = TestClientWrapper), BackendConfig.StagingBackend)
+  lazy val client = new RegistrationClient(new AsyncClient(wrapper = TestClientWrapper()), BackendConfig.StagingBackend)
 
   lazy val assetGenerator = zmessaging.assetGenerator
 

--- a/tests/integration/src/test/scala/com/waz/znet/AuthenticationManagerBackendSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/znet/AuthenticationManagerBackendSpec.scala
@@ -31,7 +31,7 @@ import org.robolectric.Robolectric
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfter, FeatureSpec, Matchers, RobolectricTests}
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class AuthenticationManagerBackendSpec extends FeatureSpec with Matchers with BeforeAndAfter with ProvisionedSuite with ShadowLogging with RobolectricTests with ScalaFutures with DefaultPatienceConfig { test =>
@@ -40,13 +40,13 @@ class AuthenticationManagerBackendSpec extends FeatureSpec with Matchers with Be
   override protected lazy val logfileBaseDir: File = new File("target/logcat/integration")
 
   lazy val globalModule: GlobalModule = new GlobalModule(Robolectric.application, BackendConfig.StagingBackend) {
-    override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
   }
 
   lazy val storage = new ZmsDatabase(AccountId(), Robolectric.application)
   lazy val keyValue = new UserPreferences(Robolectric.application, storage)
 
-  lazy val client = new LoginClient(new AsyncClient(wrapper = TestClientWrapper), BackendConfig.StagingBackend)
+  lazy val client = new LoginClient(new AsyncClient(wrapper = TestClientWrapper()), BackendConfig.StagingBackend)
 
   lazy val email = provisionedEmail("auto1")
   lazy val passwd = "auto1_pass"

--- a/tests/integration/src/test/scala/com/waz/znet/WebSocketWebSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/znet/WebSocketWebSpec.scala
@@ -24,6 +24,7 @@ import com.koushikdutta.async.{ByteBufferList, DataEmitter}
 import com.waz.RobolectricUtils
 import com.waz.test.WebSocketEchoServer
 import com.waz.provision.RemoteProcess
+import com.waz.utils.events.EventContext
 import org.robolectric.shadows.ShadowLog
 import org.scalatest._
 
@@ -39,7 +40,7 @@ class WebSocketWebSpec extends FeatureSpecLike with Matchers with BeforeAndAfter
 
   before {
     ShadowLog.stream = System.out
-    client = new AsyncClient(wrapper = TestClientWrapper)
+    client = new AsyncClient(wrapper = TestClientWrapper())
   }
 
   after {
@@ -68,7 +69,8 @@ class WebSocketWebSpec extends FeatureSpecLike with Matchers with BeforeAndAfter
   feature("websocket") {
 
     scenario("Connect to echo server: http//localhost:18084") {
-      cl = Await.result(client.client, 1.second)
+      import scala.concurrent.ExecutionContext.Implicits.global
+      cl = Await.result(client.wrapper.map(ClientWrapper.unwrap), 1.second)
       @volatile var socket: WebSocket = null
 
       cl.websocket(new AsyncHttpGet("http://localhost:18084"), null, new WebSocketConnectCallback {

--- a/tests/integration/src/test/scala/com/waz/znet/ZNetClientBackendSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/znet/ZNetClientBackendSpec.scala
@@ -26,7 +26,7 @@ import org.json.JSONObject
 import org.robolectric.Robolectric
 import org.scalatest._
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class ZNetClientBackendSpec extends FeatureSpec with Matchers with ProvisionedSuite with RobolectricTests {
@@ -35,11 +35,11 @@ class ZNetClientBackendSpec extends FeatureSpec with Matchers with ProvisionedSu
   override val provisionFile = "/three_users.json"
 
   lazy val Seq(client1, client2, client3) = 1 to 3 map { i =>
-    new ZNetClient(provisionedEmail(s"auto$i"), s"auto${i}_pass", new AsyncClient(wrapper = TestClientWrapper))
+    new ZNetClient(provisionedEmail(s"auto$i"), s"auto${i}_pass", new AsyncClient(wrapper = TestClientWrapper()))
   }
 
   lazy val globalModule = new GlobalModule(Robolectric.application, BackendConfig.StagingBackend) {
-    override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
   }
 
   feature("Login user") {

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -52,6 +52,7 @@ import com.waz.znet._
 import com.wire.cryptobox.PreKey
 import org.scalatest.{Alerting, Informing, Suite}
 
+import scala.concurrent.Future
 import scala.util.Random
 
 trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket with MockedGcm { suite: Suite with Alerting with Informing =>
@@ -188,7 +189,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
 
   class MockedGlobalModule(context: Context, backend: BackendConfig, testClient: AsyncClient) extends GlobalModule(context, testBackend) {
     override lazy val client: AsyncClient = testClient
-    override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
     override lazy val loginClient: LoginClient = new LoginClient(client, backend) {
       override def login(user: AccountId, credentials: Credentials): CancellableFuture[LoginResult] = suite.login(user, credentials)
       override def access(cookie: Cookie, token: Option[Token]): CancellableFuture[LoginResult] = suite.access(cookie, token)

--- a/tests/unit/src/test/scala/com/waz/znet/AsyncClientSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/znet/AsyncClientSpec.scala
@@ -17,72 +17,182 @@
  */
 package com.waz.znet
 
+
 import java.io.{File, PipedInputStream, PipedOutputStream}
 
-import android.os.Build._
-import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.koushikdutta.async.callback.CompletedCallback.NullCompletedCallback
 import com.koushikdutta.async.callback.DataCallback.NullDataCallback
-import com.koushikdutta.async.callback.{CompletedCallback, DataCallback}
-import com.koushikdutta.async.future.{Future, SimpleFuture}
-import com.koushikdutta.async.http.callback.HttpConnectCallback
-import com.koushikdutta.async.http.{AsyncHttpClient, AsyncHttpRequest, AsyncHttpResponse, Headers}
-import com.koushikdutta.async.{AsyncServer, AsyncSocket, ByteBufferList}
-import com.waz.ZLog.LogTag
+import com.koushikdutta.async.callback._
+import com.koushikdutta.async.http._
+import com.koushikdutta.async.http.callback._
+import com.koushikdutta.async._
+import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ProgressIndicator.State
 import com.waz.api.impl.ProgressIndicator
-import com.waz.testutils.Matchers._
-import com.waz.testutils.Slow
-import com.waz.threading.CancellableFuture.CancelException
-import com.waz.threading.SerialDispatchQueue
-import com.waz.utils.wrappers.URI
+import com.waz.specs.AndroidFreeSpec
+import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils.{IoUtils, Json}
-import com.waz.znet.ContentEncoder.{EmptyRequestContent, GzippedRequestContent, JsonContentEncoder, MultipartRequestContent, StreamRequestContent}
+import com.waz.utils.wrappers.URI
+import com.waz.znet.ContentEncoder.{GzippedRequestContent, JsonContentEncoder, MultipartRequestContent, StreamRequestContent}
 import com.waz.znet.Response.{DefaultResponseBodyDecoder, HttpStatus, SuccessHttpStatus}
 import org.json.JSONObject
-import org.scalatest._
+import com.waz.testutils.Slow
+import com.waz.threading.CancellableFuture.CancelException
 
-import scala.concurrent.Future.successful
 import scala.concurrent.duration._
-import scala.concurrent.{Await, TimeoutException}
+import scala.concurrent.{Await, Future, Promise, TimeoutException}
 import scala.util.Random
 
-class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter with RobolectricTests {
-  implicit val tag: LogTag = "AsyncClientSpec"
-  
-  val wireMockPort = 9000 + Random.nextInt(3000)
-  lazy val wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig()
-    .port(wireMockPort)
-    .httpsPort(4433)
-    .withRootDirectory(getClass.getResource("/ZNetClientSpec").getPath)
-  )
-
+class AsyncClientSpec extends AndroidFreeSpec {
   implicit lazy val dispatcher = new SerialDispatchQueue
 
-  before {
-    wireMockServer.start()
-    configureFor("localhost", wireMockPort)
+  class FakeHttpResponse(c: Int = 200, m: String = "meep", h: Headers = new Headers(), body: Option[Array[Byte]] = None, completeOnSet: Boolean = true) extends AsyncHttpResponse {
+    @volatile var dataCallback: DataCallback = new NullDataCallback
+    @volatile var endCallback: CompletedCallback = new NullCompletedCallback
+
+    @volatile var alreadyConsumed = false
+
+    private def consume() = synchronized {
+      dataCallback match {
+        case c: NullDataCallback => // do nothing
+        case c: DataCallback if m.nonEmpty && !alreadyConsumed =>
+          val bb = new ByteBufferList(body.getOrElse(m.toCharArray.map(_.toByte)))
+          c.onDataAvailable(null, bb)
+          alreadyConsumed = true
+        case _ =>
+      }
+    }
+
+    private def complete() = synchronized {
+      endCallback match {
+        case c: NullCompletedCallback => // do nothing
+        case c: CompletedCallback => consume(); c.onCompleted(null)
+        case _ =>
+      }
+    }
+
+    override def setEndCallback(callback: CompletedCallback): Unit = {
+      endCallback = callback
+      if(completeOnSet) Future { complete() }
+    }
+
+    def getEndCallback: CompletedCallback = endCallback
+
+    override def setDataCallback(callback: DataCallback): Unit = {
+      dataCallback = callback
+      if(completeOnSet) Future { consume() }
+    }
+
+    def getDataCallback: DataCallback = dataCallback
+
+    override def getRequest: AsyncHttpRequest = null
+    override def message(): String = m
+    override def code(): Int = c
+    override def protocol(): String = "http"
+    override def headers(): Headers = h
+    override def detachSocket(): AsyncSocket = null
+    override def isPaused: Boolean = false
+    override def getServer: AsyncServer = null
+    override def isChunked: Boolean = false
+    override def charset(): String = "UTF-8"
+    override def pause(): Unit = ()
+    override def close(): Unit = ()
+    override def resume(): Unit = ()
   }
 
-  after {
-    wireMockServer.stop()
+  private val uriRegex = """.*(get|post)/(json|multi)*[_]*(empty|json)(\d+)""".r
+
+  private val jsonRequest = """{"key": "value"}"""
+  private val okJsonResponse = """{"result": "ok"}"""
+  private val penguinData = "some penguin data"
+  private val jsonObject = Json((1 to 25).map(i => s"key_$i" -> Seq.tabulate(i)(identity).mkString(",")).toMap)
+
+  private def toHeaders(tuples: (String, String)*): Headers = {
+    val headers = new Headers()
+    tuples.foreach(t => headers.set(t._1, t._2))
+    headers
   }
 
-  def client = new AsyncClient(wrapper = TestClientWrapper)
+  private def contentLength(data: String): (String, String) = "Content-Length" -> data.length.toString
+  private def contentLength(body: Array[Byte]): (String, String) = "Content-Length" -> body.length.toString
 
-  @volatile var progress = ProgressIndicator.ProgressData(0L, 0L, State.UNKNOWN)
-  @volatile var progressTickCount: Int = 0
+  private def mockResponse(req: HttpRequest): HttpResponse =
+    req.absoluteUri.getOrElse(throw new IllegalArgumentException("No URI found")).getPath match {
+      case uriRegex(method, json, expect, code) if expect == "empty" => new FakeHttpResponse(code.toInt, "", toHeaders(contentLength("")))
 
-  def doGet(path: String, auth: Boolean = false) = Await.result(client(URI.parse(s"http://localhost:$wireMockPort$path"), "GET", EmptyRequestContent, timeout = AsyncClient.DefaultTimeout, decoder = Some(DefaultResponseBodyDecoder), downloadProgressCallback = Some({
-    case currentProgress =>
-      progressTickCount += 1
-      progress = currentProgress
-  })), 500.millis)
+      case uriRegex(method, json, expect, code) if expect == "json" =>
+        new FakeHttpResponse(code.toInt, okJsonResponse, toHeaders("Content-Type" -> "application/json", contentLength(okJsonResponse)))
 
-  def doPost[A: ContentEncoder](path: String, data: A, auth: Boolean = false, timeout: FiniteDuration = AsyncClient.DefaultTimeout, waitTime: FiniteDuration = 500.millis) =
-    Await.result(client(URI.parse(s"http://localhost:$wireMockPort$path"), "POST", implicitly[ContentEncoder[A]].apply(data), timeout = timeout), waitTime)
+      case str: String if str.endsWith("/get/penguin") =>
+        new FakeHttpResponse(200, penguinData, toHeaders("Content-Type" -> "image/png", contentLength(penguinData)))
+
+      case str: String if str.endsWith("/get/gzipped") =>
+        val gzipped = IoUtils.gzip(jsonObject.toString.getBytes("utf8"))
+        new FakeHttpResponse(200, jsonObject.toString, toHeaders("Content-Type" -> "application/json", "Content-Encoding" -> "gzip", contentLength(gzipped)))
+
+      case str: String if str.endsWith("/post/gzipped") =>
+        val gzipped = IoUtils.gzip(okJsonResponse.getBytes("utf8"))
+        new FakeHttpResponse(200, okJsonResponse, toHeaders("Content-Type" -> "application/json", "Content-Encoding" -> "gzip", contentLength(gzipped)))
+
+      case str: String if str.endsWith("/get/delayed") => new FakeHttpResponse(200, okJsonResponse, toHeaders("Content-Type" -> "application/json", contentLength(okJsonResponse)))
+
+      case other => throw new IllegalArgumentException(s"Unrecognized URI: $other")
+    }
+
+  private val requestWorker = new RequestWorker {
+    override def processRequest(req: HttpRequest): HttpRequest = req
+  }
+
+  class FakeClientWrapper(delay: Option[Long] = None) extends ClientWrapper {
+    override def execute(request: HttpRequest, callback: HttpConnectCallback): CancellableFuture[HttpResponse] = {
+      val p = Promise[HttpResponse]
+      Future {
+        delay.map(Thread.sleep)
+        val fakeResponse = mockResponse(request)
+        callback.onConnectCompleted(null, fakeResponse)
+        p.success(fakeResponse)
+      }
+      CancellableFuture.lift(p.future)
+    }
+
+    override def websocket(request: HttpRequest, protocol: String, callback: AsyncHttpClient.WebSocketConnectCallback): CancellableFuture[WebSocket] = ???
+    override def stop(): Unit = ???
+  }
+
+  private def client = new AsyncClient(
+    bodyDecoder = DefaultResponseBodyDecoder,
+    userAgent="test",
+    wrapper = Future { new FakeClientWrapper(Some(100L)) },
+    requestWorker = requestWorker,
+    responseWorker = new ResponseImplWorker
+  )
+
+  private def clientWithDelay = new AsyncClient(
+    bodyDecoder = DefaultResponseBodyDecoder,
+    userAgent="test",
+    wrapper = Future { new FakeClientWrapper(Some(3000L)) },
+    requestWorker = requestWorker,
+    responseWorker = new ResponseImplWorker
+  )
+
+  @volatile private var progress = ProgressIndicator.ProgressData(0L, 0L, State.UNKNOWN)
+  @volatile private var progressTickCount: Int = 0
+
+  private val callback = (currentProgress: ProgressIndicator.ProgressData) => {
+    progressTickCount += 1
+    progress = currentProgress
+  }
+
+  private def doGet(path: String, auth: Boolean = false, waitTime: FiniteDuration = 500.millis) = {
+    val request = Request.Get(path, baseUri = Some(URI.parse("http://localhost")), downloadCallback = Some(callback), requiresAuthentication = auth)
+    Await.result(client(request), waitTime)
+  }
+
+  private def doPost[A: ContentEncoder](path: String, data: A, auth: Boolean = false, timeout: FiniteDuration = AsyncClient.DefaultTimeout, waitTime: FiniteDuration = 500.millis, client: AsyncClient = client) = {
+    val request = Request.Post(path, implicitly[ContentEncoder[A]].apply(data), baseUri = Some(URI.parse("http://localhost")), requiresAuthentication = auth, timeout = timeout)
+    Await.result(client(request), waitTime)
+  }
 
   feature("GET request") {
 
@@ -101,10 +211,10 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("Perform json GET request") {
-      val json = """{"result": "ok"}"""
+
       doGet("/get/json200") match {
-        case Response(HttpStatus(200, _), JsonObjectResponse(js), headers) if js.toString == new JSONObject(json).toString && headers("Content-Type").contains("application/json") => info(s"got json response with headers: $headers") //fine
-        case r => fail(s"got: $r instead of Response(HttpStatus(200), JsonBody($json))")
+        case Response(HttpStatus(200, _), JsonObjectResponse(js), headers) if js.toString == new JSONObject(okJsonResponse).toString && headers("Content-Type").contains("application/json") => info(s"got json response with headers: $headers") //fine
+        case r => fail(s"got: $r instead of Response(HttpStatus(200), JsonBody($okJsonResponse))")
       }
     }
 
@@ -120,6 +230,7 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
       progress.state shouldEqual State.COMPLETED
     }
 
+    // I'm not sure if this test actually does what it says it does...
     scenario("Get gzipped json") {
       import scala.collection.JavaConverters._
 
@@ -129,14 +240,6 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
       val obj = Json((1 to 25).map(i => s"key_$i" -> Seq.tabulate(i)(identity).mkString(",")).toMap)
 
       val gzipped = IoUtils.gzip(obj.toString.getBytes("utf8"))
-
-      stubFor(get(urlEqualTo("/get/gzipped"))
-        .willReturn(aResponse()
-        .withStatus(200)
-        .withHeader("Content-Type", "application/json")
-        .withHeader("Content-Encoding", "gzip")
-        .withBody(gzipped)
-        ))
 
       doGet("/get/gzipped") match {
         case Response(HttpStatus(200, _), JsonObjectResponse(js), headers) => toMap(js) shouldEqual toMap(obj)
@@ -155,38 +258,40 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("Post json, receive empty 200") {
-      doPost("/post/json_empty200", new JSONObject("""{ "key": "value"}""")) match {
+      doPost("/post/json_empty200", new JSONObject(jsonRequest)) match {
         case Response(HttpStatus(200, _), EmptyResponse, _) => // expected
         case resp => fail(s"got: $resp when expected Response(HttpStatus(200))")
       }
     }
 
-    scenario("Post json, receive json 200") {
-      val json = """{"result": "ok"}"""
-      doPost("/post/json_json200", new JSONObject("""{ "key": "value"}""")) match {
-        case Response(HttpStatus(200, _), JsonObjectResponse(js), _) if js.toString == new JSONObject(json).toString => //fine
-        case r => fail(s"got: $r instead of Response(HttpStatus(200), JsonBody($json))")
+   scenario("Post json, receive json 200") {
+      doPost("/post/json_json200", new JSONObject(jsonRequest)) match {
+        case Response(HttpStatus(200, _), JsonObjectResponse(js), _) if js.toString == new JSONObject(okJsonResponse).toString => //fine
+        case r => fail(s"got: $r instead of Response(HttpStatus(200), JsonBody($okJsonResponse))")
       }
     }
   }
 
   feature("Cancelling") {
 
+    val baseUri = Some(URI.parse("http://localhost"))
+
     scenario("Cancel once completed") {
-      val future = client(URI.parse(s"http://localhost:$wireMockPort/get/empty200"), "GET", EmptyRequestContent, timeout = AsyncClient.DefaultTimeout)
-      Thread.sleep(100)
+      val path = "/get/empty200"
+      val future = client(Request.Get(path, baseUri = baseUri))
+      Thread.sleep(200L)
       future.cancel()
 
-      Await.result(future, 100.millis) match {
+      Await.result(future, 200.millis) match {
         case Response(HttpStatus(200, _), EmptyResponse, _) => //expected
         case resp => fail(s"got: $resp while expecting Response(HttpStatus(200))")
       }
     }
 
     scenario("Cancel right away", Slow) {
-      val c = client
       (0 to 100) map { _ =>
-        val future = c(URI.parse(s"http://localhost:$wireMockPort/get/json200"), "GET", EmptyRequestContent, timeout = AsyncClient.DefaultTimeout)
+        val path = "/get/json200"
+        val future = client(Request.Get(path, baseUri = baseUri))
         future.cancel()
         future
       } foreach { future =>
@@ -197,9 +302,9 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("Cancel randomly", Slow) {
-      val c = client
       (0 to 255) foreach { _ =>
-        val future = c(URI.parse(s"http://localhost:$wireMockPort/get/json200"), "GET", EmptyRequestContent, timeout = AsyncClient.DefaultTimeout)
+        val path = "/get/json200"
+        val future = client(Request.Get(path, baseUri = baseUri))
         Thread.sleep(Random.nextInt(50))
         future.cancel()
         try {
@@ -214,10 +319,10 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("Cancel randomly on post", Slow) {
-      val c = client
-      val data = JsonContentEncoder(new JSONObject("""{ "key": "value"}"""))
+      val data = JsonContentEncoder(new JSONObject(jsonRequest))
       (0 to 255) foreach { _ =>
-        val future = c(URI.parse(s"http://localhost:$wireMockPort/post/json_json200"), "POST", data, timeout = AsyncClient.DefaultTimeout)
+        val path = "/post/json_json200"
+        val future = client(Request.Post(path, data, baseUri = baseUri, timeout = AsyncClient.DefaultTimeout))
         Thread.sleep(Random.nextInt(50))
         future.cancel()
         try {
@@ -232,15 +337,8 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("Cancel long get") {
-      stubFor(get(urlEqualTo("/get/delayed"))
-        .willReturn(aResponse()
-        .withStatus(200)
-        .withHeader("Content-Type", "application/json")
-        .withBody("""{"result":"ok"}""")
-        .withFixedDelay(500)
-        ))
-
-      val future = client(URI.parse(s"http://localhost:$wireMockPort/get/delayed"), "GET", EmptyRequestContent, timeout = AsyncClient.DefaultTimeout)
+      val path = "/get/delayed"
+      val future = clientWithDelay(Request.Get(path, baseUri = baseUri))
       Thread.sleep(100)
 
       future.cancel()
@@ -250,11 +348,11 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
       }
     }
 
-
     scenario("Cancel while streaming POST") {
       val os = new PipedOutputStream()
       val is = new PipedInputStream(os)
-      val future = client(URI.parse(s"http://localhost:$wireMockPort/post/json_json200"), "POST", new StreamRequestContent(is, "application/json", -1), timeout = AsyncClient.DefaultTimeout)
+      val path = "/post/json_json200"
+      val future = client(Request.Post(path, StreamRequestContent(is, "application/json", -1), baseUri = baseUri, timeout = AsyncClient.DefaultTimeout))
       os.write("""{"key":"""".getBytes("utf8"))
       future.cancel()
       os.write("""value"}""".getBytes("utf8"))
@@ -268,96 +366,68 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
   feature("Gzip POST encoding") {
 
     scenario("Send gzipped json request") {
-      stubFor(post(urlEqualTo("/post/gzipped"))
-        .willReturn(aResponse()
-        .withStatus(200)
-        .withHeader("Content-Type", "application/json")
-        .withBody("""{"result":"ok"}""")
-        ))
-
       val obj = Json((1 to 100).map(i => s"key_$i" -> Seq.tabulate(i)(identity).mkString(",")).toMap)
 
-      client(URI.parse(s"http://localhost:$wireMockPort/post/gzipped"), "POST", GzippedRequestContent(obj.toString.getBytes("utf8"), "application/json"), timeout = AsyncClient.DefaultTimeout) should eventually(beMatching {
-        case Response(SuccessHttpStatus(), JsonObjectResponse(json), _) if json.getString("result") == "ok" => // fine
-      })
+      val path = "/post/gzipped"
+      val future = client(Request.Post(path, GzippedRequestContent(obj.toString.getBytes("utf8"), "application/json"), baseUri = Some(URI.parse("http://localhost")), timeout = AsyncClient.DefaultTimeout))
+      Await.result(future, AsyncClient.DefaultTimeout) match {
+        case Response(SuccessHttpStatus(), JsonObjectResponse(json), headers) if json.getString("result") == "ok" && headers("Content-Encoding") == Some("gzip") => // fine
+        case other => fail(s"Wrong response: $other")
+      }
 
-      verify(postRequestedFor(urlEqualTo("/post/gzipped")).withHeader("Content-Encoding", equalTo("gzip")))
-    }
-  }
-
-  feature("User-Agent") {
-
-    scenario("Send user agent with requests") {
-      val agent = s"Wire/* (zms *; Android ${VERSION.RELEASE}; $MANUFACTURER $MODEL)"
-
-      verify(getRequestedFor(urlEqualTo("/get/empty200")).withHeader("User-Agent", equalTo(agent)))
-      verify(postRequestedFor(urlEqualTo("/post/empty200")).withHeader("User-Agent", equalTo(agent)))
-      verify(getRequestedFor(urlEqualTo("/get/delayed")).withHeader("User-Agent", equalTo(agent)))
     }
   }
 
   feature("Network inactivity timeout") {
-    import scala.language.reflectiveCalls
 
-    lazy val mockedResponse = new AsyncHttpResponse {
-      @volatile var dataCallback: DataCallback = new NullDataCallback
-      @volatile var endCallback: CompletedCallback = new NullCompletedCallback
+    val baseUri = Some(URI.parse("http://meep.me"))
+    lazy val mockedResponse = new FakeHttpResponse(200, "", completeOnSet = false)
 
-      override def getRequest: AsyncHttpRequest = null
-      override def message(): String = "meep"
-      override def code(): Int = 200
-      override def protocol(): String = "http"
-      override def headers(): Headers = new Headers()
-      override def detachSocket(): AsyncSocket = null
-      override def getEndCallback: CompletedCallback = endCallback
-      override def isPaused: Boolean = false
-      override def setDataCallback(callback: DataCallback): Unit = dataCallback = callback
-      override def getDataCallback: DataCallback = dataCallback
-      override def getServer: AsyncServer = null
-      override def isChunked: Boolean = false
-      override def charset(): String = "UTF-8"
-      override def setEndCallback(callback: CompletedCallback): Unit = endCallback = callback
-      override def pause(): Unit = ()
-      override def close(): Unit = ()
-      override def resume(): Unit = ()
+    @volatile var onConnect: Option[HttpConnectCallback] = None
+
+    lazy val clientWrapper = new ClientWrapper {
+      override def execute(req: HttpRequest, callback: HttpConnectCallback): CancellableFuture[HttpResponse] = {
+        onConnect = Option(callback)
+        CancellableFuture(mockedResponse)
+      }
+
+      def websocket(request: HttpRequest, protocol: String, callback: AsyncHttpClient.WebSocketConnectCallback): CancellableFuture[WebSocket] = ???
+      def stop(): Unit = {}
     }
 
-    lazy val mockedClient = new AsyncClient {
-      @volatile var onConnect: Option[HttpConnectCallback] = None
-
-      override val client = successful(new AsyncHttpClient(new AsyncServer) {
-        override def execute(req: AsyncHttpRequest, callback: HttpConnectCallback): Future[AsyncHttpResponse] = {
-          onConnect = Option(callback)
-          new SimpleFuture[AsyncHttpResponse](mockedResponse)
-        }
-      })
-    }
+    lazy val mockedClient = new AsyncClient(
+      bodyDecoder = DefaultResponseBodyDecoder,
+      userAgent="test",
+      wrapper = Future { clientWrapper },
+      requestWorker = requestWorker,
+      responseWorker = new ResponseImplWorker
+    )
 
     scenario("connect doesn't complete") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       a[TimeoutException] should be thrownBy Await.result(resp, 2.seconds)
     }
 
     scenario("connect completes, no response is sent") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       Thread.sleep(100L)
-      mockedClient.onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
+      onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
       a[TimeoutException] should be thrownBy Await.result(resp, 2.seconds)
     }
 
     scenario("connect completes, response is sent, but no completion") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       Thread.sleep(100L)
-      mockedClient.onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
+      onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
       Thread.sleep(100L)
       mockedResponse.dataCallback.onDataAvailable(null, new ByteBufferList)
       a[TimeoutException] should be thrownBy Await.result(resp, 2.seconds)
     }
 
     scenario("connect completes, response is sent, in time completion") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       Thread.sleep(100L)
-      mockedClient.onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
+      onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
       Thread.sleep(100L)
       mockedResponse.dataCallback.onDataAvailable(null, new ByteBufferList)
       Thread.sleep(100L)
@@ -366,9 +436,9 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("connect completes, response is sent slowly, in time completion") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       Thread.sleep(100L)
-      mockedClient.onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
+      onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
       for (i <- 1 to 3) {
         Thread.sleep(500L)
         mockedResponse.dataCallback.onDataAvailable(null, new ByteBufferList)
@@ -379,9 +449,9 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("connect completes, response is sent slowly, then takes too long") {
-      val resp = mockedClient(URI.parse("http://meep.me"), timeout = 1.second)
+      val resp = mockedClient(Request.Get("", baseUri = baseUri, timeout = 1.second))
       Thread.sleep(100L)
-      mockedClient.onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
+      onConnect.foreach { _.onConnectCompleted(null, mockedResponse) }
       for (i <- 1 to 2) {
         Thread.sleep(500L)
         mockedResponse.dataCallback.onDataAvailable(null, new ByteBufferList)
@@ -394,74 +464,16 @@ class AsyncClientSpec extends FeatureSpecLike with Matchers with BeforeAndAfter 
     }
 
     scenario("multipart POST, connect (incl. sending of request) is very slow") {
-      wireMockServer.addRequestProcessingDelay(3000)
-      doPost("/post/multi_empty200", MultipartRequestContent(Seq("meep" -> new File(getClass.getResource("/emojis.txt").getPath))), false, 2.seconds, 10.seconds) match {
+      doPost("/post/multi_empty200", MultipartRequestContent(Seq("meep" -> new File(getClass.getResource("/emojis.txt").getPath))), false, 2.seconds, 10.seconds, client = clientWithDelay) match {
         case Response(HttpStatus(200, _), _, _) => // expected
         case resp => fail(s"got: $resp when expected Response(HttpStatus(200))")
       }
     }
 
     scenario("JSON POST, connect (incl. sending of request) is very slow") {
-      wireMockServer.addRequestProcessingDelay(3000)
-      a[TimeoutException] should be thrownBy doPost("/post/json_json200", new JSONObject("""{ "key": "value"}"""), false, 2.seconds, 10.seconds)
+      a[TimeoutException] should be thrownBy doPost("/post/json_json200", jsonObject, false, 2.seconds, 10.seconds, client = clientWithDelay)
     }
+
   }
 
-  /*
-  TODO: Maciek Gorywoda: We need a way to mock the AsyncClient in a more complex way - for example, simulating low
-  bandwidth connection, but only for downloading assets and for a given time, so after the time passes the connection
-  gets well again and the user is able to download the asset). For that, we need to wrap koushikdutta's AsyncHttpClient.
-  I leave here the code I used in AsyncClientto simulate that situation.
-
-  import com.koushikdutta.async.future.SimpleFuture
-
-  class AsyncClient ... {
-    ...
-    private def mockExecute(callback: () => Boolean): SimpleFuture[AsyncHttpResponse] = {
-    debug(s"CE mocked execute started")
-    new SimpleFuture[AsyncHttpResponse] {
-      val c = CancellableFuture {
-        debug(s"the mocked future started")
-        Thread.sleep(DefaultTimeout.toMillis)
-        callback()
-      }
-
-      override def cancel(): Boolean = {
-        debug(s"mocked future cancel")
-        c.cancel()
-      }
-    }
-  }
-
-  def execute(client: AsyncHttpClient, request: AsyncHttpRequest, callback: HttpConnectCallback, mockCallback: Option[() => Boolean] = None): KFuture[AsyncHttpResponse] = {
-    val uri = request.getUri().toString
-    if (request.getMethod() == "GET" && uri.contains("https://staging-nginz-https.zinfra.io/assets/v3") && mockCallback.isDefined) {
-      AsyncClient.addIfMissing(uri)
-      if(AsyncClient.mockDuration(uri) > 4*DefaultTimeout.toMillis + 1L) {
-        debug(s"the mock execute finished for $uri, calling the standard execute")
-        client.execute(request, callback)
-      } else {
-        mockExecute(mockCallback.get)
-      }
-    }
-    else {
-      debug(s"the standard execute for method ${request.getMethod()} and uri ${request.getUri()}")
-      client.execute(request, callback)
-    }
-  }
-  ...
-    val mockedCallback = () => p.tryFailure(new TimeoutException("mocked timeout"))
-    val httpFuture = execute(client, request, callback, Some(mockedCallback))  // instead of: val httpFuture = client.execute(request, callback)
-  ...
-  }
-
-  object AsyncClient {
-    ...
-    import scala.collection.mutable
-    val mockTime = mutable.HashMap[String, Long]()
-    def addIfMissing(uri: String) = mockTime.getOrElseUpdate(uri, System.currentTimeMillis())
-    def mockDuration(uri: String) = mockTime.get(uri).map(System.currentTimeMillis() - _).getOrElse(0L)
-    ...
-  }
-   */
 }

--- a/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
+++ b/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
@@ -46,7 +46,7 @@ import org.scalatest._
 import org.scalatest.enablers.{Containing, Emptiness, Length}
 import com.waz.ZLog.ImplicitTag._
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.{PartialFunction => =/>}
 
@@ -81,12 +81,12 @@ trait ApiSpec extends BeforeAndAfterEach with BeforeAndAfterAll with Matchers wi
   private lazy val eventSpies = new AtomicReference(Vector.empty[Event =/> Unit])
 
   def testBackend: BackendConfig = BackendConfig.StagingBackend
-  lazy val testClient = new AsyncClient(wrapper = TestClientWrapper)
+  lazy val testClient = new AsyncClient(wrapper = TestClientWrapper())
 
   lazy val globalModule: GlobalModule = new ApiSpecGlobal
 
   class ApiSpecGlobal extends GlobalModule(context, testBackend) {
-    override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+    override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
     override lazy val client: AsyncClient = testClient
     override lazy val timeouts: Timeouts = suite.timeouts
 
@@ -108,7 +108,7 @@ trait ApiSpec extends BeforeAndAfterEach with BeforeAndAfterAll with Matchers wi
 
   def netClient = zmessaging.zNetClient
 
-  def znetClientFor(email: String, password: String) = new ZNetClient(email, password, new AsyncClient(wrapper = TestClientWrapper))
+  def znetClientFor(email: String, password: String) = new ZNetClient(email, password, new AsyncClient(wrapper = TestClientWrapper()))
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/tests/utils/src/main/scala/com/waz/provision/RemoteProcess.scala
+++ b/tests/utils/src/main/scala/com/waz/provision/RemoteProcess.scala
@@ -56,7 +56,7 @@ class RemoteProcess extends RoboProcess {
 
     val backend = BackendConfig.byName(args(3))
 
-    val processActor = actorSystem.actorOf(RemoteProcessActor.props(Robolectric.application, processName, coordinatorActor, backend, TestClientWrapper), processName.replaceAll("\\s+", "_"))
+    val processActor = actorSystem.actorOf(RemoteProcessActor.props(Robolectric.application, processName, coordinatorActor, backend, TestClientWrapper()), processName.replaceAll("\\s+", "_"))
 
     Robolectric.getShadowApplication.grantPermissions(Permission.values.map(_.id):_*)
 

--- a/tests/utils/src/main/scala/com/waz/testutils/FeigningAsyncClient.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/FeigningAsyncClient.scala
@@ -18,18 +18,13 @@
 package com.waz.testutils
 
 import com.waz.threading.CancellableFuture
-import com.waz.utils.wrappers.URI
-import com.waz.znet.ContentEncoder.{EmptyRequestContent, RequestContent}
-import com.waz.znet.Request._
-import com.waz.znet.Response.ResponseBodyDecoder
-import com.waz.znet.{AsyncClient, Response, TestClientWrapper}
+import com.waz.znet.{AsyncClient, Request, Response, TestClientWrapper}
 
-import scala.concurrent.duration._
-
-class FeigningAsyncClient extends AsyncClient(wrapper = TestClientWrapper) {
+class FeigningAsyncClient extends AsyncClient(wrapper = TestClientWrapper()) {
   @volatile var simulateNetworkFailure = false
 
-  override def apply(uri: URI, method: String = "GET", body: RequestContent = EmptyRequestContent, headers: Map[String, String] = AsyncClient.EmptyHeaders, followRedirect: Boolean = false, timeout: FiniteDuration = 30.seconds, decoder: Option[ResponseBodyDecoder] = None, downloadProgressCallback: Option[ProgressCallback] = None): CancellableFuture[Response] =
+  override def apply(request: Request[_]): CancellableFuture[Response] =
     if (simulateNetworkFailure) CancellableFuture.successful(Response(Response.ConnectionError("somebody set up us the bomb")))
-    else super.apply(uri, method, body, headers, followRedirect, timeout, decoder, downloadProgressCallback)
+    else super.apply(request)
+
 }

--- a/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
@@ -46,8 +46,8 @@ import scala.concurrent.{Await, Future}
 import scala.util.Random
 
 class MockGlobalModule(dbSuffix: String = Random.nextInt().toHexString) extends GlobalModule(Robolectric.application, BackendConfig.StagingBackend) { global =>
-  override lazy val client: AsyncClient = new EmptyAsyncClient(TestClientWrapper)
-  override lazy val clientWrapper: ClientWrapper = TestClientWrapper
+  override lazy val client: AsyncClient = new EmptyAsyncClient(TestClientWrapper())
+  override lazy val clientWrapper: Future[ClientWrapper] = TestClientWrapper()
   override lazy val storage: Database = new GlobalDatabase(context, dbSuffix)
 
   ZMessaging.context = context

--- a/tests/utils/src/main/scala/com/waz/utils/wrappers/JVMURI.scala
+++ b/tests/utils/src/main/scala/com/waz/utils/wrappers/JVMURI.scala
@@ -26,7 +26,7 @@ class JavaURIBuilder(uriBuilder: JURIBuilder) extends URIBuilder {
   //TODO figure out which methods map best to java.net.URI
   override def appendPath(path: String)                         = new JavaURIBuilder(uriBuilder.setPath(path))
   override def encodedPath(path: String)                        = ???
-  override def appendEncodedPath(path: String)                  = ???
+  override def appendEncodedPath(path: String)                  = new JavaURIBuilder(uriBuilder.setPath(path))
   override def appendQueryParameter(key: String, value: String) = new JavaURIBuilder(uriBuilder.setParameter(key, value))
   override def build                                            = new JavaURI(uriBuilder.build())
 }
@@ -40,7 +40,7 @@ class JavaURI(uri: JURI) extends URI {
   override def getPathSegments                = ???
   override def getLastPathSegment             = ???
   override def getQueryParameter(key: String) = ???
-  override def normalizeScheme                = ???
+  override def normalizeScheme                = JavaURIUtil.parse(uri.toString.toLowerCase)
   override def toString                       = uri.toString
 }
 

--- a/zmessaging/src/main/scala/com/waz/api/HockeyCrashReporter.scala
+++ b/zmessaging/src/main/scala/com/waz/api/HockeyCrashReporter.scala
@@ -34,9 +34,11 @@ object HockeyCrashReporter {
   import Threading.Implicits.Background
 
   def uploadCrashReport(hockeyId: String, dump: File, log: File) = {
-    val url = s"https://rink.hockeyapp.net/api/2/apps/$hockeyId/crashes/upload"
+    val baseUri = URI.parse("https://rink.hockeyapp.net")
+    val path = s"/api/2/apps/$hockeyId/crashes/upload"
 
-    ZMessaging.currentGlobal.client(URI.parse(url), Request.PostMethod, MultipartRequestContent(Seq("attachment0" -> dump, "log" -> log)), timeout = 1.minute) map {
+    val request = Request.Post(path, MultipartRequestContent(Seq("attachment0" -> dump, "log" -> log)), baseUri = Some(baseUri), timeout = 1.minute)
+    ZMessaging.currentGlobal.client(request) map {
       case Response(SuccessHttpStatus(), _, _) => verbose("crash report successfully sent")
       case resp => error(s"Unexpected response from hockey crash report request: $resp")
     } map { _ =>

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -36,6 +36,8 @@ import com.waz.utils.Cache
 import com.waz.utils.wrappers.{GoogleApi, GoogleApiImpl}
 import com.waz.znet._
 
+import scala.concurrent.Future
+
 
 class GlobalModule(val context: Context, val backend: BackendConfig) { global =>
   lazy val storage:             Database                         = new GlobalDatabase(context)
@@ -70,7 +72,7 @@ class GlobalModule(val context: Context, val backend: BackendConfig) { global =>
   lazy val recordingAndPlayback                                  = wire[GlobalRecordAndPlayService]
   lazy val tempFiles: TempFileService                            = wire[TempFileService]
 
-  lazy val clientWrapper: ClientWrapper = ClientWrapper
+  lazy val clientWrapper: Future[ClientWrapper] = ClientWrapper()
   lazy val client: AsyncClient = new AsyncClient(decoder, AsyncClient.userAgent(metadata.appVersion.toString, ZmsVersion.ZMS_VERSION), clientWrapper)
 
   lazy val globalClient = new ZNetClient(global, "", "")

--- a/zmessaging/src/main/scala/com/waz/service/downloads/DownloadRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/DownloadRequest.scala
@@ -54,7 +54,7 @@ object DownloadRequest {
   case class UnencodedAudioAsset(cacheKey: CacheKey, name: Option[String]) extends DownloadRequest
 
   case class External(cacheKey: CacheKey, uri: URI) extends ExternalAssetRequest {
-    override def request: Request[Unit] = Request[Unit](absoluteUri = Some(uri), requiresAuthentication = false)
+    override def request: Request[Unit] = Request[Unit](baseUri = Some(uri), requiresAuthentication = false)
   }
 
   // external asset downloaded from wire proxy, path is relative to our proxy endpoint

--- a/zmessaging/src/main/scala/com/waz/service/downloads/Downloader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/Downloader.scala
@@ -69,8 +69,7 @@ class AssetDownloader(client: AssetClient, cache: CacheService) extends Download
       val headers = wa.remoteData.token.fold(Map.empty[String, String])(t => Map("Asset-Token" -> t.str))
       val decoder = new AssetBodyDecoder(cache, wa.remoteData.otrKey.filter(_ != AESKey.Empty), wa.remoteData.sha256.filter(_ != Sha256.Empty))
       Some(new Request[Unit](Request.GetMethod, path, downloadCallback = Some(callback), decoder = Some(decoder), headers = headers))
-    case req: ExternalAssetRequest =>
-      Some(req.request.copy(downloadCallback = Some(callback), decoder = Some(new AssetBodyDecoder(cache))))
+    case req: ExternalAssetRequest => Some(req.request.copy(downloadCallback = Some(callback), decoder = Some(new AssetBodyDecoder(cache))))
     case LocalAssetRequest(_, _, _, _) => None
     case CachedAssetRequest(_, _, _) => None
   }

--- a/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/AssetClient.scala
@@ -54,7 +54,8 @@ class AssetClientImpl(netClient: ZNetClient) extends AssetClient {
   import Threading.Implicits.Background
   import com.waz.sync.client.AssetClient._
 
-  override def loadAsset(req: Request[Unit]): ErrorOrResponse[CacheEntry] =
+  override def loadAsset(req: Request[Unit]): ErrorOrResponse[CacheEntry] = {
+    debug(s"AC loadAsset($req)")
     netClient.withErrorHandling("loadAsset", req) {
       case Response(SuccessHttpStatus(), resp: BinaryResponse, _) => resp
       case Response(SuccessHttpStatus(), resp: FileResponse, _) => resp
@@ -63,6 +64,7 @@ class AssetClientImpl(netClient: ZNetClient) extends AssetClient {
       case Right(resp) => CancellableFuture successful Left(ErrorResponse.internalError(s"unexpected response: $resp"))
       case Left(err) => CancellableFuture successful Left(err)
     }
+  }
 
   override def postImageAssetData(asset: AssetData, data: LocalData, nativePush: Boolean = true, convId: RConvId): ErrorOrResponse[RAssetId] = {
     asset match {

--- a/zmessaging/src/main/scala/com/waz/sync/client/OpenGraphClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OpenGraphClient.scala
@@ -42,7 +42,7 @@ class OpenGraphClient(netClient: ZNetClient) {
         "Cookie" -> cookie.map { case (k, v) => s"$k=$v" } .mkString("; ")
       )
 
-      val req = Request[Unit](Request.HeadMethod, absoluteUri = Some(uri), decoder = Some(ResponseDecoder), requiresAuthentication = false, headers = headers, followRedirect = false)
+      val req = Request[Unit](Request.HeadMethod, baseUri = Some(uri), decoder = Some(ResponseDecoder), requiresAuthentication = false, headers = headers, followRedirect = false)
       netClient(req) flatMap {
         case (Response(SuccessStatus(), StringResponse(_), _) | Response(SuccessStatus(), EmptyResponse, _)) => // this means that ResponseDecoder accepted the content type, we can proceed with GET
           netClient.withErrorHandling("loadOpenGraph", req.copy(httpMethod = Request.GetMethod)) {

--- a/zmessaging/src/main/scala/com/waz/sync/client/SpotifyClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SpotifyClient.scala
@@ -97,7 +97,7 @@ object SpotifyClient {
 
   private def withMarket(u: URI, authenticated: Boolean): URI = if (authenticated) uri(u)(_ :? ("market", "from_token")) else u
 
-  private def get(url: URI, headers: Map[String, String]) = Request[Unit](httpMethod = Request.GetMethod, absoluteUri = Option(url), requiresAuthentication = false, headers = headers)
+  private def get(url: URI, headers: Map[String, String]) = Request[Unit](httpMethod = Request.GetMethod, baseUri = Option(url), requiresAuthentication = false, headers = headers)
 
   object IsPremiumResponse extends SpotifyJsonObjectResponse[Boolean] {
     override def fromJson(implicit js: JSONObject): Option[Boolean] = Some(js.has("product") && js.getString("product") == "premium")

--- a/zmessaging/src/main/scala/com/waz/sync/client/VersionBlacklistClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/VersionBlacklistClient.scala
@@ -36,7 +36,7 @@ class VersionBlacklistClient(netClient: ZNetClient, backendConfig: BackendConfig
   private implicit val tag: LogTag = logTagFor[VersionBlacklistClient]
 
   def loadVersionBlacklist(): ErrorOrResponse[VersionBlacklist] = {
-    netClient.withErrorHandling("loadVersionBlacklist", Request(absoluteUri = Some(blacklistsUrl(backendConfig.environment)), requiresAuthentication = false, decoder = Some(decoder))(EmptyContentEncoder)) {
+    netClient.withErrorHandling("loadVersionBlacklist", Request(baseUri = Some(blacklistsUrl(backendConfig.environment)), requiresAuthentication = false, decoder = Some(decoder))(EmptyContentEncoder)) {
       case Response(SuccessHttpStatus(), VersionBlacklistExtractor(blacklist), _) => blacklist
     }
   }

--- a/zmessaging/src/main/scala/com/waz/znet/HttpRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/HttpRequest.scala
@@ -1,0 +1,73 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.znet
+
+import com.koushikdutta.async.http._
+import com.waz.utils.wrappers.{AndroidURI, URI}
+import com.waz.znet.ContentEncoder.{EmptyRequestContent, RequestContent}
+
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+
+trait HttpRequest {
+  def absoluteUri: Option[URI]
+  def httpMethod: String
+  def getBody: RequestContent
+  def headers: Map[String, String]
+  def followRedirect: Boolean
+  def timeout: FiniteDuration
+}
+
+class HttpRequestImpl(val req: AsyncHttpRequest) extends HttpRequest {
+  override val absoluteUri: Option[URI] = Some(new AndroidURI(req.getUri()))
+  override val httpMethod: String = req.getMethod()
+  override val getBody: RequestContent = EmptyRequestContent // TODO
+  override val headers: Map[String, String] = {
+    val m = req.getHeaders().getMultiMap()
+    m.keySet().asScala.toSet[String].map(k => (k -> m.getString(k))).toMap
+  }
+  override val followRedirect: Boolean = req.getFollowRedirect()
+  override val timeout: FiniteDuration = req.getTimeout().millis
+}
+
+object HttpRequest {
+  import scala.language.implicitConversions
+
+  def apply(req: AsyncHttpRequest): HttpRequest = new HttpRequestImpl(req)
+
+  implicit def wrap(req: AsyncHttpRequest): HttpRequest = apply(req)
+  implicit def unwrap(req: HttpRequest): AsyncHttpRequest = req match {
+    case wrapper: HttpRequestImpl => wrapper.req
+    case _ => throw new IllegalArgumentException(s"Expected AsyncHttpRequest, but tried to unwrap: $req")
+  }
+}
+
+trait RequestWorker {
+  def processRequest(request: HttpRequest): HttpRequest
+}
+
+class HttpRequestImplWorker extends RequestWorker {
+  override def processRequest(request: HttpRequest): HttpRequest = {
+    val r = new AsyncHttpRequest(URI.unwrap(request.absoluteUri.getOrElse(throw new IllegalArgumentException("URI not provided")).normalizeScheme), request.httpMethod)
+    r.setTimeout(request.timeout.toMillis.toInt)
+    r.setFollowRedirect(request.followRedirect)
+    r.getHeaders.set(AsyncClient.UserAgentHeader, AsyncClient.userAgent())
+    request.headers.foreach(p => r.getHeaders.set(p._1, p._2.trim))
+    new HttpRequestImpl(request.getBody.apply(r))
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/znet/HttpResponse.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/HttpResponse.scala
@@ -1,0 +1,171 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.znet
+
+import java.util.concurrent.atomic.AtomicLong
+
+import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
+import com.waz.api
+import com.waz.api.impl.ProgressIndicator
+import com.waz.threading.{CancellableFuture, SerialDispatchQueue, Threading}
+import com.waz.utils.wrappers.URI
+import com.waz.znet.Request.ProgressCallback
+import com.waz.znet.Response.{HttpStatus, ResponseBodyDecoder}
+import com.waz.znet.ResponseConsumer.ConsumerState.Done
+import com.koushikdutta.async.http._
+import com.koushikdutta.async._
+import com.koushikdutta.async.callback.CompletedCallback.NullCompletedCallback
+import com.koushikdutta.async.callback.DataCallback.NullDataCallback
+import com.koushikdutta.async.callback.{CompletedCallback, DataCallback}
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
+import scala.collection.JavaConverters._
+
+trait HttpResponse {
+  def status: Response.Status
+  def body: ResponseContent
+  def headers: Response.Headers
+
+  def setDataCallback(callback: DataCallback): Unit = {}
+  def setEndCallback(callback: CompletedCallback): Unit = {}
+
+  def close(): Unit = {}
+}
+
+class HttpResponseImpl(val res: AsyncHttpResponse) extends HttpResponse {
+  override val status: Response.Status = HttpStatus(res.code(), res.message())
+  override val body: ResponseContent = EmptyResponse // TODO
+  override val headers: Response.Headers = {
+    val multiMap = res.headers().getMultiMap()
+    val map: Map[String, String] = multiMap.keySet().asScala.toSet[String].map(k => (k -> multiMap.getString(k))).toMap
+    Response.createHeaders(map)
+  }
+
+  override def setDataCallback(callback: DataCallback): Unit = res.setDataCallback(callback)
+  override def setEndCallback(callback: CompletedCallback): Unit = res.setEndCallback(callback)
+
+  override def close(): Unit = res.close()
+}
+
+object HttpResponse {
+  def apply(response: AsyncHttpResponse): HttpResponse = new HttpResponseImpl(response)
+
+  import scala.language.implicitConversions
+
+  implicit def wrap(res: AsyncHttpResponse): HttpResponse = apply(res)
+  implicit def unwrap(res: HttpResponse): AsyncHttpResponse = res match {
+    case wrapper: HttpResponseImpl => wrapper.res
+    case _ => throw new IllegalArgumentException(s"Expected Koushikdutta's AsyncHttpResponse, but tried to unwrap: $res")
+  }
+}
+
+trait ResponseWorker {
+  def processResponse(requestUri: Option[URI],
+                      response: HttpResponse,
+                      decoder: ResponseBodyDecoder,
+                      progressCallback: Option[ProgressCallback],
+                      networkActivityCallback: () => Unit): CancellableFuture[Response]
+}
+
+class ResponseImplWorker extends ResponseWorker {
+  protected implicit val dispatcher = new SerialDispatchQueue(Threading.ThreadPool)
+
+  //XXX: has to be executed on Http thread (inside onConnectCompleted), since data callbacks have to be set before this callback completes,
+  override def processResponse(requestUri: Option[URI],
+                               response: HttpResponse,
+                               decoder: ResponseBodyDecoder,
+                               progressCallback: Option[ProgressCallback],
+                               networkActivityCallback: () => Unit): CancellableFuture[Response] = {
+    val httpStatus = response.status
+    val contentLength = response.headers("Content-Length").map(_.toInt).getOrElse(-1)
+    val contentType = response.headers("Content-Type").getOrElse("")
+
+    debug(s"got connection response for $requestUri, status: '$httpStatus', length: '$contentLength', type: '$contentType'")
+
+    progressCallback foreach (_(ProgressIndicator.ProgressData(0L, contentLength, api.ProgressIndicator.State.RUNNING)))
+    if (contentLength == 0) {
+      progressCallback foreach { cb => Future(cb(ProgressIndicator.ProgressData(0, 0, api.ProgressIndicator.State.COMPLETED))) }
+      CancellableFuture.successful(Response(httpStatus, headers = response.headers))
+    } else {
+      val p = Promise[Response]()
+      val consumer = decoder(contentType, contentLength)
+
+      def onComplete(ex: Exception) = {
+        response.setDataCallback(new NullDataCallback)
+        response.setEndCallback(new NullCompletedCallback)
+        p.tryComplete(
+          if (ex != null) Failure(ex)
+          else consumer.result match {
+            case Success(body) =>
+              progressCallback foreach { cb => Future(cb(ProgressIndicator.ProgressData(contentLength, contentLength, api.ProgressIndicator.State.COMPLETED))) }
+              Success(Response(httpStatus, body, response.headers))
+            case Failure(t) =>
+              progressCallback foreach { cb => Future(cb(ProgressIndicator.ProgressData(0, contentLength, api.ProgressIndicator.State.FAILED))) }
+              Success(Response(Response.InternalError(s"Response body consumer failed for request: '$requestUri'", Some(t), Some(httpStatus))))
+          }
+        )
+      }
+
+      response.setDataCallback(new DataCallback {
+        val bytesSent = new AtomicLong(0L)
+
+        override def onDataAvailable(emitter: DataEmitter, bb: ByteBufferList): Unit = {
+          val numConsumed = bb.remaining
+          val state = consumer.consume(bb)
+
+          networkActivityCallback()
+          progressCallback foreach { cb => Future(cb(ProgressIndicator.ProgressData(bytesSent.addAndGet(numConsumed), contentLength, api.ProgressIndicator.State.RUNNING))) }
+
+          state match {
+            case Done =>
+              // consumer doesn't need any more data, we can stop receiving and report success
+              debug(s"consumer [$consumer] returned Done, finishing response processing for: $requestUri")
+              onComplete(null)
+              response.close()
+            case _ => // ignore
+          }
+        }
+      })
+
+      response.setEndCallback(new CompletedCallback {
+        override def onCompleted(ex: Exception): Unit = {
+          debug(s"response for $requestUri ENDED, ex: $ex, p.isCompleted: ${p.isCompleted}")
+          Option(ex) foreach { error(s"response for $requestUri failed", _) }
+          networkActivityCallback()
+          onComplete(ex)
+        }
+      })
+
+      new CancellableFuture(p) {
+        override def cancel()(implicit tag: LogTag): Boolean = {
+          debug(s"cancelling response processing for: $requestUri")(tag)
+          response.setDataCallback(new NullDataCallback)
+          response.setEndCallback(new NullCompletedCallback)
+          response.close()
+          progressCallback foreach { cb => Future(cb(ProgressIndicator.ProgressData(0, contentLength, api.ProgressIndicator.State.CANCELLED))) }
+          super.cancel()(tag)
+        }
+      }
+    }
+
+  }
+}
+
+

--- a/zmessaging/src/main/scala/com/waz/znet/Request.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/Request.scala
@@ -40,7 +40,7 @@ import scala.concurrent.duration._
 case class Request[A: ContentEncoder](
       httpMethod: String = Request.GetMethod,
       resourcePath: Option[String] = None,
-      absoluteUri: Option[URI] = None,
+      baseUri: Option[URI] = None,
       data: Option[A] = None,
       decoder: Option[ResponseBodyDecoder] = None,
       uploadCallback: Option[ProgressCallback] = None,
@@ -50,13 +50,23 @@ case class Request[A: ContentEncoder](
       retryPolicy: RetryPolicy = RetryPolicy.NeverRetry,
       followRedirect: Boolean = true,
       timeout: FiniteDuration = AsyncClient.DefaultTimeout
-) {
+) extends HttpRequest {
 
   assert(uploadCallback.isEmpty, "uploadCallback is not supported yet") //TODO
 
-  require(resourcePath.isDefined || absoluteUri.isDefined, "Either resourcePath or absoluteUri has to be specified")
+  require(resourcePath.isDefined || baseUri.isDefined, "Either resourcePath or baseUri has to be specified")
 
   def getBody = data.map(implicitly[ContentEncoder[A]].apply).getOrElse(EmptyRequestContent)
+
+  def withHeaders(headers: Map[String, String]) = copy[A](headers = this.headers ++ headers)
+  def withTimeout(timeout: FiniteDuration) = copy[A](timeout = timeout)
+  def withBaseUri(uri: URI) = copy[A](baseUri = Option(uri))
+  def withBaseUriIfNone(uri: URI) = baseUri.map(_ => this).getOrElse(withBaseUri(uri))
+
+  override lazy val absoluteUri: Option[URI] = baseUri match {
+    case Some(uri) => Some(resourcePath.map(path => uri.buildUpon.appendEncodedPath(path).build).getOrElse(uri))
+    case None => None
+  }
 }
 
 object Request {
@@ -70,20 +80,50 @@ object Request {
 
   val EmptyHeaders = Map[String, String]()
 
-  def Post[A: ContentEncoder](path: String, data: A, uploadCallback: Option[ProgressCallback] = None, requiresAuthentication: Boolean = true, headers: Map[String, String] = EmptyHeaders, timeout: FiniteDuration = AsyncClient.DefaultTimeout) =
-    Request[A](PostMethod, Some(path), data = Some(data), uploadCallback = uploadCallback, requiresAuthentication = requiresAuthentication, headers = headers, timeout = timeout)
+  def Post[A: ContentEncoder](path: String,
+                              data: A,
+                              baseUri: Option[URI] = None,
+                              uploadCallback: Option[ProgressCallback] = None,
+                              requiresAuthentication: Boolean = true,
+                              headers: Map[String, String] = EmptyHeaders,
+                              timeout: FiniteDuration = AsyncClient.DefaultTimeout) =
+    Request[A](PostMethod, resourcePath = Some(path), baseUri = baseUri, data = Some(data),
+               uploadCallback = uploadCallback, requiresAuthentication = requiresAuthentication,
+               headers = headers, timeout = timeout)
 
-  def Put[A: ContentEncoder](path: String, data: A, uploadCallback: Option[ProgressCallback] = None, requiresAuthentication: Boolean = true, headers: Map[String, String] = EmptyHeaders) =
-    Request[A](PutMethod, Some(path), data = Some(data), uploadCallback = uploadCallback, requiresAuthentication = requiresAuthentication, headers = headers)
+  def Put[A: ContentEncoder](path: String,
+                             data: A,
+                             baseUri: Option[URI] = None,
+                             uploadCallback: Option[ProgressCallback] = None,
+                             requiresAuthentication: Boolean = true,
+                             headers: Map[String, String] = EmptyHeaders) =
+    Request[A](PutMethod, resourcePath = Some(path), baseUri = baseUri, data = Some(data),
+               uploadCallback = uploadCallback, requiresAuthentication = requiresAuthentication,
+               headers = headers)
 
-  def Delete[A: ContentEncoder](path: String, data: Option[A] = None, requiresAuthentication: Boolean = true, headers: Map[String, String] = EmptyHeaders) =
-    Request[A](DeleteMethod, Some(path), data = data, requiresAuthentication = requiresAuthentication, headers = headers)
+  def Delete[A: ContentEncoder](path: String,
+                                data: Option[A] = None,
+                                baseUri: Option[URI] = None,
+                                requiresAuthentication: Boolean = true,
+                                headers: Map[String, String] = EmptyHeaders) =
+    Request[A](DeleteMethod, resourcePath = Some(path), baseUri = baseUri, data = data, requiresAuthentication = requiresAuthentication, headers = headers)
 
-  def Get(path: String, downloadCallback: Option[ProgressCallback] = None, requiresAuthentication: Boolean = true, headers: Map[String, String] = EmptyHeaders) =
-    Request[Unit](GetMethod, Some(path), downloadCallback = downloadCallback, requiresAuthentication = requiresAuthentication, headers = headers)(EmptyContentEncoder)
+  def Get(path: String,
+          baseUri: Option[URI] = None,
+          downloadCallback: Option[ProgressCallback] = None,
+          requiresAuthentication: Boolean = true,
+          headers: Map[String, String] = EmptyHeaders,
+          timeout: FiniteDuration = AsyncClient.DefaultTimeout) =
+    Request[Unit](GetMethod, resourcePath = Some(path), baseUri = baseUri, downloadCallback = downloadCallback,
+                  requiresAuthentication = requiresAuthentication, headers = headers, timeout = timeout)(EmptyContentEncoder)
 
-  def Head(path: String, downloadCallback: Option[ProgressCallback] = None, requiresAuthentication: Boolean = true, headers: Map[String, String] = EmptyHeaders) =
-    Request[Unit](HeadMethod, Some(path), downloadCallback = downloadCallback, requiresAuthentication = requiresAuthentication, headers = headers)(EmptyContentEncoder)
+  def Head(path: String,
+           baseUri: Option[URI] = None,
+           downloadCallback: Option[ProgressCallback] = None,
+           requiresAuthentication: Boolean = true,
+           headers: Map[String, String] = EmptyHeaders) =
+    Request[Unit](HeadMethod, resourcePath = Some(path), baseUri = baseUri, downloadCallback = downloadCallback,
+                  requiresAuthentication = requiresAuthentication, headers = headers)(EmptyContentEncoder)
 
   def query(path: String, args: (String, Any)*): String = {
     args map {
@@ -207,6 +247,10 @@ object ContentEncoder {
 
   implicit object GzippedContentEncoder extends ContentEncoder[GzippedRequestContent] {
     override def apply(data: GzippedRequestContent) = data
+  }
+
+  implicit object StreamedContentEncoder extends ContentEncoder[StreamRequestContent] {
+    override def apply(data: StreamRequestContent) = data
   }
 
   implicit object EmptyContentEncoder extends ContentEncoder[Unit] {

--- a/zmessaging/src/main/scala/com/waz/znet/WebSocketClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/WebSocketClient.scala
@@ -118,14 +118,14 @@ class WebSocketClient(context: Context,
       req.setHeader("Accept-Encoding", "identity") // XXX: this is a hack for Backend In The Box problem: 'Accept-Encoding: gzip' header causes 500
       req.setHeader("User-Agent", client.userAgent)
 
-      CancellableFuture.lift(client.client) flatMap { client =>
+      CancellableFuture.lift(client.wrapper) flatMap { client =>
         val f = client.websocket(req, null, new WebSocketConnectCallback {
           override def onCompleted(ex: Exception, socket: WebSocket): Unit = {
             debug(s"WebSocket request finished, ex: $ex, socket: $socket")
             p.tryComplete(if (ex == null) Try(onConnected(socket)) else Failure(ex))
           }
         })
-        returning(new CancellableFuture(p).withTimeout(30.seconds)) { _.onFailure { case _ => f.cancel(true) } }
+        returning(new CancellableFuture(p).withTimeout(30.seconds)) { _.onFailure { case _ => f.cancel() } }
       }
     case Left(status) =>
       CancellableFuture.failed(new Exception(s"Authentication returned error status: $status"))


### PR DESCRIPTION
There are now wrappers on AsyncHttpClient, AsyncHttpRequest and AsyncHttpResponse, and worker classes taking care of processing the request and the response, so they can be mocked in tests. The Request and Response case classes can be converted to respective AsyncHttp* classes and so they are used directly in AsyncClient. The Request class is now used  to transport all data needed for AsyncClient. Building requests and processing responses were taken out from AsyncClient, so now they can be mocked and we can write Android-free unit tests for AsyncClient.