### PR TITLE
Update account data correctly in registration

### DIFF
--- a/tests/unit/src/test/scala/com/waz/service/AccountsServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/AccountsServiceSpec.scala
@@ -56,8 +56,8 @@ class AccountsServiceSpec extends FeatureSpec with Matchers with BeforeAndAfter 
 
       override def userModule(userId: UserId, account: AccountManager): UserModule =
         new UserModule(userId, account) {
-          override def ensureClientRegistered(account: AccountData): Future[Either[ErrorResponse, AccountData]] = {
-            Future successful Right(account.copy(clientId = account.clientId.orElse(Some(ClientId())), clientRegState = ClientRegistrationState.REGISTERED))
+          override def ensureClientRegistered(account: AccountData) = {
+            Future successful Right({})
           }
         }
     }

--- a/zmessaging/src/main/scala/com/waz/model/AccountData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AccountData.scala
@@ -115,9 +115,8 @@ case class AccountData(id:             AccountId               = AccountId(),
   def withTeam(teamId: Option[TeamId], permissions: Option[PermissionsMasks]): AccountData =
     copy(teamId = Right(teamId), _selfPermissions = permissions.map(_._1).getOrElse(0), _copyPermissions = permissions.map(_._2).getOrElse(0))
   
-  def isTeamAccount(): Boolean = {
+  def isTeamAccount: Boolean =
     teamId.fold(_ => false, _.isDefined)
-  }
 
 }
 

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrClientsSyncHandler.scala
@@ -88,7 +88,7 @@ class OtrClientsSyncHandler(context: Context, accountId: AccountId, userId: User
           case Right(cl) =>
             for {
               _ <- clientRegVersion := ZmsVersion.ZMS_MAJOR_VERSION
-              _ <- otrClients.updateUserClients(userId, Seq(c.copy(id = cl.id).updated(cl)), replace = false)
+              _ <- otrClients.updateUserClients(userId, Seq(c.copy(id = cl.id).updated(cl)))
             } yield Right((REGISTERED, Some(cl)))
           case Left(error@ErrorResponse(Status.Forbidden, _, "missing-auth")) =>
             warn(s"client registration not allowed: $error, password missing")


### PR DESCRIPTION
Ensures that each step of the ensureFullyRegistered method is responsible for updating the account storage completely before passing onto the next step - there was a bug where one step expected it to be done, but the account was only updated in memory, leading to client registration state loss and ultimately registered multiple clients per login.

This commit also tidies up the method, making it flatter - the error is only used in one spot to determine if we should create a zms instance or not.