### PR TITLE
Removes TeamMembers

### DIFF
--- a/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
+++ b/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
@@ -84,8 +84,8 @@ class DeviceActor(val deviceName: String,
     }
 
     override lazy val factory: ZMessagingFactory = new ZMessagingFactory(this) {
-      override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging =
-        new ZMessaging(clientId, user) {
+      override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): ZMessaging =
+        new ZMessaging(teamId, clientId, user) {
 
         }
     }

--- a/tests/integration/src/test/scala/com/waz/invitations/PersonalInvitationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/invitations/PersonalInvitationSpec.scala
@@ -149,8 +149,8 @@ class PersonalInvitationSpec extends FeatureSpec with Matchers with BeforeAndAft
   lazy val internalBackendClient = new InternalBackendClient(globalModule.client, testBackend)
 
   override lazy val zmessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): service.ZMessaging =
-      new service.ZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): service.ZMessaging =
+      new service.ZMessaging(teamId, clientId, user) {
         override lazy val invitationClient = new InvitationClient(zNetClient) {
           override def postInvitation(i: Invitation): ErrorOrResponse[Either[UserId, ConfirmedInvitation]] =
             lift(super.postInvitation(i).andThen { case Success(Right(Right(inv))) => invitation = Some(inv) })

--- a/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AssetMessageSpec.scala
@@ -663,8 +663,8 @@ class AssetMessageSpec extends FeatureSpec with BeforeAndAfter with Matchers wit
 
   override lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
 
-    override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging =
-      new ApiZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule): ZMessaging =
+      new ApiZMessaging(teamId, clientId, userModule) {
 
         override lazy val otrSync = new OtrSyncHandlerImpl(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {
           override def postOtrMessage(convId: ConvId, remoteId: RConvId, message: GenericMessage, recipients: Option[Set[UserId]], nativePush: Boolean = true): Future[Either[ErrorResponse, Date]] =

--- a/tests/integration/src/test/scala/com/waz/messages/AudioMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AudioMessageSpec.scala
@@ -115,8 +115,8 @@ class AudioMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   @volatile private var isAudioMessageFromTest = Set.empty[CacheKey]
 
   override lazy val zmessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): service.ZMessaging =
-      new ApiZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule): service.ZMessaging =
+      new ApiZMessaging(teamId, clientId, userModule) {
         override lazy val assetMetaData = new MetaDataService(context, cache, assetsStorage, assets, assetGenerator) {
           override def loadMetaData(asset: AssetData, data: LocalData): CancellableFuture[Option[AssetMetaData]] = (asset.mime, data) match {
             case (Mime.Audio(), entry: CacheEntry) if isAudioMessageFromTest(entry.data.key) =>

--- a/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
@@ -24,6 +24,7 @@ import com.waz.api.MessageContent.Image
 import com.waz.api._
 import com.waz.api.impl.LocalImageAsset
 import com.waz.cache.CacheEntry
+import com.waz.model.TeamId
 import com.waz.model.otr.ClientId
 import com.waz.provision.ActorMessage.{AwaitSyncCompleted, Login, Successful}
 import com.waz.service._
@@ -104,8 +105,8 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
   }
 
   override lazy val zmessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging =
-      new ZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): ZMessaging =
+      new ZMessaging(teamId, clientId, user) {
         override lazy val assetClient = new AssetClientImpl(zNetClient) {
 
           override def loadAsset(req: Request[Unit]): ErrorOrResponse[CacheEntry] = {

--- a/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
@@ -25,7 +25,7 @@ import com.waz.api._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.GenericContent.LastRead
 import com.waz.model.otr.ClientId
-import com.waz.model.{ConvId, GenericMessage, RConvId, UserId}
+import com.waz.model._
 import com.waz.provision.ActorMessage.{AwaitSyncCompleted, Login, SendText, Successful}
 import com.waz.service._
 import com.waz.sync.otr.{OtrSyncHandler, OtrSyncHandlerImpl}
@@ -60,7 +60,7 @@ class LastReadSpec extends FeatureSpec with Matchers with BeforeAndAfterAll with
   }
 
   override lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, userModule: UserModule): ZMessaging = new ApiZMessaging(clientId, userModule) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule): ZMessaging = new ApiZMessaging(teamId, clientId, userModule) {
 
 
       override lazy val otrSync: OtrSyncHandler = new OtrSyncHandlerImpl(otrClient, messagesClient, assetClient, otrService, assets, conversations, convsStorage, users, messages, errors, otrClientsSync, cache) {

--- a/tests/integration/src/test/scala/com/waz/messages/MessageReactionsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/MessageReactionsSpec.scala
@@ -186,7 +186,7 @@ class MessageReactionsSpec extends FeatureSpec with Matchers with BeforeAndAfter
   @volatile var delayMessages = false
 
   override lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(teamId, clientId, user) {
       override lazy val messagesClient = new MessagesClient(netClient) {
         override def postMessage(conv: RConvId, content: OtrMessage, ignoreMissing: Boolean, receivers: Option[Set[UserId]] = None): ErrorOrResponse[MessageResponse] =
           if (! delayMessages) super.postMessage(conv, content, ignoreMissing, receivers)

--- a/tests/integration/src/test/scala/com/waz/users/AddressBookSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/users/AddressBookSpec.scala
@@ -149,7 +149,7 @@ class AddressBookSpec extends FeatureSpec with Matchers with BeforeAndAfter with
   def newClient = new RegistrationClient(new AsyncClientImpl(wrapper = TestClientWrapper()), testBackend)
 
   override lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(clientId, user) {
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(teamId, clientId, user) {
       override lazy val userSearchClient: UserSearchClient = new UserSearchClient(netClient) {
         // server response will not update immediately with newly registered users, thus we fail the sync request
         // which will cause the search to use local suggestions, which should find the contacts because

--- a/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/MockedClientSuite.scala
@@ -68,7 +68,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
     override lazy val otrClient: OtrClient = new MockedOtrClient(account.netClient)
   }
 
-  class MockedZMessaging(clientId: ClientId, userModule: UserModule) extends ZMessaging(clientId, userModule) {
+  class MockedZMessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule) extends ZMessaging(teamId, clientId, userModule) {
 
     override lazy val flowmanager: DefaultFlowManagerService = new MockedFlowManagerService(context, zNetClient, websocket, prefs, network)
     override lazy val mediamanager: DefaultMediaManagerService = new MockedMediaManagerService(context, prefs)
@@ -162,7 +162,7 @@ trait MockedClientSuite extends ApiSpec with MockedClient with MockedWebSocket w
 
     override def userModule(userId: UserId, account: AccountService) = new MockedUserModule(userId, account)
 
-    override def zmessaging(clientId: ClientId, userModule: UserModule): ZMessaging = new MockedZMessaging(clientId, userModule)
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule): ZMessaging = new MockedZMessaging(teamId, clientId, userModule)
 
   }
 

--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -99,6 +99,7 @@ object Generators {
 
   implicit lazy val arbUserData: Arbitrary[UserData] = Arbitrary(for {
     id <- arbitrary[UserId]
+    teamId <- arbitrary[Option[TeamId]]
     name <- arbitrary[String]
     email <- arbitrary[Option[EmailAddress]]
     phone <- arbitrary[Option[PhoneNumber]]
@@ -114,7 +115,7 @@ object Generators {
     syncTimestamp <- posNum[Long]
     displayName <- arbitrary[String]
     handle <- arbitrary[Option[Handle]]
-  } yield UserData(id, name, email, phone, trackingId, picture, accent, searchKey, connection, connectionLastUpdated, connectionMessage, conversation, relation, syncTimestamp, displayName, handle = handle))
+  } yield UserData(id, teamId, name, email, phone, trackingId, picture, accent, searchKey, connection, connectionLastUpdated, connectionMessage, conversation, relation, syncTimestamp, displayName, handle = handle))
 
   implicit lazy val arbOpenGraphData: Arbitrary[OpenGraphData] = Arbitrary(resultOf(OpenGraphData))
 

--- a/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/api/impl/RegistrationSpec.scala
@@ -88,8 +88,8 @@ class RegistrationSpec extends FeatureSpec with Matchers with OptionValues with 
       override def register(user: AccountId, credentials: Credentials, name: String, accentId: Option[Int]) = CancellableFuture.successful(registerResponse)
     }
     override lazy val factory = new MockZMessagingFactory(this) {
-      override def zmessaging(clientId: ClientId, userModule: UserModule): service.ZMessaging =
-        new service.ZMessaging(clientId, userModule) {
+      override def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule): service.ZMessaging =
+        new service.ZMessaging(teamId, clientId, userModule) {
           override lazy val sync = new EmptySyncService {
             override def syncSelfUser(): Future[SyncId] = {
               selfUserSyncRequested = true

--- a/tests/unit/src/test/scala/com/waz/db/ZGlobalDBSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/db/ZGlobalDBSpec.scala
@@ -116,5 +116,6 @@ class ZGlobalDBSpec extends FeatureSpec with Matchers with OptionValues with Ins
         updated shouldEqual changed
       }
     }
+
   }
 }

--- a/tests/unit/src/test/scala/com/waz/db/ZGlobalDBSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/db/ZGlobalDBSpec.scala
@@ -88,8 +88,8 @@ class ZGlobalDBSpec extends FeatureSpec with Matchers with OptionValues with Ins
           user.phone shouldBe empty
         }
         AccountDataDao.list shouldEqual Seq(
-          AccountData(AccountId("8546c628-c9e8-45d6-82dd-7f6dcb56e171"), Some(EmailAddress("joachim.hofer+001@wearezeta.com")), "Xx/rjrJc0B/MhvaAt/aegKrs+bohYNkBTnZ3wJbl+Pg=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("nK4NNJ7XN9-riGCcJ6YDCIXYEpHSYJWV2L9s3at1brf33Nb5TcFjY341iQHhQ7GjAS8sDgfXNx6NvzmSyXDXBQ==.v=1.k=1.d=1458844442.t=u.l=.u=e222adf6-22a0-4180-b628-936049f0899f.r=ccaae5e6")), userId = Some(userId1)),
-          AccountData(AccountId("09621ddd-736f-4ec5-b4b5-d24cbb56b9f3"), Some(EmailAddress("joachim.hofer+003@wearezeta.com")), "WtjSXe7G8CHlcy4PRxGoaisUr9UGyKR51zriDwIFAco=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("u0mEC2etISwrAAf-_pNwG204HG5-Uf7EIRFFTp1TEqKGcSIXDbFC9_i8PftnKRTWSjUsAbZ-PHVIxS3eZDK-AQ==.v=1.k=1.d=1459026632.t=u.l=.u=9a01b792-42f6-4dee-a3c0-e22179d742f8.r=591684f6")), userId = Some(userId2) )
+          AccountData(AccountId("8546c628-c9e8-45d6-82dd-7f6dcb56e171"), None, Some(EmailAddress("joachim.hofer+001@wearezeta.com")), "Xx/rjrJc0B/MhvaAt/aegKrs+bohYNkBTnZ3wJbl+Pg=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("nK4NNJ7XN9-riGCcJ6YDCIXYEpHSYJWV2L9s3at1brf33Nb5TcFjY341iQHhQ7GjAS8sDgfXNx6NvzmSyXDXBQ==.v=1.k=1.d=1458844442.t=u.l=.u=e222adf6-22a0-4180-b628-936049f0899f.r=ccaae5e6")), userId = Some(userId1)),
+          AccountData(AccountId("09621ddd-736f-4ec5-b4b5-d24cbb56b9f3"), None, Some(EmailAddress("joachim.hofer+003@wearezeta.com")), "WtjSXe7G8CHlcy4PRxGoaisUr9UGyKR51zriDwIFAco=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("u0mEC2etISwrAAf-_pNwG204HG5-Uf7EIRFFTp1TEqKGcSIXDbFC9_i8PftnKRTWSjUsAbZ-PHVIxS3eZDK-AQ==.v=1.k=1.d=1459026632.t=u.l=.u=9a01b792-42f6-4dee-a3c0-e22179d742f8.r=591684f6")), userId = Some(userId2) )
         )
       }
     }
@@ -98,8 +98,8 @@ class ZGlobalDBSpec extends FeatureSpec with Matchers with OptionValues with Ins
       Managed(loadDb("/db/ZGlobal_7.db")) foreach { implicit db: DB =>
         dbHelper.onUpgrade(db, 7, ZGlobalDB.DbVersion)
         AccountDataDao.list shouldEqual Seq(
-          AccountData(AccountId("8546c628-c9e8-45d6-82dd-7f6dcb56e171"), Some(EmailAddress("joachim.hofer+001@wearezeta.com")), "Xx/rjrJc0B/MhvaAt/aegKrs+bohYNkBTnZ3wJbl+Pg=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("nK4NNJ7XN9-riGCcJ6YDCIXYEpHSYJWV2L9s3at1brf33Nb5TcFjY341iQHhQ7GjAS8sDgfXNx6NvzmSyXDXBQ==.v=1.k=1.d=1458844442.t=u.l=.u=e222adf6-22a0-4180-b628-936049f0899f.r=ccaae5e6")), userId = Some(userId1)),
-          AccountData(AccountId("09621ddd-736f-4ec5-b4b5-d24cbb56b9f3"), Some(EmailAddress("joachim.hofer+003@wearezeta.com")), "WtjSXe7G8CHlcy4PRxGoaisUr9UGyKR51zriDwIFAco=", Some(PhoneNumber("+0123456789")), handle = Some(Handle()), None, verified = true, Some(Cookie("u0mEC2etISwrAAf-_pNwG204HG5-Uf7EIRFFTp1TEqKGcSIXDbFC9_i8PftnKRTWSjUsAbZ-PHVIxS3eZDK-AQ==.v=1.k=1.d=1459026632.t=u.l=.u=9a01b792-42f6-4dee-a3c0-e22179d742f8.r=591684f6")), userId = Some(userId2))
+          AccountData(AccountId("8546c628-c9e8-45d6-82dd-7f6dcb56e171"), None, Some(EmailAddress("joachim.hofer+001@wearezeta.com")), "Xx/rjrJc0B/MhvaAt/aegKrs+bohYNkBTnZ3wJbl+Pg=", None, handle = Some(Handle()), None, verified = true, Some(Cookie("nK4NNJ7XN9-riGCcJ6YDCIXYEpHSYJWV2L9s3at1brf33Nb5TcFjY341iQHhQ7GjAS8sDgfXNx6NvzmSyXDXBQ==.v=1.k=1.d=1458844442.t=u.l=.u=e222adf6-22a0-4180-b628-936049f0899f.r=ccaae5e6")), userId = Some(userId1)),
+          AccountData(AccountId("09621ddd-736f-4ec5-b4b5-d24cbb56b9f3"), None, Some(EmailAddress("joachim.hofer+003@wearezeta.com")), "WtjSXe7G8CHlcy4PRxGoaisUr9UGyKR51zriDwIFAco=", Some(PhoneNumber("+0123456789")), handle = Some(Handle()), None, verified = true, Some(Cookie("u0mEC2etISwrAAf-_pNwG204HG5-Uf7EIRFFTp1TEqKGcSIXDbFC9_i8PftnKRTWSjUsAbZ-PHVIxS3eZDK-AQ==.v=1.k=1.d=1459026632.t=u.l=.u=9a01b792-42f6-4dee-a3c0-e22179d742f8.r=591684f6")), userId = Some(userId2))
         )
       }
     }

--- a/tests/unit/src/test/scala/com/waz/model/ContactsDaoSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/ContactsDaoSpec.scala
@@ -78,8 +78,8 @@ class ContactsDaoSpec extends FeatureSpec with Matchers with RobolectricTests {
     coyote.copy(
       emailAddresses = Set(EmailAddress("coyote@wile.me"), EmailAddress("wile.e.coyote@gmail.not"))))
 
-  lazy val meepUser = UserData(UserId("meepuser"), "Meep Moop", None, Some(PhoneNumber("123")), searchKey = SearchKey("Meep Moop"), handle = Some(Handle.random))
-  lazy val coyoteUser = UserData(UserId("coyoteuser"), "Wile E. Coyote", Some(EmailAddress("wile.e.coyote@gmail.not")), None, searchKey = SearchKey("Wile E. Coyote"), handle = Some(Handle.random))
+  lazy val meepUser = UserData(UserId("meepuser"), None, "Meep Moop", None, Some(PhoneNumber("123")), searchKey = SearchKey("Meep Moop"), handle = Some(Handle.random))
+  lazy val coyoteUser = UserData(UserId("coyoteuser"), None, "Wile E. Coyote", Some(EmailAddress("wile.e.coyote@gmail.not")), None, searchKey = SearchKey("Wile E. Coyote"), handle = Some(Handle.random))
 
   def contact(name: String) = Contact(ContactId(), name, NameSource.StructuredName, name, SearchKey(name), Set.empty, Set.empty)
 

--- a/tests/unit/src/test/scala/com/waz/service/connections/ConnectionsServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/connections/ConnectionsServiceSpec.scala
@@ -136,7 +136,7 @@ class ConnectionsServiceSpec extends FeatureSpec with Matchers with BeforeAndAft
       Await.ready(service.dispatch(ContactJoinEvent(userId, "test name")), 1.second)
       syncRequestedUsers shouldEqual Set(userId)
       service.usersStorage.get(userId) should eventually(beMatching {
-        case Some(UserData(`userId`, "test name", _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)) => true
+        case Some(u: UserData) if u.id == userId && u.name == "test name" => true
       })
     }
   }

--- a/tests/unit/src/test/scala/com/waz/service/otr/OtrClientsServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/otr/OtrClientsServiceSpec.scala
@@ -57,7 +57,7 @@ class OtrClientsServiceSpec extends FeatureSpec with Matchers with OptionValues 
     }
   }
 
-  lazy val service = new MockZMessaging(userModule, ClientId("client1")) {
+  lazy val service = new MockZMessaging(userModule, None, ClientId("client1")) {
     usersStorage.addOrOverwrite(selfUser).futureValue
   }
 

--- a/tests/unit/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
@@ -51,6 +51,9 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
 
   val defaultDuration = 5.seconds
 
+  def accountData(token: PushToken): AccountData = AccountData(accountId, None, None, "", None, None, Some(token))
+  def accountData(token: Option[PushToken]): AccountData = AccountData(accountId, None, None, "", None, None, token)
+
   after {
 
     prefs.reset()
@@ -105,7 +108,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       val oldToken = PushToken("oldToken")
       val newToken = PushToken("token")
 
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(oldToken))
+      accountSignal ! accountData(oldToken)
       currentAccount := accountId.str
 
       currentToken := Some(newToken)
@@ -131,7 +134,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       val oldToken = PushToken("oldToken")
       val newToken = PushToken("newToken")
 
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(oldToken))
+      accountSignal ! accountData(oldToken)
       currentAccount := accountId.str
       pushEnabled := true
       googlePlayAvailable ! true
@@ -159,7 +162,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
     scenario("After user is logged out, clearing their current push token should NOT trigger new registration") {
       val token = PushToken("token")
 
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(token))
+      accountSignal ! accountData(token)
       currentAccount := accountId.str
       pushEnabled := true
       googlePlayAvailable ! true
@@ -173,7 +176,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       result(service.pushActive.filter(_ == true).head)
 
       currentAccount := "" //user is logged out
-      accountSignal ! AccountData(accountId, None, "", None, None, None)
+      accountSignal ! accountData(None)
 
       result(service.pushActive.filter(_ == false).head)
 
@@ -193,7 +196,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
 
     scenario("Push should be active if push is enabled and inactive if not") {
       val token = PushToken("token")
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(token))
+      accountSignal ! accountData(token)
       currentAccount := accountId.str
       pushEnabled := true //set active
       googlePlayAvailable ! true
@@ -209,7 +212,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
 
     scenario("Push should be active if app is in background and inactive if not") {
       val token = PushToken("token")
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(token))
+      accountSignal ! accountData(token)
       currentAccount := accountId.str
       pushEnabled := true
       googlePlayAvailable ! true
@@ -226,7 +229,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
 
     scenario("Push should be inactive if play services are unavailable") {
       val token = PushToken("token")
-      accountSignal ! AccountData(accountId, None, "", None, None, Some(token))
+      accountSignal ! accountData(token)
       currentAccount := accountId.str
       pushEnabled := true
       googlePlayAvailable ! true
@@ -243,7 +246,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
     scenario("Push should be inactive if user is not currently registered") {
 
       val token = PushToken("token")
-      accountSignal ! AccountData(accountId, None, "", None, None, None)
+      accountSignal ! accountData(None)
       currentAccount := accountId.str
       pushEnabled := true
       googlePlayAvailable ! true

--- a/tests/unit/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.sync.client
 
-import com.waz.model.TeamMemberData._
-import com.waz.model.TeamMemberData.Permission._
+import com.waz.model.AccountData._
+import com.waz.model.AccountData.Permission._
 import com.waz.specs.AndroidFreeSpec
 
 class TeamsClientSpec extends AndroidFreeSpec {

--- a/tests/unit/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/OtrClientsSyncHandlerSpec.scala
@@ -77,7 +77,7 @@ class OtrClientsSyncHandlerSpec extends FeatureSpec with Matchers with BeforeAnd
     account.storage.usersStorage.addOrOverwrite(selfUser).futureValue
   }
 
-  lazy val service = new MockZMessaging(userModule, clientId)
+  lazy val service = new MockZMessaging(userModule, None, clientId)
 
   before {
     loadSelfClientsRequested = false

--- a/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -23,7 +23,7 @@ import com.waz.service.teams.TeamsService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
-import com.waz.sync.client.TeamsClient.TeamsResponse
+import com.waz.sync.client.TeamsClient.TeamBindingResponse$
 import com.waz.threading.CancellableFuture
 
 import scala.concurrent.Future
@@ -43,7 +43,7 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
       val teams = Seq(TeamData(teamId, "My Team", UserId()))
       val members = Set(UserId(), UserId())
 
-      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamsResponse(teams, hasMore = false))))
+      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamBindingResponse(teams, hasMore = false))))
       (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(members)))
 
       val teamsFetched = teams.toSet
@@ -73,10 +73,10 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
         val resp = callsToTeams match {
           case 1 =>
             start shouldEqual None
-            TeamsResponse(teams.init, hasMore = true)
+            TeamBindingResponse(teams.init, hasMore = true)
           case 2 =>
             start shouldEqual teamIds.headOption
-            TeamsResponse(teams.tail, hasMore = false)
+            TeamBindingResponse(teams.tail, hasMore = false)
           case _ => fail("Unexpected number of calls to getTeams")
         }
 
@@ -113,7 +113,7 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
 
       val timeoutError = ErrorResponse(ErrorResponse.ConnectionErrorCode, s"Request failed with timeout", "connection-error")
 
-      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamsResponse(teams, hasMore = true))))
+      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamBindingResponse(teams, hasMore = true))))
       (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Left(timeoutError)))
 
       (service.onTeamsSynced _).expects(*, *, *).never().returning(Future.successful({}))

--- a/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -18,7 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{TeamData, TeamId, TeamMemberData, UserId}
+import com.waz.model.{TeamData, TeamId, UserId}
 import com.waz.service.teams.TeamsService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -41,10 +41,7 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
 
       val teamId = TeamId()
       val teams = Seq(TeamData(teamId, "My Team", UserId()))
-      val members = Set(
-        TeamMemberData(UserId(), teamId),
-        TeamMemberData(UserId(), teamId)
-      )
+      val members = Set(UserId(), UserId())
 
       (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamsResponse(teams, hasMore = false))))
       (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(members)))
@@ -64,8 +61,8 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
       }
       val members = teamIds.map { id =>
         Set(
-          TeamMemberData(UserId(s"User 1 team ${id.str}"), id),
-          TeamMemberData(UserId(s"User 2 team ${id.str}"), id)
+          UserId(s"User 1 team ${id.str}"),
+          UserId(s"User 2 team ${id.str}")
         )
       }
 

--- a/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -23,14 +23,12 @@ import com.waz.service.teams.TeamsService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
-import com.waz.sync.client.TeamsClient.TeamBindingResponse$
 import com.waz.threading.CancellableFuture
 
 import scala.concurrent.Future
 
 
 class TeamsSyncHandlerSpec extends AndroidFreeSpec {
-
 
   val client = mock[TeamsClient]
   val service = mock[TeamsService]
@@ -40,88 +38,34 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
     scenario("Basic single team with some members sync") {
 
       val teamId = TeamId()
-      val teams = Seq(TeamData(teamId, "My Team", UserId()))
+      val teams = Seq((teamId, true))
+      val teamData = TeamData(teamId, "name", UserId())
       val members = Set(UserId(), UserId())
 
-      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamBindingResponse(teams, hasMore = false))))
+      (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))
       (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Right(members)))
+      (service.onTeamSynced _).expects(teamData, members).once().returning(Future.successful({}))
 
-      val teamsFetched = teams.toSet
-      (service.onTeamsSynced _).expects(teamsFetched, members, true).once().returning(Future.successful({}))
+      result(initHandler(Some(teamId)).syncTeam()) shouldEqual SyncResult.Success
 
-      result(initHandler.syncTeams(Set.empty)) shouldEqual SyncResult.Success
-
-    }
-
-    scenario("Paginated teams with some members sync") {
-
-      val teamIds = Seq(TeamId("1"), TeamId("2"))
-      val teams = teamIds.map { id =>
-        TeamData(id, s"Team: ${id.str}", UserId())
-      }
-      val members = teamIds.map { id =>
-        Set(
-          UserId(s"User 1 team ${id.str}"),
-          UserId(s"User 2 team ${id.str}")
-        )
-      }
-
-      var callsToTeams = 0
-      (client.getTeams(_: Option[TeamId])).expects(*).twice().onCall { start: Option[TeamId] =>
-        callsToTeams += 1
-
-        val resp = callsToTeams match {
-          case 1 =>
-            start shouldEqual None
-            TeamBindingResponse(teams.init, hasMore = true)
-          case 2 =>
-            start shouldEqual teamIds.headOption
-            TeamBindingResponse(teams.tail, hasMore = false)
-          case _ => fail("Unexpected number of calls to getTeams")
-        }
-
-        CancellableFuture.successful(Right(resp))
-      }
-
-      var callsToMembers = 0
-      (client.getTeamMembers _).expects(*).twice().onCall { teamId: TeamId =>
-        callsToMembers += 1
-
-        val resp = callsToMembers match {
-          case 1 =>
-            teamId shouldEqual teamIds.head
-            members.head
-          case 2 =>
-            teamId shouldEqual teamIds.last
-            members.last
-          case _ => fail("Unexpected number of calls to getTeamMembers")
-        }
-
-        CancellableFuture.successful(Right(resp))
-      }
-
-      val teamsReturned = teams.toSet
-      val membersReturned = members.flatten.toSet
-      (service.onTeamsSynced _).expects(teamsReturned, membersReturned, true).once().returning(Future.successful({}))
-      result(initHandler.syncTeams(Set.empty)) shouldEqual SyncResult.Success
     }
 
     scenario("Failed members download should fail entire sync") {
 
       val teamId = TeamId()
-      val teams = Seq(TeamData(teamId, "My Team", UserId()))
+      val teamData = TeamData(teamId, "name", UserId())
 
       val timeoutError = ErrorResponse(ErrorResponse.ConnectionErrorCode, s"Request failed with timeout", "connection-error")
 
-      (client.getTeams(_: Option[TeamId])).expects(None).once().returning(CancellableFuture.successful(Right(TeamBindingResponse(teams, hasMore = true))))
+      (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))
       (client.getTeamMembers _).expects(teamId).once().returning(CancellableFuture.successful(Left(timeoutError)))
 
-      (service.onTeamsSynced _).expects(*, *, *).never().returning(Future.successful({}))
+      (service.onTeamSynced _).expects(*, *).never().returning(Future.successful({}))
 
-      result(initHandler.syncTeams(Set.empty)) shouldEqual SyncResult(timeoutError)
+      result(initHandler(Some(teamId)).syncTeam()) shouldEqual SyncResult(timeoutError)
     }
   }
 
-  def initHandler = new TeamsSyncHandlerImpl(client, service)
+  def initHandler(teamId: Option[TeamId]) = new TeamsSyncHandlerImpl(teamId, client, service)
 
 }

--- a/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
+++ b/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
@@ -66,10 +66,10 @@ trait ApiSpec extends BeforeAndAfterEach with BeforeAndAfterAll with Matchers wi
   protected case object InitManually extends InitBehaviour
 
   lazy val zmessagingFactory: ZMessagingFactory = new ZMessagingFactory(globalModule) {
-    override def zmessaging(clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(clientId, user)
+    override def zmessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule): ZMessaging = new ApiZMessaging(teamId, clientId, user)
   }
 
-  class ApiZMessaging(clientId: ClientId, user: UserModule) extends ZMessaging(clientId, user) {
+  class ApiZMessaging(teamId: Option[TeamId], clientId: ClientId, user: UserModule) extends ZMessaging(teamId, clientId, user) {
     override lazy val eventPipeline = new EventPipeline(Vector(otrService.eventTransformer), events =>
       returning(eventScheduler.enqueue(events))(_ => eventSpies.get.foreach(pf => events.foreach(e => pf.applyOrElse(e, (_: Event) => ())))))
 

--- a/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
@@ -35,7 +35,7 @@ object EmptySyncService extends EmptySyncService
 trait EmptySyncServiceTrait extends SyncServiceHandle {
   override def syncSearchQuery(query: SearchQuery) = sid
   override def syncConversations(ids: Set[ConvId], dependsOn: Option[SyncId] = None) = sid
-  override def syncTeams(ids: Set[TeamId], dependsOn: Option[SyncId] = None) = sid
+  override def syncTeam(dependsOn: Option[SyncId] = None) = sid
   override def syncSelfUser() = sid
   override def deleteAccount() = sid
   override def syncUsers(ids: UserId*) = sid

--- a/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/MockModules.scala
@@ -103,7 +103,7 @@ class MockZMessaging(val mockUser: MockUserModule = new MockUserModule(), client
 
   var timeout = 5.seconds
 
-  storage.usersStorage.put(selfUserId, UserData(selfUserId, "test name", Some(EmailAddress("test@test.com")), None, searchKey = SearchKey("test name"), connection = ConnectionStatus.Self, handle = Some(Handle("test_username"))))
+  storage.usersStorage.put(selfUserId, UserData(selfUserId, None, "test name", Some(EmailAddress("test@test.com")), None, searchKey = SearchKey("test name"), connection = ConnectionStatus.Self, handle = Some(Handle("test_username"))))
   global.accountsStorage.put(accountId, AccountData(accountId, Some(EmailAddress("test@test.com")), "", None, handle = Some(Handle("test_username")), None, verified = true, Some(Cookie("cookie")), Some("passwd"), None, Some(selfUserId), Some(clientId))) map { _ =>
     mockUser.mockAccount.set(this)
   }

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -25,7 +25,7 @@ public enum SyncCommand {
     SyncSelf("sync-self"),
     DeleteAccount("delete-account"),
     SyncConversations("sync-convs"),
-    SyncTeams("sync-teams"),
+    SyncTeam("sync-team"),
     SyncConnections("sync-connections"),
     SyncConversation("sync-conv"),
     SyncSearchQuery("sync-search"),

--- a/zmessaging/src/main/scala/com/waz/api/impl/otr/OtrClients.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/otr/OtrClients.scala
@@ -93,8 +93,8 @@ object OtrClients {
 
   def incoming(implicit ui: UiModule): OtrClients = new OtrClients({ account =>
 
-    account.accountData flatMap {
-      case AccountData(_, _, _, _, _, _, _, _, _, _, Some(userId), Some(clientId), _, _) =>
+    account.accountData.map(ac => (ac.userId, ac.clientId)) flatMap {
+      case (Some(userId), Some(clientId)) =>
         account.storage.otrClientsStorage.incomingClientsSignal(userId, clientId).map { cs =>
           (userId, cs.sorted(IncomingClientOrdering).toVector)
         }

--- a/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -52,7 +52,7 @@ class ZGlobalDB(context: Context, dbNameSuffix: String = "")
 
 object ZGlobalDB {
   val DbName = "ZGlobal.db"
-  val DbVersion = 17
+  val DbVersion = 18
 
   lazy val daos = Seq(AccountDataDao, CacheEntryDao)
 
@@ -100,6 +100,11 @@ object ZGlobalDB {
       }},
       Migration(16, 17) { db =>
         db.execSQL(s"ALTER TABLE Accounts ADD COLUMN registered_push TEXT")
+      },
+      Migration(17, 18) { db =>
+        db.execSQL("ALTER TABLE Accounts ADD COLUMN teamId TEXT")
+        db.execSQL("ALTER TABLE Accounts ADD COLUMN self_permissions INTEGER DEFAULT 0")
+        db.execSQL("ALTER TABLE Accounts ADD COLUMN copy_permissions INTEGER DEFAULT 0")
       }
     )
 

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -157,8 +157,8 @@ object ZMessagingDB {
       db.execSQL("DROP TABLE IF EXISTS CommonConnections")
     },
     Migration(91, 92) { db =>
-      db.execSQL("ALTER TABLE Users ADD COLUMN self_permissions INTEGER")
-      db.execSQL("ALTER TABLE Users ADD COLUMN copy_permissions INTEGER")
+      db.execSQL("ALTER TABLE Accounts ADD COLUMN self_permissions INTEGER")
+      db.execSQL("ALTER TABLE Accounts ADD COLUMN copy_permissions INTEGER")
       db.execSQL("DROP TABLE IF EXISTS TeamMembers")
     }
   )

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -157,9 +157,6 @@ object ZMessagingDB {
       db.execSQL("DROP TABLE IF EXISTS CommonConnections")
     },
     Migration(91, 92) { db =>
-      db.execSQL("ALTER TABLE Accounts ADD COLUMN teamId TEXT")
-      db.execSQL("ALTER TABLE Accounts ADD COLUMN self_permissions INTEGER DEFAULT 0")
-      db.execSQL("ALTER TABLE Accounts ADD COLUMN copy_permissions INTEGER DEFAULT 0")
       db.execSQL("ALTER TABLE Users ADD COLUMN teamId TEXT")
       db.execSQL("DROP TABLE IF EXISTS TeamMembers")
     }

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -53,7 +53,7 @@ class ZMessagingDB(context: Context, dbName: String) extends DaoDB(context.getAp
 }
 
 object ZMessagingDB {
-  val DbVersion = 91
+  val DbVersion = 92
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao, TeamDataDoa,
@@ -157,8 +157,10 @@ object ZMessagingDB {
       db.execSQL("DROP TABLE IF EXISTS CommonConnections")
     },
     Migration(91, 92) { db =>
-      db.execSQL("ALTER TABLE Accounts ADD COLUMN self_permissions INTEGER")
-      db.execSQL("ALTER TABLE Accounts ADD COLUMN copy_permissions INTEGER")
+      db.execSQL("ALTER TABLE Accounts ADD COLUMN teamId TEXT")
+      db.execSQL("ALTER TABLE Accounts ADD COLUMN self_permissions INTEGER DEFAULT 0")
+      db.execSQL("ALTER TABLE Accounts ADD COLUMN copy_permissions INTEGER DEFAULT 0")
+      db.execSQL("ALTER TABLE Users ADD COLUMN teamId TEXT")
       db.execSQL("DROP TABLE IF EXISTS TeamMembers")
     }
   )

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -38,7 +38,6 @@ import com.waz.model.MsgDeletion.MsgDeletionDao
 import com.waz.model.NotificationData.NotificationDataDao
 import com.waz.model.SearchQueryCache.SearchQueryCacheDao
 import com.waz.model.TeamData.TeamDataDoa
-import com.waz.model.TeamMemberData.TeamMemberDataDoa
 import com.waz.model.UserData.UserDataDao
 import com.waz.model.otr.UserClients.UserClientsDao
 import com.waz.model.sync.SyncJob.SyncJobDao
@@ -57,7 +56,7 @@ object ZMessagingDB {
   val DbVersion = 91
 
   lazy val daos = Seq (
-    UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao, TeamDataDoa, TeamMemberDataDoa,
+    UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao, TeamDataDoa,
     ConversationMemberDataDao, MessageDataDao, KeyValueDataDao,
     SyncJobDao, NotificationDataDao, ErrorDataDao,
     ContactHashesDao, ContactsOnWireDao, InvitedContactsDao, UserClientsDao, LikingDao,
@@ -156,6 +155,11 @@ object ZMessagingDB {
     },
     Migration(90, 91) { db =>
       db.execSQL("DROP TABLE IF EXISTS CommonConnections")
+    },
+    Migration(91, 92) { db =>
+      db.execSQL("ALTER TABLE Users ADD COLUMN self_permissions INTEGER")
+      db.execSQL("ALTER TABLE Users ADD COLUMN copy_permissions INTEGER")
+      db.execSQL("DROP TABLE IF EXISTS TeamMembers")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -17,13 +17,10 @@
  */
 package com.waz.model
 
-import com.waz.db.{Dao, Dao2}
-import com.waz.service.SearchKey
+import com.waz.db.Dao
 import com.waz.utils.JsonDecoder
-import com.waz.utils.wrappers.{DB, DBCursor}
+import com.waz.utils.wrappers.DBCursor
 import org.json.JSONObject
-
-import scala.collection.mutable
 
 case class TeamData(id:      TeamId,
                     name:    String,
@@ -52,88 +49,5 @@ object TeamData {
     override val table = Table("Teams", Id, Name, Creator, Icon, IconKey)
 
     override def apply(implicit cursor: DBCursor): TeamData = new TeamData(Id, Name, Creator, Icon, IconKey)
-  }
-}
-
-case class TeamMemberData(userId:      UserId,
-                          teamId:      TeamId,
-                          private val _selfPermissions: Long = 0,
-                          private val _copyPermissions: Long = 0) {
-  import TeamMemberData._
-
-  lazy val selfPermissions = decodeBitmask(_selfPermissions)
-  lazy val copyPermissions = decodeBitmask(_copyPermissions)
-}
-
-object TeamMemberData {
-
-  type Key = (UserId, TeamId)
-
-  type Permission = Permission.Value
-  object Permission extends Enumeration {
-    val CreateConversation,         // 0x001
-        DeleteConversation,         // 0x002
-        AddTeamMember,              // 0x004
-        RemoveTeamMember,           // 0x008
-        AddConversationMember,      // 0x010
-        RemoveConversationMember,   // 0x020
-        GetBilling,                 // 0x040
-        SetBilling,                 // 0x080
-        SetTeamData,                // 0x100
-        GetMemberPermissions,       // 0x200
-        GetTeamConversations,       // 0x400
-        DeleteTeam,                 // 0x800
-        SetMemberPermissions        // 0x1000
-    = Value
-  }
-
-  def decodeBitmask(mask: Long): Set[Permission] = {
-    val builder = new mutable.SetBuilder[Permission, Set[Permission]](Set.empty)
-    (0 until Permission.values.size).map(math.pow(2, _).toInt).zipWithIndex.foreach {
-      case (one, pos) => if ((mask & one) != 0) builder += Permission(pos)
-    }
-    builder.result()
-  }
-
-  def encodeBitmask(ps: Set[Permission]): Long = {
-    var mask = 0L
-    (0 until Permission.values.size).map(math.pow(2, _).toLong).zipWithIndex.foreach {
-      case (m, i) => if (ps.contains(Permission(i))) mask = mask | m
-    }
-    mask
-  }
-
-  import com.waz.db.Col._
-  implicit object TeamMemberDataDoa extends Dao2[TeamMemberData, UserId, TeamId] {
-    val UserId          = id[UserId]('user_id).apply(_.userId)
-    val TeamId          = id[TeamId]('team_id).apply(_.teamId)
-    val SelfPermissions = long('self_permissions)(_._selfPermissions)
-    val CopyPermissions = long('copy_permissions)(_._copyPermissions)
-
-    override val idCol = (UserId, TeamId)
-    override val table = Table("TeamMembers", UserId, TeamId, SelfPermissions, CopyPermissions)
-
-    override def apply(implicit cursor: DBCursor): TeamMemberData = TeamMemberData(UserId, TeamId, SelfPermissions, CopyPermissions)
-
-    def findForUsers(users: Set[UserId])(implicit db: DB) = iterating(findInSet(UserId, users))
-    def findForTeams(teams: Set[TeamId])(implicit db: DB) = iterating(findInSet(TeamId, teams))
-
-    def search(prefix: SearchKey, team: TeamId, handleOnly: Boolean)(implicit db: DB) = {
-      import UserData.{UserDataDao => U}
-      val select =
-        s"""SELECT DISTINCT tm.*
-           |  FROM ${table.name} tm, ${U.table.name} u
-           | WHERE tm.${UserId.name} = u.${U.Id.name}""".stripMargin
-      val handleCondition =
-        if (handleOnly){
-          s"""AND u.${U.Handle.name} LIKE '%${prefix.asciiRepresentation}%'""".stripMargin
-        } else {
-          s"""AND (   u.${U.SKey.name} LIKE '${U.SKey(prefix)}%'
-             |     OR u.${U.SKey.name} LIKE '% ${U.SKey(prefix)}%'
-             |     OR u.${U.Handle.name} LIKE '%${prefix.asciiRepresentation}%')""".stripMargin
-        }
-      list(db.rawQuery(select + " " + handleCondition, null)).toSet
-    }
-
   }
 }

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -106,6 +106,8 @@ case class UserData(
     }
   )
 
+  def updated(teamId: Option[TeamId]): UserData = copy(teamId = teamId)
+
   def updateConnectionStatus(status: UserData.ConnectionStatus, time: Option[Date] = None, message: Option[String] = None): UserData = {
     if (time.exists(_.before(this.connectionLastUpdated))) this
     else if (this.connection == status) time.fold(this) { time => this.copy(connectionLastUpdated = time) }

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -31,8 +31,11 @@ import com.waz.utils._
 import com.waz.utils.wrappers.{DB, DBCursor}
 import org.json.JSONObject
 
+import scala.collection.mutable
+
 case class UserData(
                      id:                    UserId,
+                     teamId:                Option[TeamId]        = None,
                      name:                  String,
                      email:                 Option[EmailAddress]  = None,
                      phone:                 Option[PhoneNumber]   = None,
@@ -148,13 +151,14 @@ object UserData {
   }
 
   // used for testing only
-  def apply(name: String): UserData = UserData(UserId(), name, None, None, searchKey = SearchKey(name), handle = None)
+  def apply(name: String): UserData = UserData(UserId(), None, name, None, None, searchKey = SearchKey(name), handle = None)
 
-  def apply(id: UserId, name: String): UserData = UserData(id, name, None, None, searchKey = SearchKey(name), handle = None)
+  def apply(id: UserId, name: String): UserData = UserData(id, None, name, None, None, searchKey = SearchKey(name), handle = None)
 
   def apply(entry: UserSearchEntry): UserData =
     UserData(
       id        = entry.id,
+      teamId    = None,
       name      = entry.name,
       accent    = entry.colorId.getOrElse(0),
       searchKey = SearchKey(entry.name),
@@ -162,14 +166,14 @@ object UserData {
     ) // TODO: improve connection, relation, search level stuff
 
   def apply(user: UserInfo): UserData =
-    UserData(user.id, user.name.getOrElse(""), user.email, user.phone, user.trackingId, user.mediumPicture.map(_.id),
+    UserData(user.id, None, user.name.getOrElse(""), user.email, user.phone, user.trackingId, user.mediumPicture.map(_.id),
       user.accentId.getOrElse(AccentColor().id), SearchKey(user.name.getOrElse("")), deleted = user.deleted,
       handle = user.handle)
 
   implicit lazy val Decoder: JsonDecoder[UserData] = new JsonDecoder[UserData] {
     import JsonDecoder._
     override def apply(implicit js: JSONObject): UserData = UserData(
-      id = 'id, name = 'name, email = decodeOptEmailAddress('email), phone = decodeOptPhoneNumber('phone),
+      id = 'id, teamId = decodeOptTeamId('teamId), name = 'name, email = decodeOptEmailAddress('email), phone = decodeOptPhoneNumber('phone),
       trackingId = decodeOptId[TrackingId]('trackingId), picture = decodeOptAssetId('assetId), accent = decodeInt('accent), searchKey = SearchKey('name),
       connection = ConnectionStatus('connection), connectionLastUpdated = new Date(decodeLong('connectionLastUpdated)), connectionMessage = decodeOptString('connectionMessage),
       conversation = decodeOptRConvId('rconvId), relation = Relation.withId('relation),
@@ -180,6 +184,7 @@ object UserData {
   implicit lazy val Encoder: JsonEncoder[UserData] = new JsonEncoder[UserData] {
     override def apply(v: UserData): JSONObject = JsonEncoder { o =>
       o.put("id", v.id.str)
+      v.teamId foreach (id => o.put("teamId", id.str))
       o.put("name", v.name)
       v.email foreach (o.put("email", _))
       v.phone foreach (o.put("phone", _))
@@ -201,6 +206,7 @@ object UserData {
 
   implicit object UserDataDao extends Dao[UserData, UserId] {
     val Id = id[UserId]('_id, "PRIMARY KEY").apply(_.id)
+    val TeamId = opt(id[TeamId]('teamId))(_.teamId)
     val Name = text('name)(_.name)
     val Email = opt(emailAddress('email))(_.email)
     val Phone = opt(phoneNumber('phone))(_.phone)
@@ -220,10 +226,10 @@ object UserData {
     val Handle = opt(handle('handle))(_.handle)
 
     override val idCol = Id
-    override val table = Table("Users", Id, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage, Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, Handle)
+    override val table = Table("Users", Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage, Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, Handle)
 
     override def apply(implicit cursor: DBCursor): UserData =
-      new UserData(Id, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage, Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, Handle)
+      new UserData(Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage, Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, Handle)
 
     override def onCreate(db: DB): Unit = {
       super.onCreate(db)
@@ -261,10 +267,28 @@ object UserData {
         Array(s"${query.asciiRepresentation}%", s"% ${query.asciiRepresentation}%", prefix, s"%${query.asciiRepresentation}%"))
     }
 
-    private def search(whereClause: String, args: Array[String])(implicit db: DB): Managed[Iterator[UserData]] =
+    def search(whereClause: String, args: Array[String])(implicit db: DB): Managed[Iterator[UserData]] =
       iterating(db.query(table.name, null, whereClause, args, null, null,
         s"case when ${Conn.name} = '${Conn(ConnectionStatus.Accepted)}' then 0 when ${Rel.name} != '${Relation.Other.name}' then 1 else 2 end ASC, ${Name.name} ASC"))
 
+    def search(prefix: SearchKey, handleOnly: Boolean, teamId: Option[TeamId])(implicit db: DB): Set[UserData] = {
+      val select = s"SELECT u.* ${if (teamId.isDefined) ", COUNT(*)" else ""} FROM ${table.name} u"
+      val handleCondition =
+        if (handleOnly){
+          s"""AND u.${Handle.name} LIKE '%${prefix.asciiRepresentation}%'""".stripMargin
+        } else {
+          s"""AND (
+             |     u.${SKey.name} LIKE '${SKey(prefix)}%'
+             |     OR u.${SKey.name} LIKE '% ${SKey(prefix)}%'
+             |     OR u.${Handle.name} LIKE '%${prefix.asciiRepresentation}%')""".stripMargin
+        }
+      val teamCondition = teamId.map(_ => s"AND u.${TeamId.name} = ${teamId}")
+
+      list(db.rawQuery(select + " " + handleCondition + teamCondition.map(qu => s" $qu").getOrElse(""), null)).toSet
+    }
+
     def findWireBots(implicit db: DB) = iterating(db.query(table.name, null, s"${Email.name} like 'welcome+%@wire.com' or ${Email.name} = 'welcome@wire.com' or ${Email.name} like 'anna+%@wire.com' or ${Email.name} = 'anna@wire.com'", null, null, null, null))
+
+    def findForTeams(teams: Set[TeamId])(implicit db: DB) = iterating(findInSet(TeamId, teams.map(Option(_))))
   }
 }

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -73,9 +73,7 @@ object SyncRequest {
   case object SyncSelfClients extends BaseRequest(Cmd.SyncSelfClients)
   case object SyncClientsLocation extends BaseRequest(Cmd.ValidateHandles)
 
-  case class SyncTeams(teams: Set[TeamId]) extends BaseRequest(Cmd.SyncTeams) {
-    override def mergeKey = (cmd, teams)
-  }
+  case object SyncTeam extends BaseRequest(Cmd.SyncTeam)
 
   case class PostAddressBook(addressBook: AddressBook) extends BaseRequest(Cmd.PostAddressBook) {
     override def merge(req: SyncRequest) = mergeHelper[PostAddressBook](req)(Merged(_))
@@ -321,7 +319,7 @@ object SyncRequest {
           case Cmd.SyncSelf              => SyncSelf
           case Cmd.DeleteAccount         => DeleteAccount
           case Cmd.SyncConversations     => SyncConversations
-          case Cmd.SyncTeams             => SyncTeams(decodeTeamIdSeq('teams).toSet)
+          case Cmd.SyncTeam              => SyncTeam
           case Cmd.SyncConnectedUsers    => SyncConnectedUsers
           case Cmd.SyncConnections       => SyncConnections
           case Cmd.RegisterPushToken     => RegisterPushToken(decodeId[PushToken]('token))
@@ -429,9 +427,7 @@ object SyncRequest {
         case SyncPreKeys(user, clients) =>
           o.put("user", user.str)
           o.put("clients", arrString(clients.toSeq map (_.str)))
-        case SyncTeams(teams) =>
-          o.put("teams", arrString(teams.toSeq.map(_.str)))
-        case SyncSelf | DeleteAccount | SyncConversations | SyncConnections | SyncConnectedUsers | SyncSelfClients | SyncClientsLocation | Unknown => () // nothing to do
+        case SyncSelf | SyncTeam | DeleteAccount | SyncConversations | SyncConnections | SyncConnectedUsers | SyncSelfClients | SyncClientsLocation | Unknown => () // nothing to do
         case ValidateHandles(handles) => o.put("handles", arrString(handles.map(_.toString)))
       }
     }

--- a/zmessaging/src/main/scala/com/waz/service/AccountService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountService.scala
@@ -148,6 +148,7 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
   lazy val cryptoBox          = global.factory.cryptobox(id, storage)
   lazy val netClient          = global.factory.client(credentialsHandler)
   lazy val usersClient        = global.factory.usersClient(netClient)
+  lazy val teamsClient        = global.factory.teamsClient(netClient)
   lazy val credentialsClient  = global.factory.credentialsClient(netClient)
 
   @volatile private var _userModule = Option.empty[UserModule]
@@ -176,22 +177,24 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
 
   lazy val userId = accountData.map(_.userId)
 
+  // must start empty to block the creation of ZMessaging
+  private lazy val teamId = Signal[Option[TeamId]]()
+
   // logged in zmessaging instance
   @volatile private var _zmessaging = Option.empty[ZMessaging]
 
-  val zmessaging = clientId flatMap {
-    case None => Signal const Option.empty[ZMessaging]
-    case Some(cId) =>
-      userModule flatMap { um =>
-        Signal.future {
-          cryptoBox.cryptoBox mapOpt { _ =>
-            verbose(s"Creating new ZMessaging instance, for $um, $cId, service: $this")
-            _zmessaging = _zmessaging orElse LoggedTry(global.factory.zmessaging(cId, um)).toOption
-            _zmessaging
-          }
-        }
+  val zmessaging = (for {
+    Some(cId) <- clientId
+    tId       <- teamId
+    um        <- userModule
+    res       <- Signal.future {
+      cryptoBox.cryptoBox mapOpt { _ =>
+        verbose(s"Creating new ZMessaging instance, for $um, $cId, $tId, service: $this")
+        _zmessaging = _zmessaging orElse LoggedTry(global.factory.zmessaging(tId, cId, um)).toOption
+        _zmessaging
       }
-  }
+    }
+  } yield res).orElse(Signal const Option.empty[ZMessaging])
 
   val isLoggedIn = accounts.currentAccountPref.signal.map(_ == id.str)
 
@@ -338,6 +341,27 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
         }
       }
 
+    def loadSelfTeam(account: AccountData): Future[Either[ErrorResponse, AccountData]] =
+      if (account.teamId.isDefined) Future successful Right(account)
+      else {
+        teamsClient.getTeamId().future flatMap {
+          case Right(tIdOpt) =>
+            teamId ! tIdOpt
+            verbose(s"got self team: $tIdOpt")
+
+            tIdOpt match {
+              case Some(tId) =>
+                for {
+                  _ <- account.userId.fold(Future.successful({})){ id => storage.usersStorage.update(id, _.updated(Some(tId))).map(_ => {}) }
+                  res <- accountsStorage.updateOrCreate(id, _.updated(tId), account.updated(tId))
+                } yield Right(res)
+              case _ => Future successful Right(account)
+            }
+
+          case Left(err) => Future successful Left(err)
+        }
+      }
+
     def checkCryptoBox =
       cryptoBox.cryptoBox flatMap {
         case Some(cb) => Future successful Some(cb)
@@ -350,6 +374,7 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
           } yield res
       }
 
+    // TODO: (Maciek) I'm pretty sure we can flatten this to something like f1.flatMap(res1 => f2).flatMap(res2 => f3) ...
     checkCryptoBox flatMap {
       case None => Future successful Left(ErrorResponse.internalError("CryptoBox loading failed"))
       case Some(_) =>
@@ -365,7 +390,11 @@ class AccountService(@volatile var account: AccountData, val global: GlobalModul
                     // we should merge those accounts, delete current one, and switch to the previous one
                     userModule.head flatMap { _.ensureClientRegistered(acc2) } flatMap {
                       case Right(acc3) =>
-                        accountsStorage.updateOrCreate(id, _.updated(acc3.userId, acc3.verified, acc3.clientId, acc3.clientRegState), acc3) map { Right(_) }
+                        loadSelfTeam(acc3) flatMap {
+                          case Right(acc4) =>
+                            accountsStorage.updateOrCreate(id, _.updated(acc4.userId, acc4.verified, acc4.clientId, acc4.clientRegState), acc4) map { Right(_) }
+                          case Left(err) => Future successful Left(err)
+                        }
                       case Left(err) => Future successful Left(err)
                     }
                   case Left(err) => Future successful Left(err)

--- a/zmessaging/src/main/scala/com/waz/service/Accounts.scala
+++ b/zmessaging/src/main/scala/com/waz/service/Accounts.scala
@@ -170,7 +170,7 @@ class Accounts(val global: GlobalModule) {
         login(account, normalized)
       case (normalized, None, None) =>
         verbose(s"matching account not found, creating new account")
-        login(new AccountData(AccountId(), None, "", None, handle = None), normalized)
+        login(new AccountData(AccountId(), None, None, "", None, handle = None), normalized)
     }
 
   private def login(account: AccountData, normalized: Credentials) = {

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -68,7 +68,7 @@ class ConnectionService(push: PushService, convs: ConversationsContentUpdater, m
     verbose(s"handleUserConnectionEvents: $events")
     def updateOrCreate(event: UserConnectionEvent)(user: Option[UserData]): UserData =
       user.fold {
-        UserData(event.to, UserService.defaultUserName, None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey(UserService.defaultUserName), connectionLastUpdated = event.lastUpdated,
+        UserData(event.to, None, UserService.defaultUserName, None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey(UserService.defaultUserName), connectionLastUpdated = event.lastUpdated,
           handle = None)
       } {
         _.copy(conversation = Some(event.convId)).updateConnectionStatus(event.status, Some(event.lastUpdated), event.message)

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -93,7 +93,7 @@ class UserServiceImpl(val selfUserId: UserId, usersStorage: UsersStorageImpl, us
 
   def getOrCreateUser(id: UserId) = usersStorage.getOrElseUpdate(id, {
     sync.syncUsers(id)
-    UserData(id, defaultUserName, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey(defaultUserName), handle = None)
+    UserData(id, None, defaultUserName, None, None, connection = ConnectionStatus.Unconnected, searchKey = SearchKey(defaultUserName), handle = None)
   })
 
   def getSelfUserId: Future[Option[UserId]] = Future successful Some(selfUserId)

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -60,13 +60,15 @@ class ZMessagingFactory(global: GlobalModule) {
 
   def usersClient(client: ZNetClient) = new UsersClient(client)
 
+  def teamsClient(client: ZNetClient) = new TeamsClientImpl(client)
+
   def credentialsClient(netClient: ZNetClient) = new CredentialsUpdateClient(netClient)
 
   def cryptobox(accountId: AccountId, storage: StorageModule) = new CryptoBoxService(global.context, accountId, global.metadata, storage.userPrefs)
 
   def userModule(userId: UserId, account: AccountService) = wire[UserModule]
 
-  def zmessaging(clientId: ClientId, userModule: UserModule) = wire[ZMessaging]
+  def zmessaging(teamId: Option[TeamId], clientId: ClientId, userModule: UserModule) = wire[ZMessaging]
 }
 
 
@@ -87,7 +89,7 @@ class StorageModule(context: Context, accountId: AccountId, dbPrefix: String) {
 }
 
 
-class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
+class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, val userModule: UserModule) {
 
   private implicit val logTag: LogTag = logTagFor[ZMessaging]
   private implicit val dispatcher = new SerialDispatchQueue(name = "ZMessaging")
@@ -97,6 +99,7 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   val global     = account.global
 
   val selfUserId = userModule.userId
+
   val accountId  = account.id
 
   val zNetClient = account.netClient

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -81,7 +81,6 @@ class StorageModule(context: Context, accountId: AccountId, dbPrefix: String) {
   lazy val notifStorage                         = wire[NotificationStorage]
   lazy val convsStorage                         = wire[ConversationStorageImpl]
   lazy val teamsStorage:      TeamsStorage      = wire[TeamsStorageImpl]
-  lazy val teamMemberStorage: TeamMemberStorage = wire[TeamMemberStorageImpl]
   lazy val msgDeletions                         = wire[MsgDeletionStorage]
   lazy val searchQueryCache                     = wire[SearchQueryCacheStorage]
   lazy val msgEdits                             = wire[EditHistoryStorage]
@@ -145,7 +144,6 @@ class ZMessaging(val clientId: ClientId, val userModule: UserModule) {
   def notifStorage      = storage.notifStorage
   def convsStorage      = storage.convsStorage
   def teamsStorage      = storage.teamsStorage
-  def teamMemberStorage = storage.teamMemberStorage
   def msgDeletions      = storage.msgDeletions
   def msgEdits          = storage.msgEdits
   def searchQueryCache  = storage.searchQueryCache

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -96,10 +96,10 @@ class ConversationsService(context: Context, push: PushServiceSignals, users: Us
     getSelfUserId flatMap {
       case Some(_) =>
         sync.syncConversations()
-        sync.syncTeams()
+        sync.syncTeam()
       case None     => sync.syncSelfUser().flatMap { dependency =>
         sync.syncConversations(Set.empty, Some(dependency))
-        sync.syncTeams(Set.empty, Some(dependency))
+        sync.syncTeam(Some(dependency))
       }
     }
 

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -162,6 +162,7 @@ class TeamsServiceImpl(selfUser:          UserId,
     verbose(s"onTeamMembersLeft: users: $userIds")
     if (userIds.contains(selfUser)) {
       warn("Self user removed from team")
+      Future.successful {}
     } else {
       for {
         _ <- userStorage.remove(userIds)

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -39,7 +39,7 @@ import scala.concurrent.Future.traverse
 //TODO - return Signals of the search results for UI??
 trait TeamsService {
 
-  def getTeams(userId: UserId): Signal[Set[TeamData]]
+  def getTeam(userId: UserId): Signal[Option[TeamData]]
 
   def searchTeamMembers(teamId: TeamId, query: Option[SearchKey] = None, handleOnly: Boolean = false): Future[Set[UserData]]
 
@@ -47,11 +47,9 @@ trait TeamsService {
 
   def findGuests(teamId: TeamId): Future[Set[UserId]]
 
-  def getSelfTeams: Signal[Set[TeamData]]
+  def getSelfTeam: Signal[Option[TeamData]]
 
-  def getPermissions(userId: UserId, teamId: TeamId): Future[Option[Set[TeamMemberData.Permission]]]
-
-  def onTeamsSynced(teams: Set[TeamData], members: Set[TeamMemberData], fullSync: Boolean = false): Future[Unit]
+  def onTeamsSynced(teams: Set[TeamData], members: Set[UserId], fullSync: Boolean = false): Future[Unit]
 
 }
 
@@ -61,7 +59,6 @@ class TeamsServiceImpl(selfUser:          UserId,
                        convsStorage:      ConversationStorage,
                        convMemberStorage: MembersStorage,
                        convsContent:      ConversationsContentUpdater,
-                       teamMemberStorage: TeamMemberStorage,
                        sync:              SyncServiceHandle,
                        userPrefs:         UserPreferences) extends TeamsService {
 
@@ -103,19 +100,13 @@ class TeamsServiceImpl(selfUser:          UserId,
   }
 
   //TODO - maybe include user permissions for supplied team
-  override def searchTeamMembers(teamId: TeamId, query: Option[SearchKey] = None, handleOnly: Boolean = false) = {
-    verbose(s"searchTeamMembers: team: $teamId, query: $query, handlOnly?: $handleOnly")
-    for {
-      userIds  <- (query match {
-        case Some(q) => teamMemberStorage.searchByTeam(teamId, q, handleOnly)
-        case None =>    teamMemberStorage.getByTeam(Set(teamId))
-      }).map(_.map(_.userId) - selfUser)
-      userData <- userStorage.getAll(userIds)
-    } yield userData.collect { case Some(data) => data }.toSet
+  override def searchTeamMembers(teamId: TeamId, query: Option[SearchKey] = None, handleOnly: Boolean = false) = query match {
+    case Some(q) => userStorage.searchByTeam(teamId, q, handleOnly)
+    case None => userStorage.getByTeam(Set(teamId))
   }
 
   override def searchTeamConversations(teamId: TeamId, query: Option[SearchKey] = None, handleOnly: Boolean = false) = {
-    verbose(s"searchTeamConversations: team: $teamId, query: $query, handlOnly?: $handleOnly")
+    verbose(s"searchTeamConversations: team: $teamId, query: $query, handleOnly?: $handleOnly")
     import ConversationDataDao._
     (query match {
       case Some(q) => convsStorage.search(q, selfUser, handleOnly, Some(teamId))
@@ -123,45 +114,32 @@ class TeamsServiceImpl(selfUser:          UserId,
     }).map(_.toSet)
   }
 
-  override def getTeams(userId: UserId) = {
-    verbose(s"getTeams: user: $userId")
+  override def getTeam(userId: UserId) = {
+    verbose(s"getTeam: user: $userId")
 
-    def load = for {
-      teamIds  <- teamMemberStorage.getByUser(Set(userId)).map(_.map(_.teamId))
-      teamData <- teamStorage.getAll(teamIds)
-    } yield teamData.collect { case Some(data) => data }.toSet
+    def load: Future[Option[TeamData]] = {
+      val user = userStorage.get(userId)
+      val team = user.map( _.flatMap(_.teamId))
+      team.collect { case Some(teamId) => teamStorage.get(teamId) }.flatMap(identity)
+    }
 
-    /**
-      * Any additions/removals to teamsStorage will be shortly followed by additions/removals to TeamMembers, so we only need to
-      * listen to additions/removals there. Updates however, may be triggered on teams without changes to TeamMembers
-      */
-    val allChanges = EventStream.union(
-      teamStorage.onUpdated.map(_.map(_._2.id)),
-      EventStream.union(
-        teamMemberStorage.onChanged.map(_.map(m => m.userId -> m.teamId)),
-        teamMemberStorage.onDeleted
-    ).collect { case evs => evs.filter(_._1 == userId)}.map(_.map(_._2))
-    )
+    val allChanges = teamStorage.onUpdated.map(_.map(_._2.id))
 
     //TODO could be nice to avoid loading for updates/deletions, since we already know the loaded set of teams is for the target user
     //We need to check TeamMembersStorage for any new additions to check that they are for the target user, hence the refreshing signal.
-    new RefreshingSignal[Set[TeamData], Seq[TeamId]](CancellableFuture.lift(load), allChanges)
+    new RefreshingSignal[Option[TeamData], Seq[TeamId]](CancellableFuture.lift(load), allChanges)
   }
 
-  override def getSelfTeams = getTeams(selfUser)
+  override def getSelfTeam = getTeam(selfUser)
 
-  override def getPermissions(userId: UserId, teamId: TeamId) =
-    teamMemberStorage.get((userId, teamId)).map(_.map(_.selfPermissions))
-
-  override def onTeamsSynced(teamsFetched: Set[TeamData], members: Set[TeamMemberData], fullSync: Boolean) = {
+  override def onTeamsSynced(teamsFetched: Set[TeamData], members: Set[UserId], fullSync: Boolean) = {
     verbose(s"onTeamsSynced: fullSync? $fullSync, teams: $teamsFetched \nmembers: $members")
 
     def insertFetchedData() = {
       for {
         _ <- teamStorage.insert(teamsFetched)
-        _ <- teamMemberStorage.insert(members)
         //TODO should we check first if we already have these users in the database?
-        _ <- sync.syncUsers(members.map(_.userId).toSeq: _* )
+        _ <- sync.syncUsers(members.toSeq: _* )
       } yield {}
     }
 
@@ -185,9 +163,9 @@ class TeamsServiceImpl(selfUser:          UserId,
     if (teams.nonEmpty)
       for {
         _          <- teamStorage.remove(teams)
-        removed    <- teamMemberStorage.removeByTeam(teams)
+        removed    <- userStorage.removeByTeam(teams)
         _          <- removeAllTeamConversations(teams)
-        _          <- removeUnconnectedUsers(removed)
+        _          <- removeUnconnectedUsers(removed.map(_.id))
         staleConvs <- {
           import ConversationDataDao._
           convsStorage.find(c => c.team.exists(teams.contains), db => iterating(findInSet(Team, teams.map(Option(_)))(db)), _.id)
@@ -220,7 +198,7 @@ class TeamsServiceImpl(selfUser:          UserId,
       onTeamsRemoved(Set(teamId))
     } else {
       for {
-        _ <- teamMemberStorage.remove(userIds.map(u => u -> teamId))
+        _ <- userStorage.remove(userIds)
         _ <- removeUsersFromTeamConversations(teamId, userIds)
         _ <- removeUnconnectedUsers(userIds)
       } yield {}
@@ -246,10 +224,9 @@ class TeamsServiceImpl(selfUser:          UserId,
 
   private def removeUnconnectedUsers(users: Set[UserId]): Future[Unit] = {
     (for {
-      stillTeamMembers <- teamMemberStorage.getByUser(users).map(_.map(_.userId).toSet)
       stillConnected   <- userStorage.find(u => users.contains(u.id), db => UserDataDao.findAll(users)(db), identity).map(_.filter(_.connection != Unconnected).map(_.id).toSet)
     } yield {
-      returning(users -- stillTeamMembers -- stillConnected) { toRemove =>
+      returning(users -- stillConnected) { toRemove =>
         verbose(s"Removing users from database: $toRemove")
       }
     }).flatMap(userStorage.remove)
@@ -275,7 +252,7 @@ class TeamsServiceImpl(selfUser:          UserId,
     for {
       convs       <- searchTeamConversations(teamId).map(_.map(_.id))
       allUsers    <- convMemberStorage.getByConvs(convs).map(_.map(_.userId).toSet)
-      teamMembers <- searchTeamMembers(teamId).map(_.map(_.id))
+      teamMembers <- userStorage.getByTeam(Set(teamId)).map(_.map(_.id))
     } yield allUsers -- teamMembers
 
   }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -44,7 +44,7 @@ trait SyncServiceHandle {
   def syncSelfUser(): Future[SyncId]
   def deleteAccount(): Future[SyncId]
   def syncConversations(ids: Set[ConvId] = Set.empty, dependsOn: Option[SyncId] = None): Future[SyncId]
-  def syncTeams(ids: Set[TeamId] = Set.empty, dependsOn: Option[SyncId] = None): Future[SyncId]
+  def syncTeam(dependsOn: Option[SyncId] = None): Future[SyncId]
   def syncConnectedUsers(): Future[SyncId]
   def syncConnections(dependsOn: Option[SyncId] = None): Future[SyncId]
   def syncRichMedia(id: MessageId, priority: Int = Priority.MinPriority): Future[SyncId]
@@ -100,7 +100,7 @@ class AndroidSyncServiceHandle(context: Context, service: => SyncRequestService,
   def syncSelfUser() = addRequest(SyncSelf, priority = Priority.High)
   def deleteAccount() = addRequest(DeleteAccount)
   def syncConversations(ids: Set[ConvId], dependsOn: Option[SyncId]) = addRequest(if (ids.nonEmpty) SyncConversation(ids) else SyncConversations, priority = if (ids.nonEmpty) Priority.Normal else Priority.High, dependsOn = dependsOn.toSeq)
-  def syncTeams(ids: Set[TeamId], dependsOn: Option[SyncId] = None): Future[SyncId] = addRequest(SyncTeams(ids), priority = Priority.High, dependsOn = dependsOn.toSeq)
+  def syncTeam(dependsOn: Option[SyncId] = None): Future[SyncId] = addRequest(SyncTeam, priority = Priority.High, dependsOn = dependsOn.toSeq)
   def syncConnectedUsers() = addRequest(SyncConnectedUsers)
   def syncConnections(dependsOn: Option[SyncId]) = addRequest(SyncConnections, dependsOn = dependsOn.toSeq)
   def syncRichMedia(id: MessageId, priority: Int = Priority.MinPriority) = addRequest(SyncRichMedia(id), priority = priority)
@@ -169,11 +169,11 @@ class AccountSyncHandler(zms: Signal[ZMessaging], otrClients: OtrClientsSyncHand
     case SyncUser(u)                           => zms.usersSync.syncUsers(u.toSeq: _*)
     case SyncSearchQuery(query)                => zms.usersearchSync.syncSearchQuery(query)
     case SyncRichMedia(messageId)              => zms.richmediaSync.syncRichMedia(messageId)
-    case DeletePushToken(token)                 => zms.gcmSync.deleteGcmToken(token)
+    case DeletePushToken(token)                => zms.gcmSync.deleteGcmToken(token)
     case PostConnection(userId, name, message) => zms.connectionsSync.postConnection(userId, name, message)
     case PostConnectionStatus(userId, status)  => zms.connectionsSync.postConnectionStatus(userId, status)
     case SyncConversations                     => zms.conversationSync.syncConversations()
-    case SyncTeams(teamIds)                    => zms.teamsSync.syncTeams(teamIds)
+    case SyncTeam                              => zms.teamsSync.syncTeam()
     case SyncConnectedUsers                    => zms.usersSync.syncConnectedUsers()
     case SyncConnections                       => zms.connectionsSync.syncConnections()
     case SyncSelf                              => zms.usersSync.syncSelfUser()

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -33,7 +33,7 @@ import scala.util.Try
 trait TeamsClient {
   def getTeams(start: Option[TeamId]): ErrorOrResponse[TeamsResponse]
   def getTeams(id: Set[TeamId]): ErrorOrResponse[TeamsResponse]
-  def getTeamMembers(id: TeamId): ErrorOrResponse[Set[TeamMemberData]]
+  def getTeamMembers(id: TeamId): ErrorOrResponse[Set[UserId]]
 }
 
 class TeamsClientImpl(zNetClient: ZNetClient) extends TeamsClient {
@@ -54,8 +54,7 @@ class TeamsClientImpl(zNetClient: ZNetClient) extends TeamsClient {
 
   override def getTeamMembers(id: TeamId) = {
     zNetClient.withErrorHandling("loadTeamMembers", Request.Get(teamMembersPath(id))) {
-      case Response(SuccessHttpStatus(), TeamMembersResponse(members), _) =>
-        members.map { case (userId, selfPermissions, copyPermissions) => TeamMemberData(userId, id, selfPermissions, copyPermissions)}
+      case Response(SuccessHttpStatus(), TeamMembersResponse(members), _) => members.map(_._1)
     }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -18,10 +18,10 @@
 package com.waz.sync.client
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.warn
+import com.waz.ZLog.{debug, warn}
 import com.waz.model._
-import com.waz.sync.client.TeamsClient.TeamsResponse
-import com.waz.threading.Threading
+import com.waz.sync.client.TeamsClient.TeamBindingResponse
+import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.JsonDecoder
 import com.waz.znet.Response.SuccessHttpStatus
 import com.waz.znet.ZNetClient.ErrorOrResponse
@@ -31,9 +31,11 @@ import org.json.JSONObject
 import scala.util.Try
 
 trait TeamsClient {
-  def getTeams(start: Option[TeamId]): ErrorOrResponse[TeamsResponse]
-  def getTeams(id: Set[TeamId]): ErrorOrResponse[TeamsResponse]
+  def getTeams(start: Option[TeamId]): ErrorOrResponse[TeamBindingResponse]
+  def getTeams(id: Set[TeamId]): ErrorOrResponse[TeamBindingResponse]
   def getTeamMembers(id: TeamId): ErrorOrResponse[Set[UserId]]
+  def getTeamData(id: TeamId): ErrorOrResponse[TeamData]
+  def getTeamId(start: Option[TeamId] = None): ErrorOrResponse[Option[TeamId]]
 }
 
 class TeamsClientImpl(zNetClient: ZNetClient) extends TeamsClient {
@@ -42,13 +44,13 @@ class TeamsClientImpl(zNetClient: ZNetClient) extends TeamsClient {
 
   override def getTeams(start: Option[TeamId]) = {
     zNetClient.withErrorHandling("loadAllTeams", Request.Get(teamsPaginatedQuery(start))) {
-      case Response(SuccessHttpStatus(), TeamsResponse(teams, hasMore), _) => TeamsResponse(teams, hasMore)
+      case Response(SuccessHttpStatus(), TeamBindingResponse(teams, hasMore), _) => TeamBindingResponse(teams, hasMore)
     }
   }
 
   override def getTeams(ids: Set[TeamId]) = {
     zNetClient.withErrorHandling("loadBatchTeams", Request.Get(teamsBatchQuery(ids))) {
-      case Response(SuccessHttpStatus(), TeamsResponse(teams, _), _) => TeamsResponse(teams, hasMore = false)
+      case Response(SuccessHttpStatus(), TeamBindingResponse(teams, _), _) => TeamBindingResponse(teams, hasMore = false)
     }
   }
 
@@ -56,6 +58,23 @@ class TeamsClientImpl(zNetClient: ZNetClient) extends TeamsClient {
     zNetClient.withErrorHandling("loadTeamMembers", Request.Get(teamMembersPath(id))) {
       case Response(SuccessHttpStatus(), TeamMembersResponse(members), _) => members.map(_._1)
     }
+  }
+
+  override def getTeamData(id: TeamId) = {
+    zNetClient.withErrorHandling("loadTeamData", Request.Get(teamQuery(id))) {
+      case Response(SuccessHttpStatus(), TeamResponse(data), _) => data
+    }
+  }
+
+  override def getTeamId(start: Option[TeamId] = None): ErrorOrResponse[Option[TeamId]] = getTeams(start).flatMap {
+    case Left(err) => CancellableFuture.successful(Left(err))
+    case Right(TeamBindingResponse(teams, hasMore)) =>
+      debug(s"getTeamId received data: $teams, hasMore? $hasMore")
+      teams.find(_._2).map(_._1) match {
+        case Some(teamId) => CancellableFuture.successful(Right(Some(teamId)))
+        case None if hasMore => getTeamId(teams.lastOption.map(_._1))
+        case None => CancellableFuture.successful(Right(None))
+      }
   }
 }
 
@@ -74,19 +93,28 @@ object TeamsClient {
   def teamsBatchQuery(ids: Set[TeamId]): String =
     Request.query(TeamsPath, ("ids", ids.mkString(",")))
 
+  def teamQuery(id: TeamId): String = Request.query(TeamsPath, "id" -> id)
+
   import JsonDecoder._
 
-  case class TeamsResponse(teams: Seq[TeamData], hasMore: Boolean)
+  case class TeamBindingResponse(teams: Seq[(TeamId, Boolean)], hasMore: Boolean)
 
-  object TeamsResponse {
-    def unapply(response: ResponseContent): Option[(Seq[TeamData], Boolean)] =
+  object TeamBindingResponse {
+    def unapply(response: ResponseContent): Option[(Seq[(TeamId, Boolean)], Boolean)] =
       response match {
         case JsonObjectResponse(js) if js.has("teams") =>
-          Try(decodeSeq('teams)(js, TeamData.Decoder), decodeOptBoolean('has_more)(js).getOrElse(false)).toOption
+          Try(decodeSeq('teams)(js, TeamBindingDecoder), decodeOptBoolean('has_more)(js).getOrElse(false)).toOption
         case _ =>
           warn(s"Unexpected response: $response")
           None
       }
+  }
+
+  lazy val TeamBindingDecoder: JsonDecoder[(TeamId, Boolean)] = new JsonDecoder[(TeamId, Boolean)] {
+    override def apply(implicit js: JSONObject): (TeamId, Boolean) = {
+      import JsonDecoder._
+      (TeamId('id), decodeOptBoolean('binding).getOrElse(false))
+    }
   }
 
   object TeamMembersResponse {
@@ -103,5 +131,15 @@ object TeamsClient {
           None
       }
     }
+  }
+
+  object TeamResponse {
+    def unapply(response: ResponseContent): Option[TeamData] =
+      response match {
+        case JsonObjectResponse(js) => Try(TeamData.Decoder(js)).toOption
+        case _ =>
+          warn(s"Unexpected response: $response")
+          None
+      }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -24,75 +24,41 @@ import com.waz.model._
 import com.waz.service.teams.TeamsService
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
-import com.waz.sync.client.TeamsClient.TeamsResponse
 import com.waz.sync.handler.TeamsSyncHandler.SyncException
-import com.waz.threading.{CancellableFuture, Threading}
-import com.waz.znet.ZNetClient.ErrorOrResponse
+import com.waz.threading.Threading
 
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 
 trait TeamsSyncHandler {
-  def syncTeams(teams: Set[TeamId]): Future[SyncResult]
+  def syncTeam(): Future[SyncResult]
 }
 
-class TeamsSyncHandlerImpl(client: TeamsClient, service: TeamsService) extends TeamsSyncHandler {
+class TeamsSyncHandlerImpl(teamId: Option[TeamId], client: TeamsClient, service: TeamsService) extends TeamsSyncHandler {
 
   import Threading.Implicits.Background
 
-  override def syncTeams(ids: Set[TeamId]) =
-    if (ids.isEmpty) syncAllTeams() else syncBatchTeams(ids)
-
-  private def syncAllTeams(): Future[SyncResult] = {
-
-    def recursive(start: Option[TeamId], teamsDownloaded: Set[TeamData], membersDownloaded: Set[UserId]): ErrorOrResponse[(Set[TeamData], Set[UserId])] = {
-      client.getTeams(start).flatMap {
-        case Right(TeamsResponse(teams, hasMore)) =>
-          debug(s"syncTeams received data: $teams, hasMore? $hasMore")
-          CancellableFuture.lift(downloadMembers(teams.map(_.id).toSet)).flatMap { teamMembers =>
-            if (hasMore) recursive(teams.lastOption.map(_.id), teams.toSet, teamMembers)
-            else CancellableFuture.successful(Right((teams.toSet ++ teamsDownloaded, teamMembers ++ membersDownloaded)))
-          }
-        case Left(err) => CancellableFuture.successful(Left(err))
+  override def syncTeam(): Future[SyncResult] = teamId match {
+    case Some(id) =>
+      client.getTeamData(id).future.flatMap {
+        case Right(data) => for { members <- downloadMembers(id); _ <- service.onTeamSynced(data, members) } yield SyncResult.Success
+        case Left(error) => warn(s"TeamsClient.syncTeam: $id failed with error: $error"); Future.successful(SyncResult(error))
       }
-    }
-
-    recursive(None, Set.empty, Set.empty).future.flatMap {
-      case Right((teams, members)) =>  service.onTeamsSynced(teams, members, fullSync = true).map(_ => SyncResult.Success)
-      case Left(err) => Future.successful(SyncResult(err))
-    }.recover {
-      case e@SyncException(_, err) =>
-        warn("Failed to sync teams", e)
-        SyncResult(err)
-    }
+    case None => Future.successful(SyncResult.Success)
   }
 
-  private def syncBatchTeams(ids: Set[TeamId]): Future[SyncResult] = client.getTeams(ids).future.flatMap {
-    case Right(TeamsResponse(teams, _)) =>
-      for {
-        members <- downloadMembers(ids)
-        _       <- service.onTeamsSynced(teams.toSet, members)
-      } yield SyncResult.Success
-    case Left(error) =>
-      warn(s"TeamsClient.syncBatchTeams: $ids failed with error: $error")
-      Future.successful(SyncResult(error))
+  private def downloadMembers(id: TeamId): Future[Set[UserId]] = client.getTeamMembers(id).future.map {
+    case Right(teamMembers) =>
+      debug(s"Received members for team: $id, $teamMembers")
+      teamMembers
+    case Left(err) => throw SyncException(s"Failed to download members for team: $id", err)
   }
-
-  private def downloadMembers(teams: Set[TeamId]): Future[Set[UserId]] =
-    Future.traverse(teams) { id =>
-      client.getTeamMembers(id).future.map {
-        case Right(teamMembers) =>
-          debug(s"Received members for team: $id, $teamMembers")
-          teamMembers
-        case Left(err) => throw SyncException(s"Failed to download members for team: $id", err)
-      }
-    }.map(_.flatten)
 
 }
 
 object TeamsSyncHandler {
 
-  def apply(client: TeamsClient, service: TeamsService): TeamsSyncHandler = new TeamsSyncHandlerImpl(client, service)
+  def apply(teamId: Option[TeamId], client: TeamsClient, service: TeamsService): TeamsSyncHandler = new TeamsSyncHandlerImpl(teamId, client, service)
 
   case class SyncException(msg: String, err: ErrorResponse) extends Exception(msg) with NoStackTrace
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -20,7 +20,7 @@ package com.waz.sync.handler
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.{debug, warn}
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{TeamData, TeamId, TeamMemberData}
+import com.waz.model._
 import com.waz.service.teams.TeamsService
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
@@ -33,9 +33,7 @@ import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 
 trait TeamsSyncHandler {
-
   def syncTeams(teams: Set[TeamId]): Future[SyncResult]
-
 }
 
 class TeamsSyncHandlerImpl(client: TeamsClient, service: TeamsService) extends TeamsSyncHandler {
@@ -47,7 +45,7 @@ class TeamsSyncHandlerImpl(client: TeamsClient, service: TeamsService) extends T
 
   private def syncAllTeams(): Future[SyncResult] = {
 
-    def recursive(start: Option[TeamId], teamsDownloaded: Set[TeamData], membersDownloaded: Set[TeamMemberData]): ErrorOrResponse[(Set[TeamData], Set[TeamMemberData])] = {
+    def recursive(start: Option[TeamId], teamsDownloaded: Set[TeamData], membersDownloaded: Set[UserId]): ErrorOrResponse[(Set[TeamData], Set[UserId])] = {
       client.getTeams(start).flatMap {
         case Right(TeamsResponse(teams, hasMore)) =>
           debug(s"syncTeams received data: $teams, hasMore? $hasMore")
@@ -80,7 +78,7 @@ class TeamsSyncHandlerImpl(client: TeamsClient, service: TeamsService) extends T
       Future.successful(SyncResult(error))
   }
 
-  private def downloadMembers(teams: Set[TeamId]): Future[Set[TeamMemberData]] =
+  private def downloadMembers(teams: Set[TeamId]): Future[Set[UserId]] =
     Future.traverse(teams) { id =>
       client.getTeamMembers(id).future.map {
         case Right(teamMembers) =>

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -24,7 +24,6 @@ import com.waz.model._
 import com.waz.service.teams.TeamsService
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
-import com.waz.sync.handler.TeamsSyncHandler.SyncException
 import com.waz.threading.Threading
 
 import scala.concurrent.Future
@@ -43,7 +42,7 @@ class TeamsSyncHandlerImpl(teamId: Option[TeamId], client: TeamsClient, service:
       case Right(data) =>
         client.getTeamMembers(id).future.flatMap {
           case Left(errorResponse) => Future.successful(SyncResult(errorResponse))
-          case Right(members) => for { _ <- service.onTeamSynced(data, members) } yield SyncResult.Success
+          case Right(members) => service.onTeamSynced(data, members).map(_ => SyncResult.Success)
         }
       case Left(error) => warn(s"TeamsClient.syncTeam: $id failed with error: $error"); Future.successful(SyncResult(error))
     }


### PR DESCRIPTION
* `teamId` is now retrieved during logging in and set in `AccountData` and `UserData`
* many methods are simplified or deleted because now there is only one `teamId` (or none) and we know it already
* some changes in UI are required
* no migration yet
* The way teamId is now stored (`Option[TeamId]`) can be improved. Right now `teamId == None` may mean both that we don't know the `teamId` yet and that this is a private account. 
* **more tests are needed...**