### PR TITLE
[AN-5475] Logged-in accounts should also filter for accounts with a defined clientId

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -58,7 +58,7 @@ class AccountsService(val global: GlobalModule) {
       )
       new RefreshingSignal[Seq[AccountData], Seq[AccountId]](CancellableFuture.lift(storage.list()), changes)
     case true => Signal.const(Seq.empty[AccountData])
-  }.map(_.filter(_.cookie.isDefined))
+  }.map(_.filter(acc => acc.cookie.isDefined && acc.clientId.isDefined))
 
   // XXX Temporary stuff to handle team account in signup/signin - start
   private var _loggedInAccounts = Seq.empty[AccountData]


### PR DESCRIPTION
I was not able to reproduce the bug. Please test it with this one-liner.