### PR TITLE
removes the AsyncHttpClient's timeout; we use our own

### DIFF
--- a/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
@@ -69,7 +69,7 @@ class AsyncClientImpl(bodyDecoder: ResponseBodyDecoder = DefaultResponseBodyDeco
       @volatile var timeoutForPhase = requestTimeout
       val interval = 5.seconds min request.timeout
 
-      val requestBuilt = requestWorker.processRequest(request.withTimeout(timeoutForPhase))
+      val requestBuilt = requestWorker.processRequest(request.withTimeout(0.millis)) // switching off the AsyncHttpClient's timeout - we will use our own
 
       val httpFuture = client.execute(requestBuilt, new HttpConnectCallback {
         override def onConnectCompleted(ex: Exception, response: AsyncHttpResponse): Unit = {


### PR DESCRIPTION
The internal AsyncHttpClient's timeout may interfere in situations when the download is slow, but steady. In such situations our "smart" timeout, on the AsyncClient level, is not triggered, but the AsyncHttpClient's one may still be. 
And it's not needed anyway.