### PR TITLE
user_agent set in headers in AsyncClient instead of RequestWorker

### DIFF
--- a/tests/unit/src/test/scala/com/waz/znet/AsyncClientSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/znet/AsyncClientSpec.scala
@@ -141,7 +141,7 @@ class AsyncClientSpec extends AndroidFreeSpec {
     }
 
   private val requestWorker = new RequestWorker {
-    override def processRequest(req: HttpRequest, additionalHeaders: (String, String)*): HttpRequest = req
+    override def processRequest(req: HttpRequest): HttpRequest = req
   }
 
   class FakeClientWrapper(delay: Option[Long] = None) extends ClientWrapper {

--- a/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
@@ -69,9 +69,10 @@ class AsyncClientImpl(bodyDecoder: ResponseBodyDecoder = DefaultResponseBodyDeco
       @volatile var timeoutForPhase = requestTimeout
       val interval = 5.seconds min request.timeout
 
-      // switching off the AsyncHttpClient's timeout - we will use our own
-      val requestBuilt = requestWorker.processRequest(request.withTimeout(0.millis), AsyncClient.UserAgentHeader -> userAgent)
-
+      val ua = request.headers.getOrElse(AsyncClient.UserAgentHeader, userAgent)
+      val requestBuilt = requestWorker.processRequest(
+        request.withTimeout(0.millis).withHeaders(Map(AsyncClient.UserAgentHeader -> ua))
+      ) // switching off the AsyncHttpClient's timeout - we will use our own
       debug(s"request headers: ${requestBuilt.headers}")
 
       val httpFuture = client.execute(requestBuilt, new HttpConnectCallback {

--- a/zmessaging/src/main/scala/com/waz/znet/HttpRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/HttpRequest.scala
@@ -37,7 +37,10 @@ class HttpRequestImpl(val req: AsyncHttpRequest) extends HttpRequest {
   override val absoluteUri: Option[URI] = Some(new AndroidURI(req.getUri()))
   override val httpMethod: String = req.getMethod()
   override val getBody: RequestContent = EmptyRequestContent // TODO
-  override val headers: Map[String, String] = HttpRequest.getHeaders(req)
+  override val headers: Map[String, String] = {
+    val m = req.getHeaders().getMultiMap()
+    m.keySet().asScala.toSet[String].map(k => (k -> m.getString(k))).toMap
+  }
   override val followRedirect: Boolean = req.getFollowRedirect()
   override val timeout: FiniteDuration = req.getTimeout().millis
 }
@@ -52,32 +55,18 @@ object HttpRequest {
     case wrapper: HttpRequestImpl => wrapper.req
     case _ => throw new IllegalArgumentException(s"Expected AsyncHttpRequest, but tried to unwrap: $req")
   }
-
-  def getHeaders(req: AsyncHttpRequest) = {
-    val m = req.getHeaders().getMultiMap()
-    m.keySet().asScala.toSet[String].map(k => (k -> m.getString(k))).toMap
-  }
 }
 
 trait RequestWorker {
-  def processRequest(request: HttpRequest, additionalHeaders: (String, String)*): HttpRequest
+  def processRequest(request: HttpRequest): HttpRequest
 }
 
 class HttpRequestImplWorker extends RequestWorker {
-  override def processRequest(request: HttpRequest, additionalHeaders: (String, String)*): HttpRequest = {
+  override def processRequest(request: HttpRequest): HttpRequest = {
     val r = new AsyncHttpRequest(URI.unwrap(request.absoluteUri.getOrElse(throw new IllegalArgumentException("URI not provided")).normalizeScheme), request.httpMethod)
     r.setTimeout(request.timeout.toMillis.toInt)
     r.setFollowRedirect(request.followRedirect)
-
-    // if 'r' is created with some headers, they have the highest priority, then headers from 'request', and only then 'additionalHeaders'
-    val h1 = HttpRequest.getHeaders(r).filter(_._2 != "")
-    val h2 = request.headers.filterKeys(key => !h1.contains(key))
-    val h3 = additionalHeaders.toMap.filterKeys(key => !h1.contains(key) && !h2.contains(key))
-    (h1 ++ h2 ++ h3).foreach {
-      case (key, value) => r.getHeaders.set(key, value)
-      case _ =>
-    }
-
+    request.headers.foreach(p => r.getHeaders.set(p._1, p._2.trim))
     new HttpRequestImpl(request.getBody.apply(r))
   }
 }


### PR DESCRIPTION
Everything works the same as before, but RequestWorker.processRequest exists only because we need a way t go around AsyncHttpRequest limitations. As such, it's better to keep it as simple as possible and, for example, prepare the headers before it is called.