### PR TITLE
[AN-5266] ephemeral images are being deleted from the storage

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -195,7 +195,7 @@ class AssetServiceImpl(storage: AssetsStorage, generator: ImageAssetGenerator, c
   def removeAssets(ids: Iterable[AssetId]): Future[Unit] = Future.traverse(ids)(removeSource).flatMap(_ => storage.remove(ids))
 
   def removeSource(id: AssetId): Future[Unit] = storage.get(id)
-    .collect { case Some(asset) => asset.source }
+    .collect { case Some(asset) if asset.isVideo || asset.isAudio => asset.source }
     .collect { case Some(source) => new File(source.getPath) }
     .collect { case file if file.exists() => file.delete() }
 

--- a/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
@@ -35,7 +35,6 @@ class MemoryImageCache(lru: Cache[MemoryImageCache.Key, MemoryImageCache.Entry])
   def get(id: AssetId, req: BitmapRequest, imgWidth: Int): Option[Bitmap] = Option(lru.get(Key(id, tag(req)))) flatMap {
     case BitmapEntry(bmp) if bmp.getWidth >= req.width || (imgWidth > 0 && bmp.getWidth > imgWidth) => Some(bmp)
     case _ => None
-
   }
 
   def add(id: AssetId, req: BitmapRequest, bmp: Bitmap): Unit = if (bmp != null && !bmp.isEmpty) {


### PR DESCRIPTION
Fix to AN-5266 was to delete ephemeral videos and audios form the temporary folder, but it also deleted images. If the user sent an ephemeral photo, she was not able to see it anymore in the Wire's gallery. Fixed that.