### PR TITLE
[AN-5331] Internal log

### DIFF
--- a/actors/android_app/src/main/scala/com/waz/androidactors/RemoteActorService.scala
+++ b/actors/android_app/src/main/scala/com/waz/androidactors/RemoteActorService.scala
@@ -28,6 +28,7 @@ import android.content.{Context, Intent}
 import android.net.wifi.WifiManager
 import com.typesafe.config.ConfigFactory
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.GlobalPreferences
 import com.waz.content.Preferences.PrefKey
 import com.waz.provision.RemoteProcessActor
@@ -45,7 +46,6 @@ class RemoteActorService(context: Context) {
   import Threading.Implicits.Background
   import android.os.Build._
   import com.waz.utils.events.EventContext.Implicits.global
-  private implicit val tag: LogTag = logTagFor[RemoteActorService]
   val prefs = GlobalPreferences(context)
 
   val background  = prefs.preference(PrefKey[Boolean]("background", false))

--- a/build.sbt
+++ b/build.sbt
@@ -371,6 +371,7 @@ lazy val macrosupport = project
     crossPaths := false,
     exportJars := true,
     name := "zmessaging-android-macrosupport",
+    sourceGenerators in Compile += generateDebugMode.taskValue,
     bintrayRepository := "releases",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % (scalaVersion in ThisBuild).value % Provided,
@@ -389,6 +390,23 @@ generateZmsVersion in zmessaging := {
                   |   public static final boolean DEBUG = %b;
                   |}
                 """.stripMargin.format(version.value, avsVersion, MajorVersion, sys.env.get("BUILD_NUMBER").isEmpty || sys.props.getOrElse("debug", "false").toBoolean)
+  IO.write(file, content)
+  Seq(file)
+}
+
+generateDebugMode in macrosupport := {
+  val file = (sourceManaged in Compile in macrosupport).value / "com"/ "waz" / "DebugMode.scala"
+  val content = """package com.waz
+                  |
+                  |import scala.reflect.macros.blackbox.Context
+                  |
+                  |object DebugMode {
+                  |  def DEBUG(c: Context) = {
+                  |    import c.universe._
+                  |    Literal(Constant(%b))
+                  |  }
+                  |}
+                """.stripMargin.format(sys.env.get("BUILD_NUMBER").isEmpty || sys.props.getOrElse("debug", "false").toBoolean)
   IO.write(file, content)
   Seq(file)
 }

--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -42,6 +42,7 @@ object SharedSettings {
 
   lazy val androidSdkDir = settingKey[File]("Android sdk dir from ANDROID_HOME")
   lazy val generateZmsVersion = taskKey[Seq[File]]("generate ZmsVersion.java")
+  lazy val generateDebugMode = taskKey[Seq[File]]("generate DebugMode.scala")
   lazy val generateCredentials = taskKey[Seq[File]]("generate InternalCredentials.scala")
   lazy val actorsResources = taskKey[File]("Creates resources zip for remote actor")
   lazy val nativeLibs = taskKey[Classpath]("directories containing native libs for osx and linux build")

--- a/tests/app/src/main/scala/com/waz/testapp/EmptyTestActivity.scala
+++ b/tests/app/src/main/scala/com/waz/testapp/EmptyTestActivity.scala
@@ -28,6 +28,7 @@ import android.view.View
 import android.view.View.OnClickListener
 import android.widget.{Button, ImageView}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.BitmapCallback
 import com.waz.api.BitmapCallback.BitmapLoadingFailed
 import com.waz.api._
@@ -37,7 +38,6 @@ import com.waz.utils.{wrappers, _}
 import com.waz.utils.events.ActivityEventContext
 
 class EmptyTestActivity extends Activity with ActivityEventContext {
-  private implicit val Tag: LogTag = logTagFor[EmptyTestActivity]
   import com.waz.threading.Threading.Implicits.Ui
 
   lazy val btnCapture = findViewById(R.id.btnCapture).asInstanceOf[Button]

--- a/tests/integration/src/test/scala/com/waz/conv/ConversationsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/ConversationsSpec.scala
@@ -21,6 +21,7 @@ import java.lang.Iterable
 
 import akka.pattern.ask
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ConversationsList.ConversationCallback
 import com.waz.api.ErrorsList.{ErrorDescription, ErrorListener}
 import com.waz.api.IConversation.Type._
@@ -42,8 +43,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ConversationsSpec extends FeatureSpec with Matchers with OptionValues with ProvisionedApiSpec with ProcessActorSpec with ScalaFutures with DefaultPatienceConfig { test =>
-
-  private implicit val logTag: LogTag = logTagFor[ConversationsSpec]
 
   override val provisionFile = "/conversations.json"
 

--- a/tests/integration/src/test/scala/com/waz/provision/ProvisionedSuite.scala
+++ b/tests/integration/src/test/scala/com/waz/provision/ProvisionedSuite.scala
@@ -20,6 +20,7 @@ package com.waz.provision
 import java.io.InputStream
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.service.GlobalModule
 import com.waz.utils.JsonDecoder
 import org.json.JSONObject
@@ -31,7 +32,6 @@ import scala.io.Source
 import scala.util.Random
 
 trait ProvisionedSuite extends EmailClientSuite { suite: Suite =>
-  private implicit val logTag: LogTag = logTagFor[ProvisionedSuite]
   import com.waz.provision.ProvisionedSuite._
 
   val provisionFile: String
@@ -80,7 +80,7 @@ trait ProvisionedSuite extends EmailClientSuite { suite: Suite =>
 
   override protected def beforeAll(): Unit = {
     import com.waz.ZLog._
-    info("--- start of provisioning ----------------------------------------------------------------")(logTagFor[ProvisionedSuite])
+    info("--- start of provisioning ----------------------------------------------------------------")
     val registered = userProvs.values.map(_.register())
 
     if (registered.exists(_.isLeft)) println(s"register failed for emails: $provisionEmails: error message: ${registered.head.left.get}")
@@ -105,7 +105,7 @@ trait ProvisionedSuite extends EmailClientSuite { suite: Suite =>
       userProvs(us.head).createConv(name, ids.tail: _*)
     }
 
-    info("--- end of provisioning ------------------------------------------------------------------")(logTagFor[ProvisionedSuite])
+    info("--- end of provisioning ------------------------------------------------------------------")
 
     super.beforeAll()
   }

--- a/tests/integration/src/test/scala/com/waz/users/RegistrationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/users/RegistrationSpec.scala
@@ -25,12 +25,12 @@ import com.waz.content.GlobalPreferences.ShareContacts
 import com.waz.model.AccountData.AccountDataDao
 import com.waz.model._
 import com.waz.provision.EmailClientSuite
-import com.waz.service.{BackendConfig, ContactsService}
+import com.waz.service.{BackendConfig}
 import com.waz.testutils.{DefaultPatienceConfig, prepareAddressBookEntries}
 import com.waz.testutils.Matchers._
 import com.waz.threading.Threading
 import com.waz.utils.IoUtils
-import com.waz.znet.{AsyncClient, AsyncClientImpl, TestClientWrapper}
+import com.waz.znet.{AsyncClientImpl, TestClientWrapper}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FeatureSpec, GivenWhenThen, Matchers}
 

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -20,6 +20,7 @@ package com.waz.mocked
 import android.content.Context
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.{Credentials, ErrorResponse, PhoneCredentials}
 import com.waz.api.{OtrClient => _, _}
 import com.waz.cache.LocalData
@@ -55,7 +56,6 @@ import scala.concurrent.Future
 import scala.util.Random
 
 trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket with MockedGcm { suite: Suite with Alerting with Informing =>
-  private implicit val logTag: LogTag = logTagFor[MockedClientSuite]
 
   @volatile private var pushService = Option.empty[PushServiceImpl]
   @volatile protected var keyValueStoreOverrides = Map.empty[String, Option[String]]

--- a/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
@@ -20,6 +20,7 @@ package com.waz.api.impl
 import android.net.Uri
 import com.koushikdutta.async.http.WebSocket
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ZMessagingApi.RegistrationListener
 import com.waz.api.{ClientRegistrationState, CredentialsFactory, InitListener, LoginListener}
 import com.waz.client.RegistrationClient
@@ -266,7 +267,7 @@ class RegistrationSpec extends FeatureSpec with Matchers with OptionValues with 
       idle(1.second)
       ui.accounts.storage.update(accountId, _.copy(password = None)).futureValue
       api.account.foreach { acc =>
-        debug(s"closing db: ${acc.storage.db.dbHelper.getDatabaseName}")("RegistrationSpec")
+        debug(s"closing db: ${acc.storage.db.dbHelper.getDatabaseName}")
         acc.storage.db.close().await()
       }
       ui.accounts.ec.onContextStop()
@@ -288,7 +289,7 @@ class RegistrationSpec extends FeatureSpec with Matchers with OptionValues with 
           Response(HttpStatus(403), JsonObjectResponse(Json("code" -> 403, "message" -> "invalid credentials", "label" -> "")))
       }
 
-      debug("##### starting new api")(logTagFor[RegistrationSpec])
+      debug("##### starting new api")
 
       val api2 = new ZMessagingApi()(MockUiModule(new MockAccounts(global)))
       api2.onCreate(context)

--- a/tests/unit/src/test/scala/com/waz/db/ZMessagingDBSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/db/ZMessagingDBSpec.scala
@@ -21,13 +21,13 @@ import android.content.ContentValues
 import android.database.DatabaseUtils
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteDatabase._
-import com.waz.{Generators, ShadowLogging}
+import com.waz.Generators
 import com.waz.utils.wrappers.{DB, DBHelper, URI}
 import com.waz.api.{ContentSearchQuery, KindOfCallingEvent, Message}
 import com.waz.model.AssetData.AssetDataDao
 import com.waz.model.AssetMetaData.Image.Tag.Medium
 import com.waz.model.CallLogEntry.CallLogEntryDao
-import com.waz.model.ConversationData.{ConversationDataDao, ConversationType}
+import com.waz.model.ConversationData.ConversationDataDao
 import com.waz.model.MessageData.MessageDataDao
 import com.waz.model.MsgDeletion.MsgDeletionDao
 import com.waz.model.SearchQueryCache.SearchQueryCacheDao
@@ -37,7 +37,6 @@ import com.waz.model.sync.SyncJob.SyncJobDao
 import com.waz.model.sync.{SyncCommand, SyncJob}
 import com.waz.utils.{DbLoader, returning}
 import org.robolectric.Robolectric
-import org.robolectric.shadows.ShadowLog
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.threeten.bp.Instant

--- a/tests/unit/src/test/scala/com/waz/log/InternalLogSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/log/InternalLogSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.log
+
+import java.io.File
+
+import com.waz.api.ZmsVersion
+import com.waz.specs.AndroidFreeSpec
+
+class InternalLogSpec extends AndroidFreeSpec {
+  val tag = "InternalLogSuite"
+  val tempDir = System.getProperty("java.io.tmpdir")+"tmp"+System.nanoTime()
+
+  def tempFileName = tempDir + "/" + System.nanoTime() + ".log"
+
+  def overflow(log: BufferedLogOutput) = {
+    var prevSize = -1L
+    while (log.bufferSize > log.size && log.size > prevSize) {
+      prevSize = log.size
+      InternalLog.debug("!", tag)
+    }
+    Thread.sleep(500L) // give the buffer some time to flush
+  }
+
+  def exists(fileName: String) = new File(fileName).exists()
+
+  before {
+    InternalLog.reset()
+
+    val file = new File(tempDir)
+    if (!file.exists()) {
+      file.mkdir()
+    }
+  }
+
+  after {
+    InternalLog.reset()
+
+    val file = new File(tempDir)
+    if (file.exists()) {
+      file.delete()
+    }
+  }
+
+  feature("adding and removing log outputs") {
+    scenario("adds and removes a buffered log output") {
+      InternalLog.getOutputs.size shouldEqual(0)
+      val fileName = tempFileName
+      InternalLog.addBufferedLog(fileName)
+      InternalLog.getOutputs.size shouldEqual(1)
+
+      val log = InternalLog.get(fileName).getOrElse(fail(s"No log output: $fileName"))
+      log.isInstanceOf[BufferedLogOutput] shouldEqual(true)
+
+      InternalLog.remove(log)
+      InternalLog.getOutputs.size shouldEqual(0)
+    }
+
+    scenario("adds and removes an Android log output") {
+      InternalLog.getOutputs.size shouldEqual(0)
+      InternalLog.addAndroidLog()
+      InternalLog.getOutputs.size shouldEqual(1)
+
+      val log = InternalLog.get("android").getOrElse(fail(s"No log output for Android"))
+      log.isInstanceOf[AndroidLogOutput] shouldEqual(true)
+
+      InternalLog.remove(log)
+      InternalLog.getOutputs.size shouldEqual(0)
+    }
+
+    scenario("reset log outputs") {
+      InternalLog.getOutputs.size shouldEqual(0)
+      InternalLog.addBufferedLog(tempFileName)
+      InternalLog.addAndroidLog()
+      InternalLog.getOutputs.size shouldEqual(2)
+      InternalLog.reset()
+      InternalLog.getOutputs.size shouldEqual(0)
+    }
+  }
+
+  feature("writing logs to the buffer") {
+    scenario("creates an empty buffer") {
+      val log = InternalLog.addBufferedLog(tempFileName).asInstanceOf[BufferedLogOutput]
+      log.empty shouldEqual(true)
+    }
+
+    scenario("appends to the buffer") {
+      val log = InternalLog.addBufferedLog(tempFileName).asInstanceOf[BufferedLogOutput]
+      log.empty should equal(true)
+      InternalLog.debug("something", tag)
+      log.empty shouldEqual(false)
+    }
+
+    scenario("clears the buffer when full") {
+      val log = InternalLog.addBufferedLog(tempFileName, 128L).asInstanceOf[BufferedLogOutput]
+      log.empty shouldEqual(true)
+
+      InternalLog.debug("!", tag)
+      log.empty shouldEqual(false)
+
+      overflow(log)
+
+      log.empty shouldEqual(true)
+    }
+  }
+
+  feature("writing logs to the file") {
+    scenario("creates a log file") {
+      val fileName = tempFileName
+      exists(fileName) shouldEqual(false)
+
+      val log = InternalLog.addBufferedLog(fileName, 128L).asInstanceOf[BufferedLogOutput]
+      exists(fileName) shouldEqual(false)
+
+      overflow(log)
+
+      exists(fileName) shouldEqual(true)
+    }
+
+    scenario("appends to the log file when the buffer is full") {
+      val log = InternalLog.addBufferedLog(tempFileName, 128L).asInstanceOf[BufferedLogOutput]
+      overflow(log)
+      val fileSize1 = new File(log.fileName).length()
+      overflow(log)
+      val fileSize2 = new File(log.fileName).length()
+      fileSize2 > fileSize1 shouldEqual(true)
+    }
+  }
+
+  feature("connecting with ZLog") {
+
+    scenario("receives logs written to ZLog") {
+      ZmsVersion.DEBUG shouldEqual(true)
+      val log = InternalLog.addBufferedLog(tempFileName).asInstanceOf[BufferedLogOutput]
+      log.empty shouldEqual(true)
+
+      import com.waz.ZLog._
+      import com.waz.ZLog.ImplicitTag._
+
+      verbose("something")
+
+      log.empty shouldEqual(false)
+    }
+  }
+
+}

--- a/tests/utils/src/main/scala/com/waz/log/SystemLogOutput.scala
+++ b/tests/utils/src/main/scala/com/waz/log/SystemLogOutput.scala
@@ -15,26 +15,25 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.waz.api;
+package com.waz.log
 
-import android.util.Log;
+import com.waz.ZLog.LogTag
 
-public enum LogLevel {
-    VERBOSE(Log.VERBOSE),
-    DEBUG(Log.DEBUG),
-    INFO(Log.INFO),
-    WARN(Log.WARN),
-    ERROR(Log.ERROR),
-    ASSERT(Log.ASSERT),
-    SUPPRESS(Integer.MAX_VALUE);
+import scala.concurrent.Future
 
-    public final int priority;
+class SystemLogOutput extends LogOutput {
+  override val id = SystemLogOutput.id
 
-    public static void setMinimumLogLevel(LogLevel level) {
-        com.waz.api.impl.LogLevel.setMinimumLogLevel(level);
-    }
+  override def log(str: String, level: InternalLog.LogLevel, tag: LogTag): Unit = println(s"${InternalLog.dateTag}/$level/$tag: $str")
+  override def log(str: String, cause: Throwable, level: InternalLog.LogLevel, tag: LogTag): Unit = {
+    println(s"${InternalLog.dateTag}/$level/$tag: $str")
+    println(InternalLog.stackTrace(cause))
+  }
 
-    LogLevel(int priority) {
-        this.priority = priority;
-    }
+  override def close(): Future[Unit] = Future.successful {}
+  override def flush(): Future[Unit] = Future.successful {}
+}
+
+object SystemLogOutput {
+  val id = "system"
 }

--- a/tests/utils/src/main/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/tests/utils/src/main/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -20,10 +20,11 @@ package com.waz.specs
 import java.util.concurrent.{Executors, ThreadFactory, TimeoutException}
 
 import com.waz.ZLog.LogTag
+import com.waz.log.{InternalLog, SystemLogOutput}
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import com.waz.utils._
 import com.waz.utils.wrappers.{Intent, JVMIntentUtil, JavaURIUtil, URI, _}
-import com.waz.{HockeyApp, HockeyAppUtil, ZLog}
+import com.waz.{HockeyApp, HockeyAppUtil}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import org.threeten.bp.Instant
@@ -46,7 +47,8 @@ abstract class AndroidFreeSpec extends FeatureSpec with BeforeAndAfterAll with B
 
     isTest = true
 
-    ZLog.setTestLogging()
+    InternalLog.reset()
+    InternalLog.add(new SystemLogOutput)
 
     Intent.setUtil(JVMIntentUtil)
 

--- a/tests/utils/src/main/scala/org/robolectric/shadows/ShadowMediaMetadataRetriever2.scala
+++ b/tests/utils/src/main/scala/org/robolectric/shadows/ShadowMediaMetadataRetriever2.scala
@@ -28,6 +28,7 @@ import com.coremedia.iso.boxes.{Box, TrackBox}
 import com.googlecode.mp4parser.FileDataSourceImpl
 import com.googlecode.mp4parser.util.{Matrix, Path}
 import com.waz.ZLog
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.IoUtils
 import org.robolectric.annotation.{Implementation, Implements, Resetter}
 
@@ -87,7 +88,7 @@ class ShadowMediaMetadataRetriever2 {
       (tb.getWidth.toInt, tb.getHeight.toInt, rotation)
     }
 
-    ZLog.debug(s"getMeta, duration: $duration, dimens: $dimens")("ShadowMediaMetadataRetriever")
+    ZLog.debug(s"getMeta, duration: $duration, dimens: $dimens")
 
     Map(
       MediaMetadataRetriever.METADATA_KEY_DURATION -> duration.toMillis.toString,
@@ -100,13 +101,13 @@ class ShadowMediaMetadataRetriever2 {
   }
 
   @Implementation def setDataSource(path: String): Unit = {
-    ZLog.debug(s"getMeta, setDataSource $path")("ShadowMediaMetadataRetriever")
+    ZLog.debug(s"getMeta, setDataSource $path")
     meta = metadata.getOrElse(path, getMeta(new FileInputStream(path))).toMap
     frame = frames.getOrElse(path, Map.empty).toMap
   }
 
   @Implementation def setDataSource(context: Context, uri: Uri): Unit = {
-    ZLog.debug(s"getMeta, setDataSource $uri")("ShadowMediaMetadataRetriever")
+    ZLog.debug(s"getMeta, setDataSource $uri")
     meta = metadata.getOrElse(uri.toString, getMeta(context.getContentResolver.openInputStream(uri))).toMap
     frame = frames.getOrElse(uri.toString, Map.empty).toMap
   }

--- a/zmessaging/src/main/scala/com/waz/PermissionsService.scala
+++ b/zmessaging/src/main/scala/com/waz/PermissionsService.scala
@@ -22,6 +22,7 @@ import java.util
 import android.content.Context
 import android.support.v4.content.ContextCompat
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Permission.Status
 import com.waz.api.Permission.Status._
 import com.waz.api.{Permission, PermissionProvider}
@@ -32,10 +33,8 @@ import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 
 class PermissionsService(context: Context) {
-  private implicit val logTag: LogTag = logTagFor[PermissionsService]
   private val providers = Signal(Vector.empty[PermissionProvider])
   private val providerSignal = providers.map(_.lastOption)
-
 
   def setProvider(p: PermissionProvider): Unit = {
     Threading.assertUiThread()

--- a/zmessaging/src/main/scala/com/waz/api/Credentials.scala
+++ b/zmessaging/src/main/scala/com/waz/api/Credentials.scala
@@ -21,10 +21,9 @@ import com.waz.model.{ConfirmationCode, PhoneNumber, EmailAddress}
 import org.json.JSONObject
 import com.waz.model.PersonalInvitationToken
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 
 object CredentialsFactory {
-  private implicit val logTag: LogTag = logTagFor(CredentialsFactory)
-
   def emailCredentials(email: String, password: String): Credentials = impl.EmailCredentials(EmailAddress(email), Option(password))
   def phoneCredentials(phone: String, confirmationCode: String): Credentials = {
     assert(Option(confirmationCode).exists(_.nonEmpty), "Empty/missing phone confirmation code. Please always pass a phone confirmation code here.")

--- a/zmessaging/src/main/scala/com/waz/api/impl/Asset.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Asset.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.Asset.LoadCallback
 import com.waz.model.AssetMetaData.{HasDimensions, HasDuration, Loudness}
@@ -93,7 +94,6 @@ class Asset(id: AssetId, msg: MessageId)(implicit ui: UiModule) extends BaseAsse
 }
 
 object Asset {
-  private implicit val logTag: LogTag = logTagFor[Asset]
 
   object Empty extends BaseAsset {
     protected override def asset = AssetData.Empty

--- a/zmessaging/src/main/scala/com/waz/api/impl/AssetForUpload.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/AssetForUpload.scala
@@ -21,6 +21,7 @@ import java.io.{File, InputStream}
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.Asset.LoadCallback
 import com.waz.api.AudioEffect
@@ -49,7 +50,6 @@ abstract class AssetForUpload(val id: AssetId) extends api.AssetForUpload {
   def openDataStream(context: Context): InputStream
 }
 object AssetForUpload {
-  private implicit val Tag: LogTag = logTagFor[AssetForUpload]
 
   def apply(i: AssetId, n: Option[String], m: Mime, s: Option[Long])(f: Context => InputStream): AssetForUpload = new AssetForUpload(i) {
     override val name = successful(n)
@@ -86,8 +86,6 @@ case class AudioAssetForUpload(override val id: AssetId, data: CacheEntry, durat
   override def getPlaybackControls: api.PlaybackControls = new PlaybackControls(AssetMediaKey(id), PCMContent(data.cacheFile), _ => Signal.const(duration))(ZMessaging.currentUi)
   override def getDuration: bp.Duration = duration
 
-  private implicit def logTag: LogTag = logTagFor[AudioAssetForUpload]
-
   override def delete(): Unit = {
     verbose(s"delete() $this")
     data.delete()
@@ -99,7 +97,7 @@ case class AudioAssetForUpload(override val id: AssetId, data: CacheEntry, durat
       case Success(asset) =>
         callback.onLoaded(asset)
       case Failure(cause) =>
-        error("effect application failed", cause)(logTagFor[AudioAssetForUpload])
+        error("effect application failed", cause)
         callback.onLoadFailed()
     }(Threading.Ui)
   }

--- a/zmessaging/src/main/scala/com/waz/api/impl/Contacts.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Contacts.scala
@@ -20,6 +20,7 @@ package com.waz.api.impl
 import java.util.{Collection, Locale}
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model._
 import com.waz.service.ContactsService.{TopContactsOnWire, UnifiedContacts}
 import com.waz.service.SearchKey
@@ -36,8 +37,6 @@ import scala.concurrent.duration._
 
 class Contacts(filtering: ContactsFiltering)(implicit ui: UiModule) extends api.Contacts with CoreList[api.Contact] with SignalLoading {
   import Contacts._
-
-  private implicit val logTag: LogTag = logTagFor[Contacts] + "@" + Integer.toHexString(hashCode)
 
   private val search = Signal(filtering.initial)
   private var content = Content(UnifiedContacts(Map.empty, Map.empty, Vector.empty, SeqMap.empty, TopContactsOnWire(Vector.empty, 0)), Vector.empty,

--- a/zmessaging/src/main/scala/com/waz/api/impl/Conversation.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Conversation.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.conversation.BaseConversation
 import com.waz.content.UsersStorageImpl
 import com.waz.model.ConversationData.ConversationType
@@ -33,7 +34,6 @@ class Conversation(override val id: ConvId, val initData: ConversationData = Con
   import Threading.Implicits.Background
 
   def this(data: ConversationData)(implicit ui: UiModule) = this(data.id, data)
-  private implicit val logTag: LogTag = logTagFor[Conversation]
   private var convIsOtto = false
 
   set(initData)

--- a/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
@@ -21,6 +21,7 @@ import java.lang.Iterable
 
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.ConversationsList.{ConversationCallback, VerificationStateCallback}
 import com.waz.api.impl.ConversationsListState.Data
@@ -40,7 +41,6 @@ import scala.collection.JavaConverters._
 
 class ConversationsList(implicit val ui: UiModule) extends api.ConversationsList with BaseConversationsList {
   import ConversationsList._
-  private implicit val logTag: LogTag = logTagFor[ConversationsList]
 
   lazy val incoming = new SearchableConversationsList(conversations, IncomingListFilter)
 
@@ -117,8 +117,6 @@ class SearchableConversationsList(val conversations: Conversations, override val
   extends com.waz.api.ConversationsList.SearchableConversationsList with BaseConversationsList
 
 class ConversationsListState(implicit ui: UiModule) extends com.waz.api.ConversationsList.ConversationsListState with UiObservable with SignalLoading {
-  private implicit val logTag: LogTag = logTagFor[ConversationsListState]
-
   var data = Data()
 
   addLoader(_.convsStats.state) { data =>

--- a/zmessaging/src/main/scala/com/waz/api/impl/Giphy.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Giphy.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.model.AssetData
 import com.waz.service.media.GiphyService
@@ -26,7 +27,6 @@ import com.waz.ui.UiModule
 
 class Giphy(implicit ui: UiModule) extends com.waz.api.Giphy {
   import Threading.Implicits.Background
-  private implicit val tag = logTagFor[Giphy]
   
   override def random() = executeGiphyRequest((g, _, _) => g.getRandomGiphyImage)
 

--- a/zmessaging/src/main/scala/com/waz/api/impl/IncomingMessages.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/IncomingMessages.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.IncomingMessagesList.MessageListener
 import com.waz.model.MessageData
@@ -27,8 +28,6 @@ import com.waz.utils._
 import org.threeten.bp.Instant
 
 class IncomingMessages(implicit context: UiModule) extends com.waz.api.IncomingMessagesList with CoreList[api.Message] with SignalLoading {
-
-  private implicit val logTag: LogTag = logTagFor[IncomingMessages]
 
   private var listeners = List[MessageListener]()
   private var messages = Array[(MessageData, Int)]()

--- a/zmessaging/src/main/scala/com/waz/api/impl/InputStateIndicator.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/InputStateIndicator.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.InputStateIndicator.KnockState
 import com.waz.api.UsersList
@@ -27,8 +28,6 @@ import com.waz.ui.{SignalLoading, UiModule}
 import com.waz.utils.events.EventContext
 
 class InputStateIndicator(conv: ConvId)(implicit ui: UiModule) extends api.InputStateIndicator with UiObservable with SignalLoading  {
-
-  private implicit val logTag: LogTag = logTagFor[InputStateIndicator]
   import Threading.Implicits.Background
   private implicit val ev = EventContext.Global
   private val typingUsers = new TypingUsersList(conv)

--- a/zmessaging/src/main/scala/com/waz/api/impl/Invitations.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Invitations.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Invitations._
 import com.waz.client.RegistrationClient
 import com.waz.model.PersonalInvitationToken
@@ -30,7 +31,6 @@ import com.waz.utils._
 import scala.util.{Failure, Success}
 
 class Invitations(zms: ZMessagingResolver, convs: => Conversations, regClient: => RegistrationClient) extends com.waz.api.Invitations {
-  private implicit val logTag: LogTag = logTagFor[Invitations]
 
   override def generateInvitationUri(callback: InvitationUriCallback): Unit = zms.flatMapFuture(_.invitations.generateInvitationUri())(Threading.Background).map {
     case Some(uri) => callback.onInvitationGenerated(uri)

--- a/zmessaging/src/main/scala/com/waz/api/impl/LogLevel.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/LogLevel.scala
@@ -20,7 +20,10 @@ package com.waz.api.impl
 import com.waz.{api, ZLog}
 
 object LogLevel {
-  val initialized = () == (if (! api.ZmsVersion.DEBUG) ZLog.minimumLogLevel = api.LogLevel.WARN.priority)
+  lazy val initialized = {
+    if (! api.ZmsVersion.DEBUG) setMinimumLogLevel(android.util.Log.WARN)
+    true
+  }
 
-  def setMinimumLogLevel(level: api.LogLevel): Unit = ZLog.minimumLogLevel = level.priority
+  def setMinimumLogLevel(level: Int): Unit = ZLog.minimumLogLevel = level
 }

--- a/zmessaging/src/main/scala/com/waz/api/impl/Message.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Message.scala
@@ -20,6 +20,7 @@ package com.waz.api.impl
 import android.os.Parcel
 import com.waz.Control.getOrUpdate
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.Message.{Part, Status, Type}
 import com.waz.api.MessageContent.{Location, Text}
@@ -42,7 +43,6 @@ import scala.collection.breakOut
 
 class Message(val id: MessageId, var data: MessageData, var likes: IndexedSeq[UserId], var likedBySelf: Boolean)(implicit context: UiModule) extends api.Message with SignalLoading with UiObservable {
 
-  private implicit val logTag: LogTag = logTagFor[Message]
   private val convId = if (data == MessageData.Empty) Signal[ConvId]() else Signal(data.convId)
   private var parts = Array.empty[Part]
   private var lastMessageFromSelf = false

--- a/zmessaging/src/main/scala/com/waz/api/impl/MessagesList.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/MessagesList.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.content.Uris.SyncIndicatorUri
 import com.waz.content.{MessagesCursor, Uris}
@@ -35,7 +36,6 @@ import org.threeten.bp.Instant
 import scala.concurrent.Future
 
 class MessagesList(convId: ConvId)(implicit ui: UiModule) extends com.waz.api.MessagesList with CoreList[api.Message] with SignalLoading { list =>
-  private implicit val logTag: LogTag = logTagFor[MessagesList]
 
   var lastRead = Instant.EPOCH
 

--- a/zmessaging/src/main/scala/com/waz/api/impl/Self.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Self.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api._
 import com.waz.api.impl.otr.OtrClients
@@ -35,7 +36,6 @@ class Self()(implicit ui: UiModule) extends com.waz.api.Self with UiObservable w
 
   var data = Option.empty[AccountData]
 
-  private implicit val logTag: LogTag = logTagFor[Self]
   private var upToDate = true
 
   private def users = ui.users

--- a/zmessaging/src/main/scala/com/waz/api/impl/Spotify.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Spotify.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.KindOfSpotifyAccount
 import com.waz.api.Spotify.ConnectCallback
@@ -28,8 +29,6 @@ import com.waz.threading.Threading
 import com.waz.ui.{SignalLoading, UiModule}
 
 class Spotify(implicit context: UiModule) extends api.Spotify with UiObservable with SignalLoading {
-  private implicit lazy val logTag: LogTag = logTagFor[Spotify]
-
   private var auth = Option.empty[Authentication]
 
   addLoader((_: ZMessaging).spotifyMedia.authentication)(setAuthentication)

--- a/zmessaging/src/main/scala/com/waz/api/impl/UiObservable.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/UiObservable.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.{Subscriber, Subscription, UpdateListener}
 import com.waz.service.{AccountService, ZMessaging}
 import com.waz.threading.Threading
@@ -25,8 +26,6 @@ import com.waz.ui.{SignalLoading, UiModule}
 import com.waz.utils.events.Signal
 
 trait UiObservable extends com.waz.api.UiObservable {
-  private implicit val logTag: LogTag = logTagFor[UiObservable]
-
   private val updateListeners = new ListenerList[UpdateListener]
 
   override def addUpdateListener(listener: UpdateListener): Unit = updateListeners.add(listener)

--- a/zmessaging/src/main/scala/com/waz/api/impl/User.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/User.scala
@@ -19,6 +19,7 @@ package com.waz.api.impl
 
 import android.os.Parcel
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api._
 import com.waz.api.impl.otr.OtrClients
@@ -32,8 +33,6 @@ class User(val id: UserId, var data: UserData)(implicit ui: UiModule) extends co
 
   def this(id: UserId)(implicit ui: UiModule) = this(id, UserData(id, ""))
   def this(data: UserData)(implicit ui: UiModule) = this(data.id, data)
-
-  import User._
 
   require(id == data.id)
 
@@ -152,10 +151,6 @@ class User(val id: UserId, var data: UserData)(implicit ui: UiModule) extends co
   override def getUsername: String = data.handle.fold("")(_.string)
 
   override def getCommonConnectionsCount = getCommonConnections.getTotalCount //TODO: STUB
-}
-
-object User {
-  private implicit val logTag: LogTag = logTagFor[User]
 }
 
 object EmptyUser extends com.waz.api.User {

--- a/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
@@ -20,6 +20,7 @@ package com.waz.api.impl
 import android.content.Context
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.PermissionProvider
 import com.waz.api.ZMessagingApi.{PhoneConfirmationCodeRequestListener, PhoneNumberVerificationListener, RegistrationListener}
@@ -39,7 +40,6 @@ import scala.util.{Failure, Success, Try}
 class ZMessagingApi(implicit val ui: UiModule) extends com.waz.api.ZMessagingApi {
 
   import Threading.Implicits.Ui
-  private implicit val logTag: LogTag = logTagFor[ZMessagingApi]
 
   private[waz] var account: Option[AccountService] = None
   private[waz] def zmessaging = account match {

--- a/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
@@ -19,6 +19,7 @@ package com.waz.api.impl.conversation
 
 import android.os.Parcel
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.impl._
 import com.waz.api.{EphemeralExpiration, IConversation, MessageContent, Verification}
@@ -154,14 +155,13 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 }
 
 object BaseConversation {
-  implicit val logTag: LogTag = logTagFor[BaseConversation]
 
   lazy val UnknownName = Try(ZMessaging.context.getResources.getString(com.waz.zms.R.string.zms_unknown_conversation_name)).getOrElse("…")
 
   private def conversationName(data: ConversationData) = {
     val name = if (data.convType == IConversation.Type.GROUP) data.name.filter(!_.isEmpty).getOrElse(data.generatedName) else data.generatedName
     if (name.isEmpty) {
-      warn(s"Name is empty for: $data")(logTagFor[Conversation])
+      warn(s"Name is empty for: $data")
       UnknownName
     } else name
   }

--- a/zmessaging/src/main/scala/com/waz/api/impl/otr/OtrClients.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/otr/OtrClients.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 
 import android.os.Parcel
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.OtrClient.{DeleteCallback, ResetCallback}
 import com.waz.api.impl.{CoreList, ErrorResponse, UiObservable, UiSignal}
@@ -41,7 +42,6 @@ import scala.collection.breakOut
 import scala.concurrent.Future
 
 class OtrClients(signal: AccountService => Signal[(UserId, Vector[Client])])(implicit ui: UiModule) extends CoreList[ApiClient] with SignalLoading {
-  import OtrClients._
   private var items = IndexedSeq.empty[OtrClient]
 
   accountLoader(signal) { case (user, clients) =>
@@ -58,7 +58,6 @@ class OtrClients(signal: AccountService => Signal[(UserId, Vector[Client])])(imp
 
 object OtrClients {
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[OtrClients]
 
   // ascending by model and desc by time
   // clients for other users will always have model and time empty, in that case we sort by id
@@ -206,8 +205,6 @@ class OtrClient(val userId: UserId, val clientId: ClientId, var data: Client)(im
 }
 
 object OtrClient {
-  private implicit val tag: LogTag = logTagFor[OtrClient]
-
   def fromParcel(p: Parcel)(implicit ui: UiModule): OtrClient = {
     import JsonDecoder._
     implicit val js = new JSONObject(p.readString())

--- a/zmessaging/src/main/scala/com/waz/api/impl/search/ConversationSearchResult.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/search/ConversationSearchResult.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl.search
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.IConversation
 import com.waz.api.impl.CoreList
@@ -28,7 +29,6 @@ import com.waz.utils.events.Signal
 
 class ConversationSearchResult(prefix: String, limit: Int, handleOnly: Boolean)(implicit ui: UiModule) extends api.ConversationSearchResult with CoreList[IConversation] with SignalLoading {
   import com.waz.threading.Threading.Implicits.Background
-  private implicit val tag = logTagFor[ConversationSearchResult]
 
   @volatile private var convs = Option.empty[Vector[ConvId]]
 

--- a/zmessaging/src/main/scala/com/waz/api/impl/search/UserSearchResult.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/search/UserSearchResult.scala
@@ -18,6 +18,7 @@
 package com.waz.api.impl.search
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.impl.CoreList
 import com.waz.model.SearchQuery.TopPeople
@@ -26,8 +27,6 @@ import com.waz.ui.{SignalLoading, UiModule}
 import com.waz.utils.SeqMap
 
 class UserSearchResult(query: SearchQuery = TopPeople, limit: Int, filter: Set[String])(implicit val ui: UiModule) extends api.UserSearchResult with CoreList[api.User] with SignalLoading {
-  import UserSearchResult._
-
   private var users = Option.empty[SeqMap[UserId, UserData]]
 
   addLoader(_.userSearch.searchUserData(query, Some(limit + filter.size)), SeqMap.empty[UserId, UserData]) { us =>
@@ -42,8 +41,4 @@ class UserSearchResult(query: SearchQuery = TopPeople, limit: Int, filter: Set[S
   override def get(position: Int): api.User = ui.users.getUser(currentUsers at position)
   override def size: Int = currentUsers.size
   override def getAll: Array[api.User] = currentUsers.valuesIterator.map(ui.users.getUser).toArray
-}
-
-object UserSearchResult {
-  private implicit val tag: LogTag = logTagFor[UserSearchResult]
 }

--- a/zmessaging/src/main/scala/com/waz/bitmap/BitmapDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/BitmapDecoder.scala
@@ -22,6 +22,7 @@ import java.io.{File, InputStream}
 import android.graphics.BitmapFactory.Options
 import android.graphics.BitmapFactory
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils._
 import com.waz.utils.wrappers.Bitmap
@@ -30,7 +31,6 @@ import com.waz.utils.wrappers
 class BitmapDecoder {
 
   private implicit lazy val dispatcher = Threading.ImageDispatcher
-  private implicit val logTag: LogTag = logTagFor[BitmapDecoder]
 
   def factoryOptions(sampleSize: Int) = returning(new Options) { opts =>
     opts.inSampleSize = sampleSize

--- a/zmessaging/src/main/scala/com/waz/bitmap/BitmapUtils.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/BitmapUtils.scala
@@ -23,11 +23,10 @@ import android.graphics.Bitmap.Config
 import android.graphics._
 import android.media.ExifInterface
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.IoUtils
 
 object BitmapUtils {
-
-  private implicit val logTag: LogTag = logTagFor(BitmapUtils)
 
   object Mime {
     val Gif = "image/gif"

--- a/zmessaging/src/main/scala/com/waz/bitmap/ExifOrientation.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/ExifOrientation.scala
@@ -20,6 +20,7 @@ package com.waz.bitmap
 import java.io.InputStream
 import android.media.ExifInterface
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 
 import scala.util.control.NonFatal
 
@@ -28,8 +29,6 @@ import scala.util.control.NonFatal
  * TODO: make it prettier
  */
 object ExifOrientation {
-  private implicit val tag: LogTag = logTagFor(ExifOrientation)
-
   def apply(in: InputStream): Int = try {
 
     def readShort(be: Boolean = true) =

--- a/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder.scala
@@ -25,6 +25,7 @@ import android.media._
 import android.os.Build
 import android.view.Surface
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ProgressIndicator.{ProgressData, ProgressReporter}
 import com.waz.bitmap.video.VideoTranscoder.CodecResponse._
 import com.waz.bitmap.video.VideoTranscoder.{CodecResponse, MediaCodecIterator}
@@ -42,7 +43,6 @@ trait VideoTranscoder {
 }
 
 object VideoTranscoder {
-  implicit val tag: LogTag = logTagFor[VideoTranscoder]
 
   val BaseVideoSize = 320
   val MaxFileSizeBytes = 20 * 1024 * 1024 // smaller than backend limit to account for audio and other overhead

--- a/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder18.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder18.scala
@@ -23,6 +23,7 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.media.{MediaCodec, MediaExtractor, MediaFormat, MediaMuxer}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap.video.VideoTranscoder.CodecResponse.{CodecBuffer, FormatChanged, TryAgain}
 import com.waz.bitmap.video.VideoTranscoder.{MediaCodecIterator, OutputWriter}
 import com.waz.utils.{Cleanup, Managed, returning}
@@ -81,8 +82,6 @@ class VideoTranscoder18(context: Context) extends BaseTranscoder(context) {
 
 @TargetApi(18)
 class MuxerWriter(muxer: MediaMuxer, sources: MediaCodecIterator*) extends OutputWriter {
-  private implicit val tag: LogTag = logTagFor[MuxerWriter]
-
   case class SourceWithTrack(source: MediaCodecIterator, var track: Option[Int] = None, var positionMs: Long = 0)
 
   private val withTracks = sources.map { SourceWithTrack(_) }

--- a/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.cache.CacheEntryData.CacheEntryDao
 import com.waz.cache.CacheStorage.EntryCache
 import com.waz.content.Database
@@ -39,7 +40,6 @@ class CacheStorageImpl(storage: Database, context: Context) extends CachedStorag
   import com.waz.cache.CacheStorage._
   import com.waz.utils.events.EventContext.Implicits.global
 
-  private implicit val logTag: LogTag = logTagFor[CacheStorage]
   private implicit val dispatcher = new SerialDispatchQueue(name = "CacheStorage")
 
   onUpdated { _ foreach {

--- a/zmessaging/src/main/scala/com/waz/client/RegistrationClient.scala
+++ b/zmessaging/src/main/scala/com/waz/client/RegistrationClient.scala
@@ -18,6 +18,7 @@
 package com.waz.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.{Credentials, ErrorResponse, PhoneCredentials}
 import com.waz.api.{KindOfAccess, KindOfVerification}
 import com.waz.model._
@@ -40,7 +41,6 @@ import scala.concurrent.duration._
 class RegistrationClient(client: AsyncClient, backend: BackendConfig) {
   import Threading.Implicits.Background
   import com.waz.client.RegistrationClient._
-  private implicit val tag: LogTag = logTagFor[RegistrationClient]
 
   def register(userId: AccountId, credentials: Credentials, name: String, accentId: Option[Int]): ErrorOrResponse[(UserInfo, Option[Cookie])] = {
     val json = JsonEncoder { o =>
@@ -133,7 +133,7 @@ class RegistrationClient(client: AsyncClient, backend: BackendConfig) {
         warn(s"invitation token not found: $token")
         Left(ErrorResponse(NotFound, "no such invitation code", "invalid-invitation-code"))
       case other =>
-        ZNetClient.errorHandling("getInvitationInfo")(tag)(other)
+        ZNetClient.errorHandling("getInvitationInfo")("RegistrationClient")(other)
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/content/AccountsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/AccountsStorage.scala
@@ -18,7 +18,6 @@
 package com.waz.content
 
 import android.content.Context
-import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.{Credentials, EmailCredentials, PhoneCredentials}
 import com.waz.model.AccountData.AccountDataDao
 import com.waz.model._

--- a/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesCursor.scala
@@ -20,6 +20,7 @@ package com.waz.content
 import android.support.v4.util.LruCache
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.MessagesCursor.Entry
 import com.waz.db.{CursorIterator, Reader, ReverseCursorIterator}
 import com.waz.model._
@@ -209,7 +210,6 @@ class MessagesCursor(cursor: DBCursor, override val lastReadIndex: Int, val last
 }
 
 object MessagesCursor {
-  private implicit val tag: LogTag = "MessagesCursor"
   val WindowSize = 256
   val WindowMargin = WindowSize / 4
   val futureUnit = Future.successful(())
@@ -252,7 +252,6 @@ object MessagesCursor {
 
 class WindowLoader(cursor: DBCursor)(implicit dispatcher: SerialDispatchQueue) {
   import MessagesCursor._
-  private implicit val tag = logTagFor[WindowLoader]
 
   @volatile private[this] var window = IndexWindow.Empty
   @volatile private[this] var windowLoading = Future.successful(window)

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.{ErrorResponse, Message, MessageFilter}
 import com.waz.model.MessageData.{MessageDataDao, MessageEntry}
 import com.waz.model._
@@ -45,7 +46,6 @@ class MessagesStorageImpl(context: Context, storage: ZmsDatabase, userId: UserId
 
   import com.waz.utils.events.EventContext.Implicits.global
 
-  private implicit val tag: LogTag = logTagFor[MessagesStorageImpl]
   private implicit val dispatcher = new SerialDispatchQueue(name = "MessagesStorage")
 
   val messageAdded = onAdded
@@ -248,7 +248,6 @@ object MessagesStorage {
 
 class IncomingMessages(selfUserId: UserId, initial: Seq[MessageData], timeouts: Timeouts) {
   import scala.collection.breakOut
-  private implicit val tag: LogTag = logTagFor[IncomingMessages]
 
   private val messagesSource = new SourceSignal[SortedMap[(Long, MessageId), MessageData]](Some(initial.map(m => (m.localTime.toEpochMilli, m.id) -> m)(breakOut)))
 
@@ -285,8 +284,6 @@ class IncomingMessages(selfUserId: UserId, initial: Seq[MessageData], timeouts: 
 class MessageAndLikesStorage(selfUserId: UserId, messages: MessagesStorageImpl, likings: ReactionsStorage) {
   import com.waz.threading.Threading.Implicits.Background
   import com.waz.utils.events.EventContext.Implicits.global
-
-  private implicit val tag: LogTag = logTagFor[MessageAndLikesStorage]
 
   val onUpdate = EventStream[MessageId]() // TODO: use batching, maybe report new message data instead of just id
 

--- a/zmessaging/src/main/scala/com/waz/content/SyncStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/SyncStorage.scala
@@ -18,6 +18,7 @@
 package com.waz.content
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.SyncId
 import com.waz.model.sync.SyncJob
 import com.waz.model.sync.SyncJob.SyncJobDao
@@ -34,7 +35,6 @@ import scala.concurrent.duration._
  */
 class SyncStorage(storage: ZmsDatabase, jobs: Seq[SyncJob]) {
   import SyncStorage._
-  private implicit val logTag: LogTag = logTagFor[SyncStorage]
 
   private val jobsMap = new mutable.HashMap[SyncId, SyncJob]
 

--- a/zmessaging/src/main/scala/com/waz/content/WireContentProvider.scala
+++ b/zmessaging/src/main/scala/com/waz/content/WireContentProvider.scala
@@ -23,6 +23,7 @@ import android.net.Uri
 import android.os.ParcelFileDescriptor
 import android.provider.OpenableColumns
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.cache.{CacheEntryData, Expiration}
 import com.waz.model.CacheKey
 import com.waz.service.ZMessaging
@@ -123,7 +124,6 @@ class WireContentProvider extends ContentProvider {
 }
 
 object WireContentProvider {
-  private implicit val Tag: LogTag = logTagFor[WireContentProvider]
   private val Cache = "cache"
 
   object CacheUri {

--- a/zmessaging/src/main/scala/com/waz/db/Dao.scala
+++ b/zmessaging/src/main/scala/com/waz/db/Dao.scala
@@ -18,7 +18,7 @@
 package com.waz.db
 
 import com.waz.ZLog
-import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.wrappers.{DB, DBContentValues, DBCursor}
 import com.waz.utils.{Managed, returning}
 
@@ -108,8 +108,6 @@ abstract class DaoIdOps[T] extends BaseDao[T] {
 }
 
 abstract class BaseDao[T] extends Reader[T] {
-  private implicit val logTag: LogTag = logTagFor[BaseDao[T]]
-
   val table: Table[T]
 
   def onCreate(db: DB) = db.execSQL(table.createSql)

--- a/zmessaging/src/main/scala/com/waz/db/package.scala
+++ b/zmessaging/src/main/scala/com/waz/db/package.scala
@@ -19,6 +19,7 @@ package com.waz
 
 import com.waz.utils._
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.wrappers._
 import com.waz.utils.wrappers.DB
 
@@ -106,12 +107,11 @@ package db {
   }
 
   object ReadTransactionSupport {
-    private implicit val logTag: LogTag = logTagFor[ReadTransactionSupport]
     def chooseImplementation(): ReadTransactionSupport = Try(DeferredModeReadTransactionSupport.create).getOrElse(FallbackReadTransactionSupport.create)
   }
 
   object DeferredModeReadTransactionSupport {
-    def create(implicit logTag: LogTag): ReadTransactionSupport = new ReadTransactionSupport {
+    def create: ReadTransactionSupport = new ReadTransactionSupport {
       verbose("using deferred mode read transactions")
 
       override def beginReadTransaction(db: DB): Unit = try reflectiveBegin(db) catch { case _: Exception => db.beginTransactionNonExclusive() }
@@ -127,7 +127,7 @@ package db {
   }
 
   object FallbackReadTransactionSupport {
-    def create(implicit logTag: LogTag): ReadTransactionSupport = new ReadTransactionSupport {
+    def create: ReadTransactionSupport = new ReadTransactionSupport {
       verbose("using fallback support for read transactions")
       override def beginReadTransaction(db: DB): Unit = db.beginTransactionNonExclusive()
     }

--- a/zmessaging/src/main/scala/com/waz/log/AndroidLogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/AndroidLogOutput.scala
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.log
+
+import com.waz.ZLog
+import com.waz.ZLog.LogTag
+
+import scala.concurrent.Future
+
+class AndroidLogOutput extends LogOutput {
+
+  override val id = AndroidLogOutput.id
+
+  override def log(str: String, level: InternalLog.LogLevel, tag: LogTag): Unit = level match {
+    case InternalLog.Error    if ZLog.minimumLogLevel <= android.util.Log.ERROR    => android.util.Log.e(tag, str)
+    case InternalLog.Warn     if ZLog.minimumLogLevel <= android.util.Log.WARN     => android.util.Log.w(tag, str)
+    case InternalLog.Info     if ZLog.minimumLogLevel <= android.util.Log.INFO     => android.util.Log.i(tag, str)
+    case InternalLog.Debug    if ZLog.minimumLogLevel <= android.util.Log.DEBUG    => android.util.Log.d(tag, str)
+    case InternalLog.Verbose  if ZLog.minimumLogLevel <= android.util.Log.VERBOSE  => android.util.Log.v(tag, str)
+    case _ =>
+  }
+
+  override def log(str: String, cause: Throwable, level: InternalLog.LogLevel, tag: LogTag): Unit = level match {
+    case InternalLog.Error    if ZLog.minimumLogLevel <= android.util.Log.ERROR    => android.util.Log.e(tag, str, cause)
+    case InternalLog.Warn     if ZLog.minimumLogLevel <= android.util.Log.WARN     => android.util.Log.w(tag, str, cause)
+    case _ =>
+  }
+
+  override def close(): Future[Unit] = Future.successful {}
+  override def flush(): Future[Unit] = Future.successful {}
+}
+
+object AndroidLogOutput {
+  val id = "android"
+}

--- a/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -1,0 +1,92 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.log
+
+import java.io.{BufferedWriter, File, FileWriter, IOException}
+
+import com.waz.ZLog.LogTag
+import com.waz.threading.{SerialDispatchQueue, Threading}
+import com.waz.utils.returning
+
+import scala.concurrent.Future
+import scala.util.Random
+
+class BufferedLogOutput(val fileName: String, val bufferSize: Long) extends LogOutput {
+  override val id = fileName
+
+  private implicit val dispatcher = new SerialDispatchQueue(Threading.IO, "BufferedLogOutput" + Random.nextInt().toHexString)
+
+  private val buffer = StringBuilder.newBuilder
+
+  override def log(str: String, level: InternalLog.LogLevel, tag: LogTag): Unit = this.synchronized {
+    buffer.append(InternalLog.dateTag).append('/').append(level).append('/').append(tag).append(": ").append(str).append('\n')
+    if (size > bufferSize) flush()
+  }
+
+  override def log(str: String, cause: Throwable, level: InternalLog.LogLevel, tag: LogTag): Unit = this.synchronized {
+    buffer.append(InternalLog.dateTag).append('/').append(level).append("/").append(tag).append(": ").append(str).append('\n')
+          .append(InternalLog.stackTrace(cause)).append('\n')
+    if (size > bufferSize) flush()
+  }
+
+  override def close(): Future[Unit] = flush()
+
+  def empty = buffer.isEmpty
+
+  /*
+ * This part (estimating the string length in bytes) of the Wire software
+ * is based on an answer posted on the StackOverflow site.
+ * (https://stackoverflow.com/a/4387559/2975925)
+ *
+ * That work is licensed under a Creative Commons Attribution-ShareAlike 2.5 Generic License.
+ * (http://creativecommons.org/licenses/by-sa/2.5)
+ *
+ * Contributors on StackOverflow:
+ *  - finnw (https://stackoverflow.com/users/12048/finnw)
+ */
+  def size = buffer.length * 2L
+
+  // TODO: In this implementation we risk that writing to the file fails and we lose the contents.
+  // But if we wait for the result of writeToFile, we risk that meanwhile someone will add something
+  // to the buffer and we will lose that.
+  override def flush(): Future[Unit] = this.synchronized {
+    if (!empty) returning(Future { writeToFile(fileName, buffer.toString) }) { _ => buffer.clear() }
+    else Future.successful {}
+  }
+
+  private def writeToFile(fileName: String, contents: String): Unit = this.synchronized {
+    try {
+      val file = new File(fileName)
+      if (!file.exists) {
+        file.getParentFile.mkdirs()
+        file.createNewFile()
+        file.setReadable(true)
+        file.setWritable(true)
+      }
+
+      returning(new BufferedWriter(new FileWriter(file, true))) { writer =>
+        writer.write(contents)
+        writer.newLine()
+        writer.flush()
+        writer.close()
+      }
+    } catch {
+      case ex: IOException => ex.printStackTrace()
+    }
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/log/InternalLog.scala
+++ b/zmessaging/src/main/scala/com/waz/log/InternalLog.scala
@@ -1,0 +1,106 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.log
+
+import java.io._
+import java.util.Calendar
+
+import com.waz.ZLog.LogTag
+
+import scala.collection.mutable
+
+object InternalLog {
+  sealed trait LogLevel
+  case object Error   extends LogLevel { override def toString = "E" }
+  case object Warn    extends LogLevel { override def toString = "W" }
+  case object Info    extends LogLevel { override def toString = "I" }
+  case object Debug   extends LogLevel { override def toString = "D" }
+  case object Verbose extends LogLevel { override def toString = "V" }
+
+  private val outputs = mutable.HashMap[String, LogOutput]()
+
+  def getOutputs = outputs.values.toList
+
+  def reset() = this.synchronized {
+    outputs.values.foreach( _.close )
+    outputs.clear
+  }
+
+  def flush() = outputs.values.foreach( _.flush )
+
+  def get(id: String) = outputs.get(id)
+
+  def add(output: LogOutput) = this.synchronized {
+    get(output.id).getOrElse {
+      outputs += (output.id -> output)
+      output
+    }
+  }
+
+  def remove(output: LogOutput) = this.synchronized { outputs.remove(output.id) match {
+    case Some(output) => output.close()
+    case _ =>
+  } }
+
+  def addAndroidLog() = add(new AndroidLogOutput)
+  def addBufferedLog(fileName: String, bufferSize: Long = 1024L * 1024L) = add(new BufferedLogOutput(fileName, bufferSize))
+
+  def init(basePath: String) = {
+    addAndroidLog()
+    addBufferedLog(basePath + "/internalLog.log")
+  }
+
+  def error(msg: String, cause: Throwable, tag: LogTag) = log(msg, cause, Error, tag)
+  def error(msg: String, tag: LogTag)                   = log(msg, Error, tag)
+  def warn(msg: String, cause: Throwable, tag: LogTag)  = log(msg, cause, Warn, tag)
+  def warn(msg: String, tag: LogTag)                    = log(msg, Warn, tag)
+  def info(msg: String, tag: LogTag)                    = log(msg, Info, tag)
+  def debug(msg: String, tag: LogTag)                   = log(msg, Debug, tag)
+  def verbose(msg: String, tag: LogTag)                 = log(msg, Verbose, tag)
+
+  def stackTrace(cause: Throwable) = {
+    val result = new StringWriter()
+    val printWriter = new PrintWriter(result)
+    cause.printStackTrace(printWriter)
+    result.toString
+  }
+
+  def dateTag = {
+    val cal = Calendar.getInstance
+    StringBuilder.newBuilder
+      .append(cal.get(Calendar.YEAR)).append('-')
+      .append(twoc(cal.get(Calendar.MONTH)+1)).append('-')
+      .append(twoc(cal.get(Calendar.DAY_OF_MONTH))).append('_')
+      .append(twoc(cal.get(Calendar.HOUR_OF_DAY))).append(':')
+      .append(twoc(cal.get(Calendar.MINUTE))).append(':')
+      .append(twoc(cal.get(Calendar.SECOND))).append('.')
+      .append(threec(cal.get(Calendar.MILLISECOND))).toString
+  }
+
+  private final def twoc(n: Int) =
+    if(n < 10) "0"+n.toString
+    else n.toString
+
+  private final def threec(n: Int) =
+    if (n < 10) "00"+n.toString
+    else if (n < 100) "0" + n.toString
+    else n.toString
+
+  private def log(msg: String, level: LogLevel, tag: LogTag): Unit = outputs.values.foreach { _.log(msg, level, tag) }
+  private def log(msg: String, cause: Throwable, level: LogLevel, tag: LogTag): Unit = outputs.values.foreach { _.log(msg, cause, level, tag) }
+}

--- a/zmessaging/src/main/scala/com/waz/log/LogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogOutput.scala
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.log
+
+import com.waz.ZLog.LogTag
+
+import scala.concurrent.Future
+
+trait LogOutput {
+  val id: String
+
+  def log(str: String, level: InternalLog.LogLevel, tag: LogTag): Unit
+  def log(str: String, cause: Throwable, level: InternalLog.LogLevel, tag: LogTag): Unit
+  def close(): Future[Unit]
+  def flush(): Future[Unit]
+}

--- a/zmessaging/src/main/scala/com/waz/model/AssetMetaData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AssetMetaData.scala
@@ -25,6 +25,7 @@ import android.media.MediaMetadataRetriever
 import android.media.MediaMetadataRetriever._
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.service.assets.MetaDataRetriever
 import com.waz.utils.wrappers.URI
 import com.waz.utils.{JsonDecoder, JsonEncoder, _}
@@ -94,8 +95,6 @@ object AssetMetaData {
   case object Empty extends AssetMetaData('empty)
 
   object Video {
-    private implicit val Tag: LogTag = "AssetMetaData.Video"
-
     def apply(file: File): Future[Either[String, Video]] = MetaDataRetriever(file)(apply)
 
     def apply(context: Context, uri: Uri): Future[Either[String, Video]] = MetaDataRetriever(context, uri)(apply)

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -19,6 +19,7 @@ package com.waz.model.sync
 
 import com.waz.HockeyApp
 import com.waz.ZLog.error
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.EphemeralExpiration
 import com.waz.model.AddressBook.AddressBookDecoder
 import com.waz.model.UserData.ConnectionStatus

--- a/zmessaging/src/main/scala/com/waz/service/AccountService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountService.scala
@@ -19,6 +19,7 @@ package com.waz.service
 
 import com.softwaremill.macwire._
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ClientRegistrationState
 import com.waz.api.impl._
 import com.waz.content.Preferences.Preference
@@ -42,7 +43,6 @@ import scala.util.Right
 
 class UserModule(val userId: UserId, val account: AccountService) {
   import Threading.Implicits.Background
-  private implicit val Tag: LogTag = logTagFor[UserModule]
 
   def context = account.global.context
   def db = account.storage.db
@@ -401,7 +401,5 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
 }
 
 object AccountService {
-  private implicit val tag: LogTag = logTagFor[AccountService]
-
   val ActivationThrottling = new ExponentialBackoff(2.seconds, 15.seconds)
 }

--- a/zmessaging/src/main/scala/com/waz/service/Accounts.scala
+++ b/zmessaging/src/main/scala/com/waz/service/Accounts.scala
@@ -18,6 +18,7 @@
 package com.waz.service
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl._
 import com.waz.api.{KindOfAccess, KindOfVerification}
 import com.waz.client.RegistrationClient.ActivateResult
@@ -33,7 +34,6 @@ import scala.concurrent.Future
 
 class Accounts(val global: GlobalModule) {
 
-  import Accounts._
   implicit val dispatcher = new SerialDispatchQueue(name = "InstanceService")
 
   private[waz] implicit val ec: EventContext = EventContext.Global
@@ -259,8 +259,3 @@ class Accounts(val global: GlobalModule) {
     }
   }
 }
-
-object Accounts {
-  private implicit val logTag: LogTag = logTagFor[Accounts]
-}
-

--- a/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
@@ -20,6 +20,7 @@ package com.waz.service
 import java.lang.System._
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.cache.CacheService
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.LastCacheCleanup
@@ -32,7 +33,6 @@ import scala.concurrent.duration._
 class CacheCleaningService(cache: CacheService, prefs: GlobalPreferences) {
   import CacheCleaningService._
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[CacheCleaningService]
   private implicit val ec = EventContext.Global
 
   CancellableFuture.delayed(1.minute) { requestDeletionOfExpiredCacheEntries() }

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -20,6 +20,7 @@ package com.waz.service
 import java.util.Date
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content._
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.UserData.ConnectionStatus
@@ -40,7 +41,6 @@ class ConnectionService(push: PushService, convs: ConversationsContentUpdater, m
                         messages: MessagesService, messagesStorage: MessagesStorage, users: UserService, usersStorage: UsersStorage,
                         sync: SyncServiceHandle, scheduler: => EventScheduler) {
 
-  private implicit val logTag: LogTag = logTagFor[ConnectionService]
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
   import messages._

--- a/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ContactsService.scala
@@ -30,6 +30,7 @@ import android.provider.{BaseColumns, ContactsContract}
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.waz.PermissionsService
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Permission.READ_CONTACTS
 import com.waz.content.GlobalPreferences.ShareContacts
 import com.waz.content.UserPreferences._
@@ -425,7 +426,6 @@ class ContactsService(context: Context, accountId: AccountId, accountStorage: Ac
 }
 
 object ContactsService {
-  private implicit val logTag: LogTag = logTagFor[ContactsService]
   val CurrentAddressBookVersion = 3
   val InitialContactsBatchSize = 101
 

--- a/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ErrorsService.scala
@@ -19,6 +19,7 @@ package com.waz.service
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ErrorType
 import com.waz.content.MessagesStorageImpl
 import com.waz.model.ErrorData.ErrorDataDao
@@ -38,7 +39,6 @@ class ErrorsService(context: Context, storage: ZmsDatabase, lifecycle: ZmsLifecy
   import lifecycle._
 
   private implicit val dispatcher = new SerialDispatchQueue(name = "ErrorsService")
-  private implicit val logTag: LogTag = logTagFor[ErrorsService]
 
   private var dismissHandler: PartialFunction[ErrorData, Future[_]] = PartialFunction.empty
 

--- a/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/MetaDataService.scala
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.OtrClientType
 import com.waz.sync.client._
 import com.waz.utils.{LoggedTry, returning}
@@ -29,7 +30,6 @@ import com.waz.utils.{LoggedTry, returning}
 import scala.util.Try
 
 class MetaDataService(context: Context) {
-  private implicit val logTag: LogTag = logTagFor[MetaDataService]
 
   lazy val metaData = LoggedTry {
     import scala.collection.JavaConverters._

--- a/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
@@ -23,6 +23,7 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.google.i18n.phonenumbers.Phonenumber.{PhoneNumber => GooglePhoneNumber}
 import com.waz.PermissionsService
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.PhoneNumber
 import com.waz.threading.SerialDispatchQueue
 
@@ -30,7 +31,6 @@ import scala.concurrent.Future
 import scala.util.Try
 
 class PhoneNumberService(context: Context, permissions: PermissionsService) {
-  private implicit val logTag: LogTag = logTagFor[PhoneNumberService]
   private implicit val dispatcher = new SerialDispatchQueue(name = "PhoneNumberService")
 
   private lazy val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE).asInstanceOf[TelephonyManager]

--- a/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ReportingService.scala
@@ -27,6 +27,7 @@ import com.waz.cache.{CacheService, Expiration}
 import com.waz.content.GlobalPreferences.PushToken
 import com.waz.content.{AccountsStorageImpl, GlobalPreferences}
 import com.waz.content.WireContentProvider.CacheUri
+import com.waz.log.{BufferedLogOutput, InternalLog}
 import com.waz.model.{AccountId, Mime}
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import com.waz.utils.wrappers.URI
@@ -81,7 +82,7 @@ class GlobalReportingService(context: Context, cache: CacheService, metadata: Me
       lazy val writer = new PrintWriter(new OutputStreamWriter(entry.outputStream))
 
       val rs = if (metadata.internalBuild)
-        VersionReporter +: PushRegistrationReporter +: ZUsersReporter +: reporters :+ LogCatReporter
+        VersionReporter +: PushRegistrationReporter +: ZUsersReporter +: reporters :+ LogCatReporter :+ InternalLogReporter
       else Seq(VersionReporter, LogCatReporter)
 
       RichFuture.processSequential(rs) { reporter =>
@@ -131,5 +132,20 @@ class GlobalReportingService(context: Context, cache: CacheService, metadata: Me
       Process(Seq("logcat", "-d", "-v", "time")).run(new ProcessIO({in => latch.await(); in.close() }, writeAll, writeAll))
       latch.await()
     } (Threading.IO)
+  })
+
+  val InternalLogReporter = Reporter("InternalLog", { writer =>
+    val outputs = InternalLog.getOutputs.flatMap {
+      case o: BufferedLogOutput => Some(o)
+      case _ => None
+    }
+
+    Future.sequence(outputs.map( _.flush() )).map { _ =>
+      outputs.map(o => new File(o.fileName)).filter(_.exists).foreach { file =>
+        IoUtils.withResource(new BufferedReader(new InputStreamReader(new FileInputStream(file)))) { reader =>
+          Iterator.continually(reader.readLine()).takeWhile(_ != null).foreach(writer.println)
+        }
+      }
+    }
   })
 }

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -18,6 +18,7 @@
 package com.waz.service
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.{CommonConnectionsStorage, MessagesStorageImpl, SearchQueryCacheStorage, UsersStorageImpl}
 import com.waz.model.SearchQuery.{Recommended, RecommendedHandle, TopPeople}
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
@@ -134,7 +135,6 @@ class UserSearchService(queryCache: SearchQueryCacheStorage, commonConnsStorage:
 }
 
 object UserSearchService {
-  private implicit val tag: LogTag = logTagFor[UserSearchService]
   val MinCommonConnections = 4
   val MaxTopPeople = 10
 }

--- a/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
@@ -18,6 +18,7 @@
 package com.waz.service
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences._
 import com.waz.model.VersionBlacklist
@@ -31,7 +32,6 @@ import scala.concurrent.duration._
 class VersionBlacklistService(metadata: MetaDataService, prefs: GlobalPreferences, client: VersionBlacklistClient) {
 
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[VersionBlacklistService]
   private implicit val ec = EventContext.Global
   import metadata._
 

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -350,4 +350,5 @@ object ZMessaging { self =>
       Threading.Background { Locales.preloadTransliterator(); ContentSearchQuery.preloadTransliteration(); } // "preload"... - this should be very fast, normally, but slows down to 10 to 20 seconds when multidexed...
     }
   }
+
 }

--- a/zmessaging/src/main/scala/com/waz/service/ZmsLifecycle.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZmsLifecycle.scala
@@ -18,14 +18,13 @@
 package com.waz.service
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.Threading
 import com.waz.utils.events.{EventContext, Signal}
 
 import scala.concurrent.Future
 
 class ZmsLifecycle extends EventContext {
-  private implicit val logTag: LogTag = logTagFor[ZmsLifecycle]
-
   val lifecycleState = Signal(LifecycleState.Stopped)
   val uiActive = lifecycleState.map(_ == LifecycleState.UiActive)
   def active = lifecycleState.map(st => st == LifecycleState.UiActive || st == LifecycleState.Active)

--- a/zmessaging/src/main/scala/com/waz/service/assets/AudioLevels.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AudioLevels.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import android.content.Context
 import android.media.{MediaCodec, MediaExtractor, MediaFormat}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap.video.{MediaCodecHelper, TrackDecoder}
 import com.waz.model.AssetMetaData.Loudness
 import com.waz.model.Mime
@@ -140,8 +141,6 @@ case class AudioLevels(context: Context) {
 }
 
 object AudioLevels {
-  private implicit val logTag: LogTag = logTagFor[AudioLevels]
-
   case class TrackInfo(index: Int, format: MediaFormat, mime: String, samplingRate: Int, channels: Int, duration: FiniteDuration, samples: Double)
 
   def loudnessOverview(buckets: Int, rmsOfBuffers: Array[Double]): Vector[Float] = {

--- a/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/GlobalRecordAndPlayService.scala
@@ -23,6 +23,7 @@ import android.content.{BroadcastReceiver, Context, Intent, IntentFilter}
 import android.media.AudioManager
 import android.telephony.TelephonyManager
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.ErrorType._
 import com.waz.api.impl.AudioAssetForUpload
@@ -418,8 +419,6 @@ class GlobalRecordAndPlayService(cache: CacheService, context: Context) {
 }
 
 object GlobalRecordAndPlayService {
-  private implicit val logTag: LogTag = logTagFor[GlobalRecordAndPlayService]
-
   sealed trait State
   case object Idle extends State
   case class Playing(player: Player, key: MediaKey) extends State

--- a/zmessaging/src/main/scala/com/waz/service/assets/MetaDataService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/MetaDataService.scala
@@ -22,6 +22,7 @@ import android.graphics.Bitmap
 import android.media.MediaMetadataRetriever
 import android.media.MediaMetadataRetriever._
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap.BitmapUtils
 import com.waz.cache.{CacheEntry, CacheService, LocalData}
 import com.waz.content.AssetsStorage
@@ -43,7 +44,6 @@ import scala.util.Try
 class MetaDataService(context: Context, cache: CacheService, storage: AssetsStorage, assets: => AssetService,
                       generator: ImageAssetGenerator) {
   import com.waz.threading.Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[MetaDataService]
 
   def loadMetaData(asset: AssetData, data: LocalData): CancellableFuture[Option[AssetMetaData]] = {
     def load(entry: CacheEntry) = {

--- a/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
@@ -26,6 +26,7 @@ import android.media.AudioManager.STREAM_MUSIC
 import android.media.AudioTrack
 import android.media.AudioTrack.{MODE_STREAM, OnPlaybackPositionUpdateListener, getMinBufferSize}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.service.assets.GlobalRecordAndPlayService.{MediaPointer, PCMContent}
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import libcore.io.SizeOf
@@ -155,8 +156,6 @@ class PCMPlayer private (content: PCMContent, track: AudioTrack, totalSamples: L
 }
 
 object PCMPlayer {
-  private implicit val logTag: LogTag = logTagFor[PCMPlayer]
-
   def apply(content: PCMContent, observer: Player.Observer): Future[PCMPlayer] = Threading.BackgroundHandler.map { handler =>
     val track = new AudioTrack(STREAM_MUSIC, PCM.sampleRate, PCM.outputChannelConfig, PCM.sampleFormat, playerBufferSize, MODE_STREAM)
     verbose(s"created audio track; buffer size: $playerBufferSize")

--- a/zmessaging/src/main/scala/com/waz/service/assets/PCMRecorder.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/PCMRecorder.scala
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference
 import android.media.AudioRecord
 import android.media.AudioRecord._
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.Threading
 import com.waz.threading.Threading.BlockingIO
 import com.waz.utils._
@@ -46,7 +47,6 @@ trait PCMRecorder {
 
 object PCMRecorder {
   import Threading.Implicits.Background
-  private implicit val logTag: LogTag = logTagFor[PCMRecorder]
 
   def startRecording(destination: File, maxDuration: FiniteDuration): PCMRecorder = {
     val limit = (maxDuration.toMillis * PCM.sampleRate) / 1000L

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationEventsService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.conversation
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.GenericContent.{MsgDeleted, MsgEdit, MsgRecall, Reaction, Receipt}
 import com.waz.model._
 import com.waz.service.messages.MessagesServiceImpl
@@ -30,7 +31,6 @@ import scala.concurrent.Future
 
 class ConversationEventsService(convs: ConversationsContentUpdater, messages: MessagesServiceImpl, users: UserServiceImpl, sync: SyncServiceHandle, pipeline: EventPipeline) {
 
-  private implicit val tag: LogTag = logTagFor[ConversationEventsService]
   private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationEventsDispatcher")
 
   val selfUserId = users.selfUserId

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -54,6 +54,7 @@ trait ConversationsContentUpdater {
 
 class ConversationsContentUpdaterImpl(val storage: ConversationStorageImpl, users: UserServiceImpl, membersStorage: MembersStorageImpl, messagesStorage: => MessagesStorageImpl) extends ConversationsContentUpdater {
   import com.waz.utils.events.EventContext.Implicits.global
+
   private implicit val dispatcher = new SerialDispatchQueue(name = "ConversationContentUpdater")
 
   val conversationsSignal: Signal[ConversationsSet] = storage.convsSignal

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsNotifier.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsNotifier.scala
@@ -18,6 +18,7 @@
 package com.waz.service.conversation
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.ContentChange.{Added, Removed, Updated}
 import com.waz.content.{ContentChange, ConversationStorageImpl}
 import com.waz.model.{ConvId, ConversationData}
@@ -47,8 +48,6 @@ class ConversationsNotifier(convs: ConversationStorageImpl, service: Conversatio
 }
 
 object ConversationsNotifier {
-  implicit val tag: LogTag = logTagFor[ConversationsNotifier]
-
   val ConversationListOrdering = Ordering.by((c : ConversationData) => (c.convType == ConversationType.Self, c.lastEventTime)).reverse
   val ArchivedListOrdering = Ordering.by((c: ConversationData) => c.lastEventTime).reverse
 
@@ -76,9 +75,7 @@ object ConversationsNotifier {
 
     import com.waz.utils.events.EventContext.Implicits.global
 
-    implicit val tag: LogTag = logTagFor[SelfConversationSignal]
-
-    private implicit val dispatcher = new SerialDispatchQueue(name = tag)
+    private implicit val dispatcher = new SerialDispatchQueue(name = logTagFor[SelfConversationSignal])
 
     private val stream = new ConversationEventsEventStream(convs, { _.convType == ConversationType.Self })
     @volatile var observer = Option.empty[Subscription]

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -21,6 +21,7 @@ import android.content.Context
 import com.softwaremill.macwire._
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ErrorType
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences._
@@ -50,7 +51,6 @@ class ConversationsService(context: Context, push: PushServiceSignals, users: Us
                            messages: MessagesServiceImpl, assets: AssetService, storage: ZmsDatabase,
                            msgContent: MessagesContentUpdater, userPrefs: UserPreferences, eventScheduler: => EventScheduler) {
 
-  private implicit val tag: LogTag = logTagFor[ConversationsService]
   private implicit val ev = EventContext.Global
   import Threading.Implicits.Background
   import messages._

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.conversation
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.MessageContent.Asset.ErrorHandler
 import com.waz.api.MessageContent.Text
@@ -401,7 +402,5 @@ class ConversationsUiService(self:            UserId,
 }
 
 object ConversationsUiService {
-  private implicit val logTag: LogTag = logTagFor[ConversationsUiService]
-
   val LargeAssetWarningThresholdInBytes = 3145728L // 3MiB
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -20,6 +20,7 @@ package com.waz.service.conversation
 import java.util.Date
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.ConversationStorageImpl
 import com.waz.model._
 import com.waz.service._
@@ -36,7 +37,6 @@ class TypingService(conversations: ConversationStorageImpl, timeouts: Timeouts, 
 
   private implicit val ev = EventContext.Global
   private implicit val dispatcher = new SerialDispatchQueue(name = "TypingService")
-  private implicit val tag: LogTag = logTagFor[TypingService]
 
   private var typing: ConvId Map IndexedSeq[TypingUser] = Map().withDefaultValue(Vector.empty)
 

--- a/zmessaging/src/main/scala/com/waz/service/downloads/Downloader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/Downloader.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import android.content.Context
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ProgressIndicator._
 import com.waz.api.impl.{ErrorResponse, ProgressIndicator}
 import com.waz.bitmap.video.VideoTranscoder
@@ -57,7 +58,6 @@ object Downloader {
 
 class AssetDownloader(client: AssetClient, cache: CacheService) extends Downloader[AssetRequest] {
   import com.waz.threading.Threading.Implicits.Background
-  private implicit val tag = logTagFor[AssetDownloader]
 
   val onDownloadStarting = EventStream[AssetRequest]()
   val onDownloadDone     = EventStream[AssetRequest]()
@@ -135,7 +135,7 @@ object InputStreamAssetLoader {
         .map(Some(_))
         .recover {
           case e: Throwable =>
-            warn(s"addStreamToCache failed", e)("InputStreamAssetLoader")
+            warn(s"addStreamToCache failed", e)
             None
         }
     }
@@ -147,7 +147,6 @@ object InputStreamAssetLoader {
 }
 
 class VideoAssetLoader(context: Context, cache: => CacheService) extends Downloader[VideoAsset] {
-  private implicit val tag: LogTag = logTagFor[VideoAssetLoader]
 
   override def load(asset: VideoAsset, callback: Callback): CancellableFuture[Option[CacheEntry]] = {
     import Threading.Implicits.Background
@@ -168,8 +167,6 @@ class VideoAssetLoader(context: Context, cache: => CacheService) extends Downloa
 
 class UnencodedAudioAssetLoader(context: Context, cache: => CacheService, tempFiles: TempFileService) extends Downloader[UnencodedAudioAsset] {
   import Threading.Implicits.Background
-
-  private implicit def tag: LogTag = logTagFor[UnencodedAudioAssetLoader]
   private val transcode = new AudioTranscoder(tempFiles, context)
 
   override def load(request: UnencodedAudioAsset, callback: Callback): CancellableFuture[Option[CacheEntry]] = {

--- a/zmessaging/src/main/scala/com/waz/service/downloads/DownloaderService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/DownloaderService.scala
@@ -19,6 +19,7 @@ package com.waz.service.downloads
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.NetworkMode
 import com.waz.api.ProgressIndicator.State
 import com.waz.api.impl.ProgressIndicator
@@ -192,8 +193,6 @@ class DownloaderService(context: Context, cache: CacheService, prefs: Preference
 object DownloaderService {
 
   case object DownloadOnWifiOnlyException extends Exception("Downloading is disabled by download preference.")
-
-  private implicit val tag: LogTag = logTagFor[DownloaderService]
 
   val MaxConcurrentDownloads = 4
   // number of concurrent downloads for request not immediately required by UI

--- a/zmessaging/src/main/scala/com/waz/service/images/ImageAssetGenerator.scala
+++ b/zmessaging/src/main/scala/com/waz/service/images/ImageAssetGenerator.scala
@@ -20,6 +20,7 @@ package com.waz.service.images
 import android.content.Context
 import android.graphics.{Bitmap => ABitmap}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap.BitmapUtils.Mime
 import com.waz.bitmap.{BitmapDecoder, BitmapUtils}
 import com.waz.cache.{CacheEntry, CacheService, LocalData}
@@ -42,7 +43,6 @@ class ImageAssetGenerator(context: Context, cache: CacheService, loader: ImageLo
   import com.waz.service.images.ImageAssetGenerator._
 
   implicit private val dispatcher  = Threading.ImageDispatcher
-  implicit private val tag: LogTag = "ImageAssetGenerator"
 
   lazy val saveDir = AssetService.assetDir(context)
 

--- a/zmessaging/src/main/scala/com/waz/service/invitations/InvitationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/invitations/InvitationService.scala
@@ -20,6 +20,7 @@ package com.waz.service.invitations
 import java.util.Locale
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.ZmsDatabase
 import com.waz.model.Contact.{EmailAddressesDao, PhoneNumbersDao}
 import com.waz.model._
@@ -38,7 +39,6 @@ class InvitationService(storage: ZmsDatabase, users: UserServiceImpl, connection
                         conversations: ConversationsService, sync: SyncServiceHandle, timeouts: Timeouts) {
 
   import EventContext.Implicits.global
-  import InvitationService._
   import timeouts.contacts._
 
   private implicit lazy val dispatcher = new SerialDispatchQueue(name = "serial_InvitationService")
@@ -115,8 +115,4 @@ class InvitationService(storage: ZmsDatabase, users: UserServiceImpl, connection
   }
 
   private def similarTo(method: Either[EmailAddress, PhoneNumber]) = storage.read(db => method.fold(EmailAddressesDao.findBy(_)(db), PhoneNumbersDao.findBy(_)(db)))
-}
-
-object InvitationService {
-  private implicit val logTag: LogTag = logTagFor[InvitationService]
 }

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
@@ -21,6 +21,7 @@ import java.net.URLDecoder
 
 import android.util.Patterns
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message.Part
 import com.waz.api.Message.Part.Type._
 import com.waz.model.MessageContent
@@ -33,8 +34,6 @@ import scala.util.control.NonFatal
 class RichMediaContentParser {
   import Part.Type._
   import com.waz.service.media.RichMediaContentParser._
-
-  private implicit val logTag: LogTag = logTagFor[RichMediaContentParser]
 
   def findMatches(content: String, weblinkEnabled: Boolean = false) = {
 

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.media
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.{MediaProvider, Message}
 import com.waz.model._
@@ -34,7 +35,6 @@ import scala.concurrent.Future
 
 class RichMediaService(assets: AssetService, messages: MessagesContentUpdater, sync: SyncServiceHandle, youTube: YouTubeMediaService, soundCloud: SoundCloudMediaService, spotify: SpotifyMediaService) {
   import com.waz.api.Message.Part.Type._
-  private implicit val logTag: LogTag = logTagFor[RichMediaService]
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
 

--- a/zmessaging/src/main/scala/com/waz/service/media/SoundCloudMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/SoundCloudMediaService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.media
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.model.messages.media.MediaAssetData
 import com.waz.model.{MessageContent, MessageData}
@@ -31,7 +32,6 @@ import scala.concurrent.Future
 
 
 class SoundCloudMediaService(client: SoundCloudClient, assets: AssetService) {
-  private implicit val logTag: LogTag = logTagFor[SoundCloudMediaService]
 
   import Threading.Implicits.Background
 

--- a/zmessaging/src/main/scala/com/waz/service/media/SpotifyMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/SpotifyMediaService.scala
@@ -20,6 +20,7 @@ package com.waz.service.media
 import java.util.Locale
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.SpotifyRefreshToken
@@ -39,8 +40,6 @@ import scala.concurrent.Future
 class SpotifyMediaService(client: SpotifyClient, assets: AssetService, userPrefs: UserPreferences) {
   import SpotifyMediaService._
   import Threading.Implicits.Background
-
-  private implicit val logTag: LogTag = logTagFor[SpotifyMediaService]
 
   private val spotifyRefreshTokenPref = userPrefs.preference(SpotifyRefreshToken)
   private val accessToken = new SourceSignal[Option[AccessToken]](Some(None))

--- a/zmessaging/src/main/scala/com/waz/service/media/YouTubeMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/YouTubeMediaService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.media
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.model._
 import com.waz.model.messages.media.MediaAssetData
@@ -32,8 +33,6 @@ import scala.concurrent.Future
 
 class YouTubeMediaService(client: YouTubeClient, assets: AssetService) {
   import Threading.Implicits.Background
-
-  private implicit val logTag: LogTag = logTagFor[YouTubeMediaService]
 
   def updateMedia(msg: MessageData, content: MessageContent): ErrorOr[MessageContent] = {
     RichMediaContentParser.youtubeVideoId(content.content) match {

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -19,6 +19,7 @@ package com.waz.service.messages
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.{EphemeralExpiration, Message}
 import com.waz.api.Message.Status
 import com.waz.content._
@@ -35,7 +36,6 @@ import scala.concurrent.Future
 
 class MessagesContentUpdater(context: Context, val messagesStorage: MessagesStorageImpl, convs: ConversationStorageImpl, users: UserServiceImpl, sync: SyncServiceHandle, deletions: MsgDeletionStorage) {
 
-  private implicit val tag: LogTag = logTagFor[MessagesContentUpdater]
   import Threading.Implicits.Background
 
   val contentParser = new RichMediaContentParser

--- a/zmessaging/src/main/scala/com/waz/service/messages/ReactionsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/ReactionsService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.messages
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.{Likes, ReactionsStorage}
 import com.waz.model._
 import com.waz.service.UserServiceImpl
@@ -30,7 +31,6 @@ import org.threeten.bp.Instant.EPOCH
 import scala.concurrent.Future
 
 class ReactionsService(storage: ReactionsStorage, messages: MessagesContentUpdater, sync: SyncServiceHandle, users: UserServiceImpl, selfUserId: UserId) {
-  import ReactionsService._
   import Threading.Implicits.Background
 
   def like(conv: ConvId, msg: MessageId): Future[Likes] = addReaction(conv, msg, Liking.Action.Like)
@@ -52,10 +52,6 @@ class ReactionsService(storage: ReactionsStorage, messages: MessagesContentUpdat
   })
 
   def processReactions(likings: Seq[Liking]): Future[Seq[Likes]] = Future.traverse(likings) { storage.addOrUpdate } // FIXME: use batching
-}
-
-object ReactionsService {
-  private implicit val logTag: LogTag = logTagFor[ReactionsService]
 }
 
 case class MessageAndLikes(message: MessageData, likes: IndexedSeq[UserId], likedBySelf: Boolean)

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoBoxService.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Verification
 import com.waz.content.UserPreferences
 import com.waz.content.UserPreferences.OtrLastPrekey
@@ -110,8 +111,6 @@ class CryptoBoxService(context: Context, userId: AccountId, metadata: MetaDataSe
 }
 
 object CryptoBoxService {
-  private implicit val Tag: LogTag = logTagFor[CryptoBoxService]
-
   val PreKeysCount = 100
   val LowPreKeysThreshold = 50
   val LocalPreKeysLimit = 16 * 1024

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -19,6 +19,7 @@ package com.waz.service.otr
 
 import android.util.Base64
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.SerialDispatchQueue
 import com.waz.utils.events.{AggregatingSignal, EventStream}
 import com.waz.utils.{LoggedTry, returning}
@@ -27,7 +28,6 @@ import com.wire.cryptobox.{CryptoBox, CryptoSession, PreKey}
 import scala.concurrent.Future
 
 class CryptoSessionService(cryptoBox: CryptoBoxService) {
-  import CryptoSessionService._
 
   private val dispatchers = Array.fill(17)(new SerialDispatchQueue(name = s"CryptoSessionDispatchQueue"))
 
@@ -94,9 +94,4 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) {
 
     new AggregatingSignal[Option[Array[Byte]], Option[Array[Byte]]](stream, fingerprint, (prev, next) => next)
   }
-}
-
-object CryptoSessionService {
-  private implicit val logTag: LogTag = logTagFor[CryptoSessionService]
-
 }

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrClientsService.scala
@@ -18,6 +18,7 @@
 package com.waz.service.otr
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Verification
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UserPreferences.LastSelfClientsSyncRequestedTime
@@ -37,7 +38,6 @@ import scala.concurrent.duration._
 
 class OtrClientsService(userId: UserId, clientId: Signal[Option[ClientId]], netClient: OtrClient, userPrefs: UserPreferences, storage: OtrClientsStorage, sync: SyncServiceHandle, lifecycle: ZmsLifecycle, updater: VerificationStateUpdater) {
 
-  import OtrClientsService._
   import com.waz.threading.Threading.Implicits.Background
   import com.waz.utils.events.EventContext.Implicits.global
 
@@ -166,8 +166,4 @@ class OtrClientsService(userId: UserId, clientId: Signal[Option[ClientId]], netC
         cs.clients.get(id)
       case _ => None
     }
-}
-
-object OtrClientsService {
-  private implicit val tag: LogTag = logTagFor[OtrClientsService]
 }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -19,6 +19,7 @@ package com.waz.sync
 
 import android.content.Context
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.EphemeralExpiration
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model._
@@ -87,8 +88,6 @@ class AndroidSyncServiceHandle(context: Context, service: => SyncRequestService,
 
   import com.waz.model.sync.SyncRequest._
 
-  private implicit val logTag: LogTag = logTagFor[AndroidSyncServiceHandle]
-
   private def addRequest(req: SyncRequest, priority: Int = Priority.Normal, dependsOn: Seq[SyncId] = Nil, optional: Boolean = false, timeout: Long = 0, forceRetry: Boolean = false, delay: FiniteDuration = Duration.Zero): Future[SyncId] = {
     debug(s"addRequest: $req, prio: $priority, timeout: $timeout")
     val timestamp = SyncJob.timestamp
@@ -149,7 +148,6 @@ trait SyncHandler {
 
 class AccountSyncHandler(zms: Signal[ZMessaging], otrClients: OtrClientsSyncHandler) extends SyncHandler {
   import Threading.Implicits.Background
-  private implicit val logTag: LogTag = logTagFor[AccountSyncHandler]
 
   import com.waz.model.sync.SyncRequest._
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConnectionsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConnectionsClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model._
@@ -68,8 +69,6 @@ class ConnectionsClient(netClient: ZNetClient) {
 }
 
 object ConnectionsClient {
-  private implicit val logTag: LogTag = logTagFor[ConnectionsClient]
-
   val ConnectionsPath = "/connections"
   val PageSize = 100
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/ConversationsClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model._
 import com.waz.sync.client.ConversationsClient.ConversationResponse.{ConversationIdsResponse, ConversationsResult}
@@ -96,8 +97,6 @@ class ConversationsClient(netClient: ZNetClient) {
 }
 
 object ConversationsClient {
-  private implicit val logTag: LogTag = logTagFor[ConversationsClient]
-
   val ConversationsPath = "/conversations"
   val ConversationIdsPath = "/conversations/ids"
   val ConversationsPageSize = 100
@@ -147,8 +146,6 @@ object ConversationsClient {
     }
 
     implicit lazy val Decoder: JsonDecoder[ConversationResponse] = new JsonDecoder[ConversationResponse] {
-      implicit val logTag: LogTag = "ConversationResponse.Decoder"
-
       override def apply(implicit js: JSONObject): ConversationResponse = {
         debug(s"decoding response: $js")
         val members = js.getJSONObject("members")

--- a/zmessaging/src/main/scala/com/waz/sync/client/EventsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/EventsClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.{ConnectionErrorCode, TimeoutCode}
 import com.waz.model.otr.ClientId
@@ -123,7 +124,6 @@ object PushNotification {
 }
 
 object EventsClient {
-  private implicit val logTag: LogTag = logTagFor[EventsClient]
   val NotificationsPath = "/notifications"
   val LastNotificationPath = "/notifications/last"
   val PageSize = 1000

--- a/zmessaging/src/main/scala/com/waz/sync/client/GiphyClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/GiphyClient.scala
@@ -20,6 +20,7 @@ package com.waz.sync.client
 import java.net.URLEncoder
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.AssetMetaData.Image.Tag
 import com.waz.model.AssetMetaData.Image.Tag.{Medium, Preview}
 import com.waz.model.{AssetData, AssetMetaData, Dim2, Mime}
@@ -65,8 +66,6 @@ class GiphyClient(netClient: ZNetClient) {
 }
 
 object GiphyClient {
-  implicit val logTag: LogTag = logTagFor[GiphyClient]
-
   val BasePath = "/proxy/giphy/v1/gifs"
 
   val RandomGifPath = s"$BasePath/random"

--- a/zmessaging/src/main/scala/com/waz/sync/client/OAuth2Client.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OAuth2Client.scala
@@ -21,6 +21,7 @@ import java.net.URLEncoder
 
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.sync.client.OAuth2Client._
 import com.waz.threading.Threading
@@ -76,8 +77,6 @@ class OAuth2Client(netClient: ZNetClient)(implicit app: AppInfo) {
 
 object OAuth2Client {
   import JsonDecoder._
-
-  implicit val logTag = logTagFor[OAuth2Client]
 
   case class AppInfo(id: ClientId, tokenPath: String, redirectUri: Uri)
   case class ClientId(str: String) extends AnyVal

--- a/zmessaging/src/main/scala/com/waz/sync/client/OpenGraphClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OpenGraphClient.scala
@@ -19,6 +19,7 @@ package com.waz.sync.client
 
 import com.koushikdutta.async.ByteBufferList
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.threading.CancellableFuture
 import com.waz.utils.wrappers.URI
@@ -81,7 +82,6 @@ class OpenGraphClient(netClient: ZNetClient) {
 }
 
 object OpenGraphClient {
-  private implicit val tag: LogTag = logTagFor[OpenGraphClient]
   val MaxHeaderLength = 16 * 1024 // maximum amount of data to load from website
   val DesktopUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
   val CookiePattern = """([^=]+)=([^\;]+)""".r

--- a/zmessaging/src/main/scala/com/waz/sync/client/PushTokenClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/PushTokenClient.scala
@@ -19,7 +19,6 @@ package com.waz.sync.client
 
 import com.waz.model.PushToken
 import com.waz.model.otr.ClientId
-import com.waz.service.push.PushTokenService.PushSenderId
 import com.waz.threading.Threading
 import com.waz.utils.{JsonDecoder, JsonEncoder}
 import com.waz.znet.Response.SuccessHttpStatus

--- a/zmessaging/src/main/scala/com/waz/sync/client/SoundCloudClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SoundCloudClient.scala
@@ -20,6 +20,7 @@ package com.waz.sync.client
 import java.net.URLEncoder
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.MediaProvider
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.AssetData
@@ -60,8 +61,6 @@ object SoundCloudClient {
   import com.waz.utils.JsonDecoder._
 
   val domainNames = Set("soundcloud.com")
-
-  implicit val logTag = logTagFor[SoundCloudClient]
 
   def proxyPath(resource: String, url: String) = s"/proxy/soundcloud/$resource?url=${URLEncoder.encode(url, "utf8")}"
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/SpotifyClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/SpotifyClient.scala
@@ -19,6 +19,7 @@ package com.waz.sync.client
 
 import android.net.Uri
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.MediaProvider
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.AssetData
@@ -74,8 +75,6 @@ object SpotifyClient {
   import JsonDecoder._
 
   val domainNames = Set("open.spotify.com", "play.spotify.com")
-
-  implicit val logTag = logTagFor[SpotifyClient]
 
   private val Base = "https://api.spotify.com/v1"
   val MeUri = uri(Base)(_ / "me")

--- a/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.SearchQuery.{Recommended, RecommendedHandle, TopPeople}
 import com.waz.model._
@@ -34,7 +35,6 @@ import scala.util.control.NonFatal
 class UserSearchClient(netClient: ZNetClient) {
   import Threading.Implicits.Background
   import UserSearchClient._
-  private implicit val tag: LogTag = logTagFor[UserSearchClient]
 
   def graphSearch(query: SearchQuery, limit: Int): ErrorOrResponse[Seq[UserSearchEntry]] = {
     debug(s"graphSearch('$query', $limit)")
@@ -89,7 +89,6 @@ object UserSearchClient {
   }
 
   object UserSearchResponse {
-    private implicit val logTag: LogTag = logTagFor(UserSearchResponse)
 
     def unapply(resp: ResponseContent): Option[Seq[UserSearchEntry]] = resp match {
       case JsonObjectResponse(js) if js.has("documents") =>

--- a/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -19,6 +19,7 @@ package com.waz.sync.client
 
 import com.waz.HockeyApp.NoReporting
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model._
 import com.waz.threading.{CancellableFuture, Threading}
@@ -34,7 +35,6 @@ import scala.util.{Right, Try}
 class UsersClient(netClient: ZNetClient) {
   import Threading.Implicits.Background
   import com.waz.sync.client.UsersClient._
-  private implicit val tag: LogTag = logTagFor[UsersClient]
 
   def loadUsers(ids: Seq[UserId]): ErrorOrResponse[IndexedSeq[UserInfo]] = {
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/YouTubeClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/YouTubeClient.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.client
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.MediaProvider
 import com.waz.model.messages.media.MediaAssetData.{MediaWithImages, Thumbnail}
 import com.waz.model.AssetData
@@ -57,7 +58,6 @@ class YouTubeClient(netClient: ZNetClient) {
 }
 
 object YouTubeClient {
-  implicit val logTag = logTagFor[YouTubeClient]
 
   val domainNames = Set("youtube.com", "youtu.be")
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/AddressBookSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/AddressBookSyncHandler.scala
@@ -19,6 +19,7 @@ package com.waz.sync.handler
 
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.AddressBook
 import com.waz.service._
 import com.waz.sync.SyncResult
@@ -31,8 +32,6 @@ import scala.util.control.NoStackTrace
 class AddressBookSyncHandler(contacts: ContactsService, client: AddressBookClient) {
 
   import Threading.Implicits.Background
-  private implicit val logTag: LogTag = logTagFor[AddressBookSyncHandler]
-
   def postAddressBook(ab: AddressBook): Future[SyncResult] = {
     verbose(s"postAddressBook()")
     if (ab == AddressBook.Empty) Future.successful(SyncResult.Success)

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ClearedSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ClearedSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.{ConversationStorageImpl, MessagesStorageImpl}
@@ -33,8 +34,6 @@ import scala.concurrent.Future
 
 class ClearedSyncHandler(convs: ConversationStorageImpl, convsContent: ConversationsContentUpdaterImpl, users: UserServiceImpl, msgs: MessagesStorageImpl, convSync: ConversationsSyncHandler, otrSync: OtrSyncHandler) {
   import com.waz.threading.Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[ClearedSyncHandler]
-
 
   // Returns actual timestamp to use for clear.
   // This is needed to take local (previously unsent) messages into account.

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.UsersStorageImpl
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.UserId
@@ -32,7 +33,6 @@ import scala.concurrent.Future
 class ConnectionsSyncHandler(usersStorage: UsersStorageImpl, connectionService: ConnectionService, connectionsClient: ConnectionsClient, pipeline: EventPipeline) {
 
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[ConnectionsSyncHandler]
   private implicit val ec = EventContext.Global
 
   def syncConnections(): Future[SyncResult] = {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -20,6 +20,7 @@ package com.waz.sync.handler
 import java.util.Date
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ErrorType
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.MessagesStorageImpl
@@ -48,7 +49,6 @@ class ConversationsSyncHandler(assetSync: AssetSyncHandler,
 
   import Threading.Implicits.Background
   import com.waz.sync.handler.ConversationsSyncHandler._
-  private implicit val tag: LogTag = logTagFor[ConversationsSyncHandler]
   private implicit val ec = EventContext.Global
 
   def syncConversations(ids: Seq[ConvId]): Future[SyncResult] = {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/InvitationSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/InvitationSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.Invitation
 import com.waz.service.UserServiceImpl
@@ -32,7 +33,6 @@ import scala.concurrent.Future
 
 class InvitationSyncHandler(invitationService: InvitationService, userService: UserServiceImpl, userSync: UsersSyncHandler, client: InvitationClient, connections: ConnectionsClient) {
   import Threading.Implicits.Background
-  private implicit val logTag: LogTag = logTagFor[InvitationSyncHandler]
 
   def postInvitation(i: Invitation): Future[SyncResult] =
     client.postInvitation(i).future.flatMap {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.ConversationStorageImpl
 import com.waz.model.GenericContent.LastRead
@@ -31,7 +32,6 @@ import scala.concurrent.Future
 
 class LastReadSyncHandler(selfUserId: UserId, convs: ConversationStorageImpl, metadata: MetaDataService, convSync: ConversationsSyncHandler, msgsSync: MessagesSyncHandler, otrSync: OtrSyncHandler) {
   import com.waz.threading.Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[LastReadSyncHandler]
 
   def postLastRead(convId: ConvId, time: Instant): Future[SyncResult] = {
     verbose(s"postLastRead($convId, $time)")

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -20,6 +20,7 @@ package com.waz.sync.handler
 import android.content.Context
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.impl.ErrorResponse.internalError
 import com.waz.api.{EphemeralExpiration, Message}
@@ -57,8 +58,6 @@ class MessagesSyncHandler(context: Context, service: MessagesServiceImpl, msgCon
                           members: MembersStorageImpl, errors: ErrorsService, timeouts: Timeouts) {
 
   import com.waz.threading.Threading.Implicits.Background
-
-  private implicit val logTag: LogTag = logTagFor[MessagesSyncHandler]
 
   def postDeleted(convId: ConvId, msgId: MessageId): Future[SyncResult] =
     convs.convById(convId) flatMap {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/OpenGraphSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
 import com.waz.api.Message.Part
 import com.waz.api.impl.ErrorResponse
@@ -40,7 +41,6 @@ import org.threeten.bp.Instant
 import scala.concurrent.Future
 
 class OpenGraphSyncHandler(convs: ConversationStorageImpl, messages: MessagesStorageImpl, otrService: OtrServiceImpl, assetSync: AssetSyncHandler, assetsStorage: AssetsStorage, otrSync: OtrSyncHandler, client: OpenGraphClient, imageGenerator: ImageAssetGenerator, imageLoader: ImageLoader, assetClient: AssetClient) {
-  import OpenGraphSyncHandler._
   import com.waz.threading.Threading.Implicits.Background
 
   def postMessageMeta(convId: ConvId, msgId: MessageId, editTime: Instant): Future[SyncResult] = messages.getMessage(msgId) flatMap {
@@ -168,8 +168,4 @@ class OpenGraphSyncHandler(convs: ConversationStorageImpl, messages: MessagesSto
           Right(LinkPreview(URI.parse(prev.url), prev.urlOffset, meta.title, meta.description, imageAsset.map(Asset(_)), meta.permanentUrl))
       }
   }
-}
-
-object OpenGraphSyncHandler {
-  private implicit val tag: LogTag = logTagFor[OpenGraphSyncHandler]
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TypingSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TypingSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.ConvId
 import com.waz.service.conversation._
 import com.waz.sync.SyncResult
@@ -29,7 +30,6 @@ import scala.concurrent.Future
 class TypingSyncHandler(client: TypingClient, convs: ConversationsContentUpdaterImpl, typingService: TypingService) {
 
   import Threading.Implicits.Background
-  private implicit val logTag: LogTag = logTagFor[TypingSyncHandler]
 
   def postTypingState(convId: ConvId, typing: Boolean): Future[SyncResult] = {
     convs.convById(convId) flatMap {

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.content.SearchQueryCacheStorage
 import com.waz.model.SearchQuery
 import com.waz.service.UserSearchService
@@ -34,7 +35,6 @@ object UserSearchSyncHandler {
 
 class UserSearchSyncHandler(storage: SearchQueryCacheStorage, userSearch: UserSearchService, client: UserSearchClient) {
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[UserSearchSyncHandler]
 
   def syncSearchQuery(query: SearchQuery): Future[SyncResult] = {
     debug(s"starting sync for: $query")

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UsersStorageImpl
 import com.waz.model._
@@ -33,7 +34,6 @@ import scala.concurrent.Future
 
 class UsersSyncHandler(assetSync: AssetSyncHandler, userService: UserServiceImpl, usersStorage: UsersStorageImpl, assets: AssetService, usersClient: UsersClient, imageGenerator: ImageAssetGenerator) {
   import Threading.Implicits.Background
-  private implicit val tag: LogTag = logTagFor[UsersSyncHandler]
   private implicit val ec = EventContext.Global
 
   def syncUsers(ids: UserId*): Future[SyncResult] = usersClient.loadUsers(ids).future flatMap {

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
@@ -20,6 +20,7 @@ package com.waz.sync.otr
 import android.content.Context
 import android.location.Geocoder
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ClientRegistrationState._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.{ClientRegistrationState, ZmsVersion}
@@ -39,7 +40,6 @@ import scala.collection.breakOut
 import scala.concurrent.Future
 
 class OtrClientsSyncHandler(context: Context, accountId: AccountId, userId: UserId, clientId: Signal[Option[ClientId]], netClient: OtrClient, otrClients: OtrClientsService, storage: OtrClientsStorage, cryptoBox: CryptoBoxService, userPrefs: UserPreferences) {
-  import OtrClientsSyncHandler._
   import com.waz.threading.Threading.Implicits.Background
 
   lazy val sessions = cryptoBox.sessions
@@ -201,6 +201,3 @@ class OtrClientsSyncHandler(context: Context, accountId: AccountId, userId: User
   }
 }
 
-object OtrClientsSyncHandler {
-  private implicit val tag: LogTag = logTagFor[OtrClientsSyncHandler]
-}

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -18,6 +18,7 @@
 package com.waz.sync.queue
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.SyncState
 import com.waz.content._
 import com.waz.model.SyncId
@@ -39,7 +40,6 @@ import scala.concurrent.Future
 class SyncContentUpdater(storage: ZmsDatabase) {
   import EventContext.Implicits.global
 
-  private implicit val logTag: LogTag = logTagFor[SyncContentUpdater]
   private implicit val dispatcher = new SerialDispatchQueue(name = "SyncContentUpdaterQueue")
 
   private val mergers = new mutable.HashMap[Any, SyncJobMerger]

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
@@ -19,6 +19,7 @@ package com.waz.sync.queue
 
 import com.waz.HockeyApp
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.SyncState
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.SyncId
@@ -34,7 +35,6 @@ import scala.util.Failure
 import scala.util.control.NoStackTrace
 
 class SyncExecutor(scheduler: SyncScheduler, content: SyncContentUpdater, network: NetworkModeService, handler: => SyncHandler) {
-  import SyncExecutor._
   private implicit val dispatcher = new SerialDispatchQueue(name = "SyncExecutorQueue")
 
   def apply(job: SyncJob): Future[SyncResult] = job.request match {
@@ -132,8 +132,6 @@ class SyncExecutor(scheduler: SyncScheduler, content: SyncContentUpdater, networ
 }
 
 object SyncExecutor {
-  implicit val tag: LogTag = logTagFor[SyncExecutor]
-
   val RequestRetryBackoff = new ExponentialBackoff(5.seconds, 1.day)
   val ConvRequestRetryBackoff = new ExponentialBackoff(5.seconds, 1.hour)
 

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncJobMerger.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncJobMerger.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.sync.queue
 
-import com.waz.ZLog._
 import com.waz.api.SyncState
 import com.waz.content.SyncStorage
 import com.waz.model.SyncId
@@ -123,7 +122,6 @@ class SyncJobMerger(mergeKey: Any, storage: SyncStorage) {
 }
 
 object SyncJobMerger {
-  implicit val tag: LogTag = logTagFor[SyncJobMerger]
 
   sealed trait MergeResult[+A]
   case object Unchanged extends MergeResult[Nothing]

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncScheduler.scala
@@ -23,6 +23,7 @@ import android.app.{AlarmManager, PendingIntent}
 import android.content.Context
 import android.support.v4.content.WakefulBroadcastReceiver
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.NetworkMode
 import com.waz.model.sync.SyncJob
 import com.waz.model.{AccountId, ConvId, SyncId}
@@ -44,7 +45,6 @@ class SyncScheduler(context: Context, userId: AccountId, val content: SyncConten
   import EventContext.Implicits.global
   import content._
 
-  private implicit val tag = logTagFor[SyncScheduler]
   private implicit val dispatcher = new SerialDispatchQueue(name = "SyncSchedulerQueue")
 
   private[sync] lazy val alarmSyncIntent = PendingIntent.getService(context, SyncScheduler.AlarmRequestCode, SyncService.intent(context, userId), PendingIntent.FLAG_UPDATE_CURRENT)

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
@@ -20,6 +20,7 @@ package com.waz.sync.queue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.model.ConvId
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.threading.SerialDispatchQueue
@@ -101,7 +102,6 @@ class SyncSerializer {
 }
 
 object SyncSerializer {
-  private implicit val tag: LogTag = logTagFor[SyncSerializer]
   private val seq = new AtomicLong(0)
 
   abstract class WaitHandle[A] {

--- a/zmessaging/src/main/scala/com/waz/threading/DispatchQueue.scala
+++ b/zmessaging/src/main/scala/com/waz/threading/DispatchQueue.scala
@@ -38,7 +38,7 @@ trait DispatchQueue extends ExecutionContext {
   def apply[A](task: => A)(implicit tag: LogTag = ""): CancellableFuture[A] = CancellableFuture(task)(this, tag)
 
   //TODO: this implements ExecutionContext.reportFailure, should we use different log here? or maybe do something else
-  override def reportFailure(t: Throwable): Unit = error("reportFailure called", t)(logTagFor[DispatchQueue])
+  override def reportFailure(t: Throwable): Unit = error("reportFailure called", t)(name)
 
   //used for waiting in tests
   def hasRemainingTasks: Boolean = false

--- a/zmessaging/src/main/scala/com/waz/threading/Threading.scala
+++ b/zmessaging/src/main/scala/com/waz/threading/Threading.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.{Executor, ExecutorService, Executors}
 
 import android.os.{Handler, HandlerThread, Looper}
 import com.waz.ZLog._
-import com.waz.ZLog.ImplicitTag._
 import com.waz.api.ZmsVersion
 import com.waz.utils.returning
 

--- a/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
@@ -19,6 +19,7 @@ package com.waz.ui
 
 import android.graphics.{Bitmap => ABitmap}
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap
 import com.waz.model.AssetId
 import com.waz.threading.{CancellableFuture, Threading}
@@ -29,8 +30,6 @@ import com.waz.utils.wrappers.{Bitmap, Context}
 
 class MemoryImageCache(lru: Cache[MemoryImageCache.Key, MemoryImageCache.Entry]) {
   import MemoryImageCache._
-
-  private implicit val logTag: LogTag = logTagFor[MemoryImageCache]
 
   def get(id: AssetId, req: BitmapRequest, imgWidth: Int): Option[Bitmap] = Option(lru.get(Key(id, tag(req)))) flatMap {
     case BitmapEntry(bmp) if bmp.getWidth >= req.width || (imgWidth > 0 && bmp.getWidth > imgWidth) => Some(bmp)

--- a/zmessaging/src/main/scala/com/waz/ui/Messages.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/Messages.scala
@@ -20,6 +20,7 @@ package com.waz.ui
 import android.os.Parcel
 import com.waz.Control.getOrUpdate
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.impl.Message
 import com.waz.model._
@@ -34,7 +35,6 @@ import scala.collection.Seq
 import scala.concurrent.Future
 
 class Messages(implicit module: UiModule) {
-  import Messages._
   import Threading.Implicits.Background
 
   val messages = new UiCache[MessageId, Message](lruSize = 50)
@@ -74,8 +74,4 @@ class Messages(implicit module: UiModule) {
   def updateLastRead(conv: ConvId, msg: MessageData) = module.zms.flatMapFuture(_.convsUi.setLastRead(conv, msg)).recoverWithLog(reportHockey = true)
 
   def retry(conv: ConvId, msg: MessageId): Unit = module.zms(_.messages.retryMessageSending(conv, msg)).future.recoverWithLog(reportHockey = true)
-}
-
-object Messages {
-  private implicit val logTag: LogTag = logTagFor[Messages]
 }

--- a/zmessaging/src/main/scala/com/waz/ui/SignalLoading.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/SignalLoading.scala
@@ -18,6 +18,7 @@
 package com.waz.ui
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.service.{AccountService, ZMessaging}
 import com.waz.threading.Threading
 import com.waz.ui.SignalLoader.{AccountLoaderHandle, LoaderHandle, LoadingReference, ZmsLoaderHandle}
@@ -90,8 +91,6 @@ object LoaderSubscription {
 abstract class SignalLoader[A](handle: LoaderHandle[A])(implicit ui: UiModule) extends LoaderSubscription {
   import ui.eventContext
 
-  implicit val tag: LogTag = s"SignalLoader[${handle.loading.getClass.getName}]"
-
   ui.onResumed { _ => SignalLoader.dropQueue() }
 
   val ref = new LoadingReference(this, handle)
@@ -110,7 +109,7 @@ abstract class SignalLoader[A](handle: LoaderHandle[A])(implicit ui: UiModule) e
   }
 
   def destroy(): Unit = {
-    verbose("destroy()")
+    verbose("destroy()")(s"SignalLoader[${handle.loading.getClass.getName}]")
     observer.destroy()
     ref.get.foreach { handle => handle.loading.loaderHandles -= handle }
     ref.clear()
@@ -126,7 +125,6 @@ class AccountSignalLoader[A](handle: AccountLoaderHandle[A])(implicit ui: UiModu
 }
 
 object SignalLoader {
-  implicit val tag: LogTag = logTagFor(SignalLoader)
 
   private val queue = new ReferenceQueue[LoaderHandle[_]]
 

--- a/zmessaging/src/main/scala/com/waz/ui/UiCache.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/UiCache.scala
@@ -20,6 +20,7 @@ package com.waz.ui
 import android.support.v4.util.LruCache
 import com.waz.CacheLike
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.service.ZMessaging
 import com.waz.threading.Threading
 import com.waz.utils.ThrottledProcessingQueue
@@ -30,7 +31,6 @@ import scala.concurrent.Future
 import scala.ref.{ReferenceQueue, WeakReference}
 
 class UiCache[Key, A <: AnyRef](lruSize: Int = 0)(implicit ui: UiModule) extends CacheLike[Key, A] {
-  private implicit val tag: LogTag = logTagFor[UiCache[_, _]]
 
   val queue = new ReferenceQueue[A]
   val lru = new LruCache[Key, A](lruSize max 1)

--- a/zmessaging/src/main/scala/com/waz/ui/Users.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/Users.scala
@@ -20,6 +20,7 @@ package com.waz.ui
 import android.os.Parcel
 import com.waz.Control.getOrUpdate
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.IConversation
 import com.waz.api.impl._
@@ -31,8 +32,6 @@ import com.waz.utils.{JsonDecoder, returning}
 class Users(implicit ui: UiModule) {
   import com.waz.threading.Threading.Implicits.Background
   import ui.{convs, images, zms}
-
-  private implicit val tag: LogTag = logTagFor[Users]
 
   def getPicture(imageId: Option[AssetId]): api.ImageAsset = imageId.fold[api.ImageAsset](ImageAsset.Empty)(images.getImageAsset)
 

--- a/zmessaging/src/main/scala/com/waz/utils/EventProcessingQueue.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/EventProcessingQueue.scala
@@ -127,7 +127,7 @@ class ThrottledProcessingQueue[A](delay: FiniteDuration, processor: Seq[A] => Fu
         val d = math.max(0, lastDispatched - System.currentTimeMillis() + delay.toMillis)
         verbose(s"processQueue, delaying: $d millis")
         waitFuture = CancellableFuture.delay(d.millis)
-        if (!waiting.get()) waitFuture.cancel() // to avoid race conditions with `flush`
+        if (!waiting.get()) waitFuture.cancel()(logTag) // to avoid race conditions with `flush`
         waitFuture.future.flatMap { _ =>
           CancellableFuture.lift(processQueueNow())
         } .recover {
@@ -145,7 +145,7 @@ class ThrottledProcessingQueue[A](delay: FiniteDuration, processor: Seq[A] => Fu
 
   def flush() = {
     waiting.set(false)
-    waitFuture.cancel()
+    waitFuture.cancel()(logTag)
     post {
       processQueueNow()
     }

--- a/zmessaging/src/main/scala/com/waz/utils/TrimmingLruCache.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/TrimmingLruCache.scala
@@ -22,6 +22,7 @@ import android.content.res.Configuration
 import android.content.{ComponentCallbacks2, Context}
 import android.support.v4.util.LruCache
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.TrimmingLruCache.CacheSize
 
 trait Cache[K, V] {
@@ -68,7 +69,6 @@ object TrimmingLruCache {
 
 trait AutoTrimming extends ComponentCallbacks2 { self: LruCache[_, _] =>
   import com.waz.utils.AutoTrimming._
-  private implicit val tag: LogTag = logTagFor[AutoTrimming]
 
   def context: Context
 

--- a/zmessaging/src/main/scala/com/waz/utils/events/AggregatingSignal.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/events/AggregatingSignal.scala
@@ -19,6 +19,7 @@ package com.waz.utils.events
 
 import java.util.concurrent.atomic.AtomicReference
 
+import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.threading.Threading
 
@@ -26,8 +27,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 class AggregatingSignal[A, B](source: EventStream[A], load: => Future[B], f: (B, A) => B, stashing: Boolean = true) extends Signal[B] with EventListener[A] {
-  import AggregatingSignal.logTag
-
   private object valueMonitor
   private val loadId = new AtomicReference[AnyRef]
   @volatile private var stash = Vector.empty[A]
@@ -69,6 +68,3 @@ class AggregatingSignal[A, B](source: EventStream[A], load: => Future[B], f: (B,
   }
 }
 
-object AggregatingSignal {
-  private implicit val logTag: LogTag = logTagFor(AggregatingSignal)
-}

--- a/zmessaging/src/main/scala/com/waz/utils/events/ClockSignal.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/events/ClockSignal.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.utils.events
 
-import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.CancellableFuture
 import com.waz.threading.CancellableFuture.delayed

--- a/zmessaging/src/main/scala/com/waz/utils/events/EventContext.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/events/EventContext.scala
@@ -20,11 +20,9 @@ package com.waz.utils.events
 import android.app.{Activity, Fragment, Service}
 import android.view.View
 import com.waz.ZLog
-import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 
 trait EventContext {
-  private implicit val logTag: LogTag = logTagFor[EventContext]
-
   private object lock
 
   private[this] var started = false

--- a/zmessaging/src/main/scala/com/waz/utils/events/EventStream.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/events/EventStream.scala
@@ -20,6 +20,7 @@ package com.waz.utils.events
 import java.util.UUID.randomUUID
 
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.Events.Subscriber
 import com.waz.utils.{Serialized, returning}
@@ -102,7 +103,6 @@ class MapEventStream[E, V](source: EventStream[E], f: E => V) extends ProxyEvent
 }
 
 class FutureEventStream[E, V](source: EventStream[E], f: E => Future[V]) extends ProxyEventStream[E, V](source) {
-  import FutureEventStream._
   private val key = randomUUID()
 
   override protected[events] def onEvent(event: E, sourceContext: Option[ExecutionContext]): Unit =
@@ -111,9 +111,6 @@ class FutureEventStream[E, V](source: EventStream[E], f: E => Future[V]) extends
       case Failure(t: NoSuchElementException) => // do nothing to allow Future.filter/collect
       case Failure(t) => error("async map failed", t)
     }(sourceContext.orElse(executionContext).getOrElse(Threading.Background)))
-}
-object FutureEventStream {
-  private implicit val logTag: LogTag = logTagFor(FutureEventStream)
 }
 
 class CollectEventStream[E, V](source: EventStream[E], pf: PartialFunction[E, V]) extends ProxyEventStream[E, V](source) {

--- a/zmessaging/src/main/scala/com/waz/zms/SyncService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/SyncService.scala
@@ -25,6 +25,7 @@ import com.waz.model.AccountId
 import scala.concurrent.Future
 
 class SyncService extends FutureService with ZMessagingService {
+
   import com.waz.threading.Threading.Implicits.Background
 
   override protected def onIntent(intent: Intent, id: Int): Future[Any] =

--- a/zmessaging/src/main/scala/com/waz/zms/WebSocketService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/WebSocketService.scala
@@ -37,7 +37,7 @@ import scala.concurrent.Future
   */
 class WebSocketBroadcastReceiver extends BroadcastReceiver {
   override def onReceive(context: Context, intent: Intent): Unit = {
-    debug(s"onReceive $intent")("WebSocketBroadcastReceiver")
+    debug(s"onReceive $intent")
     WakefulBroadcastReceiver.startWakefulService(context, new Intent(context, classOf[WebSocketService]))
   }
 }

--- a/zmessaging/src/main/scala/com/waz/znet/AuthenticationManager.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/AuthenticationManager.scala
@@ -19,6 +19,7 @@ package com.waz.znet
 
 import com.koushikdutta.async.http.AsyncHttpRequest
 import com.waz.ZLog._
+import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.{Credentials, EmailCredentials, ErrorResponse}
 import com.waz.content.Preferences.Preference
 import com.waz.model.{AccountId, EmailAddress}
@@ -168,8 +169,6 @@ class AuthenticationManager(client: LoginClient, user: CredentialsHandler) exten
 }
 
 object AuthenticationManager {
-  private implicit val logTag: LogTag = logTagFor[AuthenticationManager]
-
   val MaxRetryCount = 3
   val expireThreshold = 15 * 1000 // refresh access token on background if it is close to expire
 


### PR DESCRIPTION
* An InternalLog object lying just under ZLog and taking most of its work: comparing log levels, and redirecting to Android and to our own log file.
* Logging to file is buffered. The contents are flushed when they grow over 1MB or on specific events (defined in UI)
* ZLog macros work better now. If DebugMode is false they are expanded to empty strings. Before they were expanded to "if (DEBUG) ... else ..."
* A new reporter in ReportingService
* logTag assignments replaced with implicitLogTag in many places 