### PR TITLE
[AN-5406] Searches for the exact handle match

### DIFF
--- a/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
+++ b/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
@@ -106,7 +106,6 @@ class DeviceActor(val deviceName: String,
   lazy val prefs = zmessaging.prefs
   lazy val convs = api.getConversations
   lazy val archived = convs.getArchivedConversations
-  lazy val search = api.search()
 
   //Using a large value so that the test processes will always timeout first, and not the remotes
   implicit val defaultTimeout = 5.minutes

--- a/tests/mocked/src/test/scala/com/waz/mocked/connections/InitialConnectionStatusSpec.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/connections/InitialConnectionStatusSpec.scala
@@ -46,7 +46,6 @@ class InitialConnectionStatusSpec extends FeatureSpec with Matchers with BeforeA
       users.getAll should have size 30
       all (users.getAll) shouldBe 'connected
     } (30.seconds)
-
     withDelay { convs should have size 200 } (10.seconds)
   }
 }

--- a/tests/unit/src/test/scala/com/waz/service/teams/TeamConversationSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/teams/TeamConversationSpec.scala
@@ -21,7 +21,7 @@ import com.waz.content.{ConversationStorage, MembersStorage}
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.ConversationData.ConversationType.{Group, OneToOne}
 import com.waz.model._
-import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsUiService}
+import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsUiService, ConversationsUiServiceImpl}
 import com.waz.service.messages.MessagesService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
@@ -113,8 +113,8 @@ class TeamConversationSpec extends AndroidFreeSpec {
     }
   }
 
-  def initService = {
-    new ConversationsUiService(self, null, null, null, messages, null, members, null, convsContent, convsStorage, null, null, sync, null, null)
+  def initService: ConversationsUiService = {
+    new ConversationsUiServiceImpl(self, null, null, null, messages, null, members, null, convsContent, convsStorage, null, null, sync, null, null)
   }
 
 

--- a/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
+++ b/tests/utils/src/main/scala/com/waz/testutils/EmptySyncService.scala
@@ -34,6 +34,7 @@ object EmptySyncService extends EmptySyncService
 
 trait EmptySyncServiceTrait extends SyncServiceHandle {
   override def syncSearchQuery(query: SearchQuery) = sid
+  override def exactMatchHandle(handle: Handle) = sid
   override def syncConversations(ids: Set[ConvId], dependsOn: Option[SyncId] = None) = sid
   override def syncTeam(dependsOn: Option[SyncId] = None) = sid
   override def syncTeamMember(id: UserId) = sid

--- a/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
+++ b/zmessaging/src/main/java/com/waz/model/sync/SyncCommand.java
@@ -30,6 +30,7 @@ public enum SyncCommand {
     SyncConnections("sync-connections"),
     SyncConversation("sync-conv"),
     SyncSearchQuery("sync-search"),
+    ExactMatchHandle("exact-match"),
     PostConv("post-conv"),
     PostConvName("post-conv-name"),
     PostConvState("post-conv-state"),

--- a/zmessaging/src/main/scala/com/waz/api/impl/ConnectionsSearch.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ConnectionsSearch.scala
@@ -33,9 +33,9 @@ class ConnectionsSearch(searchTerm: String, limit: Int, filter: Array[String], a
   private val query = SearchKey(searchTerm)
   private val predicate: UserData => Boolean = u =>
     ((query.isAtTheStartOfAnyWordIn(u.searchKey) && !searchByHandleOnly) || u.handle.exists(_.containsQuery(searchTerm)) || (alsoSearchByEmail && u.email.exists(e => searchTerm.trim.equalsIgnoreCase(e.str)))) && ! filteredIds.contains(u.id.str) && (showBlockedUsers || (u.connection != BLOCKED))
-
+  
   private var users = Option.empty[Vector[UserData]]
-
+  
   addLoader { zms =>
     usersFrom(zms).map(_.sortBy(_.name)(currentLocaleOrdering).take(limit))
   } { conns =>

--- a/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ZMessagingApi.scala
@@ -22,8 +22,8 @@ import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.api
 import com.waz.api.PermissionProvider
-import com.waz.api.ZMessagingApi.{PhoneConfirmationCodeRequestListener, PhoneNumberVerificationListener, RegistrationListener}
 import com.waz.api.impl.search.Search
+import com.waz.api.ZMessagingApi.{PhoneConfirmationCodeRequestListener, PhoneNumberVerificationListener, RegistrationListener}
 import com.waz.client.RegistrationClient.ActivateResult
 import com.waz.content.Uris
 import com.waz.model._

--- a/zmessaging/src/main/scala/com/waz/api/impl/search/ConversationSearchResult.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/search/ConversationSearchResult.scala
@@ -29,9 +29,9 @@ import com.waz.utils.events.Signal
 
 class ConversationSearchResult(prefix: String, limit: Int, handleOnly: Boolean)(implicit ui: UiModule) extends api.ConversationSearchResult with CoreList[IConversation] with SignalLoading {
   import com.waz.threading.Threading.Implicits.Background
-
+  
   @volatile private var convs = Option.empty[Vector[ConvId]]
-
+  
   addLoader { zms =>
     Signal.future(zms.convsUi.findGroupConversations(SearchKey(prefix), limit, handleOnly).map(_.map(_.id).toVector))
   } { cs =>

--- a/zmessaging/src/main/scala/com/waz/api/impl/search/Search.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/search/Search.scala
@@ -26,7 +26,7 @@ import com.waz.ui.UiModule
 class Search(implicit ui: UiModule) extends api.Search {
   override def getTopPeople(limit: Int, filter: Array[String]): api.UserSearchResult =
     new UserSearchResult(SearchQuery.TopPeople, limit, filter.toSet)
-
+  
   override def getRecommendedPeople(query: String, limit: Int, filter: Array[String]): api.UserSearchResult = {
     val searchQuery = query match {
       case Handle.handlePattern(term) => SearchQuery.RecommendedHandle(term)
@@ -34,18 +34,18 @@ class Search(implicit ui: UiModule) extends api.Search {
     }
     new UserSearchResult(searchQuery, limit, filter.toSet)
   }
-
+  
   override def getGroupConversations(query: String, limit: Int): api.ConversationSearchResult = {
     new ConversationSearchResult(query, limit, Handle.containsSymbol(query))
   }
-
+  
   override def getContacts(query: String): api.Contacts =
     new Contacts(OnlyContactsBySearchKeyFiltering(SearchKey(query)))
-
+  
   override def getConnectionsByName(query: String, limit: Int, filter: Array[String]): api.UserSearchResult =
     new ConnectionsSearch(query, limit, filter, false, false, Handle.containsSymbol(query))
-
-
+  
+    
   override def getConnectionsByNameOrEmailIncludingBlocked(query: String, limit: Int, filter: Array[String]): api.UserSearchResult =
     new ConnectionsSearch(query, limit, filter, true, true, Handle.containsSymbol(query))
 }

--- a/zmessaging/src/main/scala/com/waz/api/impl/search/UserSearchResult.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/search/UserSearchResult.scala
@@ -27,16 +27,16 @@ import com.waz.utils.SeqMap
 
 class UserSearchResult(query: SearchQuery, limit: Int, filter: Set[String])(implicit val ui: UiModule) extends api.UserSearchResult with CoreList[api.User] with SignalLoading {
   private var users = Option.empty[SeqMap[UserId, UserData]]
-
-  addLoader(_.userSearch.searchUserData(query, Some(limit + filter.size)), SeqMap.empty[UserId, UserData]) { us =>
+  
+  addLoader(_.userSearch.searchUserData(query), SeqMap.empty[UserId, UserData]) { us =>
     verbose(s"users[$query, $limit, $filter] loaded: ${us.size} user(s)")
     val changed = users.forall(_.keys != us.keys)
     users = Some(us)
     if (changed) notifyChanged()
   }
-
+  
   private[this] def currentUsers = users.getOrElse(SeqMap.empty)
-
+  
   override def get(position: Int): api.User = ui.users.getUser(currentUsers at position)
   override def size: Int = currentUsers.size
   override def getAll: Array[api.User] = currentUsers.valuesIterator.map(ui.users.getUser).toArray

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -62,6 +62,7 @@ trait MessagesStorage extends CachedStorage[MessageId, MessageData] {
   def getLastMessage(conv: ConvId): Future[Option[MessageData]]
   def getLastSentMessage(conv: ConvId): Future[Option[MessageData]]
   def lastLocalMessage(conv: ConvId, tpe: Message.Type): Future[Option[MessageData]]
+  def countLaterThan(conv: ConvId, time: Instant): Future[Long]
 }
 
 class MessagesStorageImpl(context: Context, storage: ZmsDatabase, userId: UserId, convs: ConversationStorageImpl, users: UsersStorageImpl, msgAndLikes: => MessageAndLikesStorage, timeouts: Timeouts) extends

--- a/zmessaging/src/main/scala/com/waz/content/SearchQueryCacheStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/SearchQueryCacheStorage.scala
@@ -27,7 +27,13 @@ import org.threeten.bp.Instant
 
 import scala.concurrent.Future
 
-class SearchQueryCacheStorage(context: Context, storage: Database) extends CachedStorageImpl[SearchQuery, SearchQueryCache](new TrimmingLruCache(context, Fixed(20)), storage)(SearchQueryCacheDao, "SearchQueryCacheStorage") {
+trait SearchQueryCacheStorage extends CachedStorage[SearchQuery, SearchQueryCache] {
+  def deleteBefore(i: Instant): Future[Unit]
+}
+
+class SearchQueryCacheStorageImpl(context: Context, storage: Database)
+  extends CachedStorageImpl[SearchQuery, SearchQueryCache](new TrimmingLruCache(context, Fixed(20)), storage)(SearchQueryCacheDao, "SearchQueryCacheStorage")
+  with SearchQueryCacheStorage {
   import Threading.Implicits.Background
   def deleteBefore(i: Instant): Future[Unit] = storage(SearchQueryCacheDao.deleteBefore(i)(_)).future.flatMap(_ => deleteCached(_.timestamp.isBefore(i)))
 }

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -23,8 +23,18 @@ import com.waz.utils.Locales
 
 case class Handle(string: String) extends AnyVal{
   override def toString : String = string
+
   def containsQuery(query: String): Boolean = {
     string.contains(Handle.transliterated(Handle.stripSymbol(query)).toLowerCase)
+  }
+
+  def exactMatchQuery(query: String): Boolean = {
+    string == Handle.transliterated(Handle.stripSymbol(query)).toLowerCase
+  }
+
+  def withSymbol: String = string match {
+    case Handle.handlePattern(_) => string
+    case _ => "@" + string
   }
 }
 
@@ -33,12 +43,15 @@ object Handle extends (String => Handle){
   def random: Handle = Handle(UUID.randomUUID().toString)
   val handlePattern = """@(.+)""".r
   def transliterated(s: String): String = Locales.transliteration.transliterate(s).trim
+
   def containsSymbol(input: String): Boolean = input match {
     case Handle.handlePattern(handle) => true
     case _ => false
   }
+
   def stripSymbol(input: String): String = input match {
     case Handle.handlePattern(handle) => handle
     case _ => input
   }
+
 }

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -103,6 +103,10 @@ object SyncRequest {
     override val mergeKey: Any = (cmd, query)
   }
 
+  case class ExactMatchHandle(handle: Handle) extends BaseRequest(Cmd.ExactMatchHandle) {
+    override val mergeKey: Any = (cmd, handle)
+  }
+
   case class SyncRichMedia(messageId: MessageId) extends BaseRequest(Cmd.SyncRichMedia) {
     override val mergeKey: Any = (cmd, messageId)
   }
@@ -302,6 +306,7 @@ object SyncRequest {
           case Cmd.SyncUser              => SyncUser(users)
           case Cmd.SyncConversation      => SyncConversation(decodeConvIdSeq('convs).toSet)
           case Cmd.SyncSearchQuery       => SyncSearchQuery(SearchQuery.fromCacheKey(decodeString('queryCacheKey)))
+          case Cmd.ExactMatchHandle      => ExactMatchHandle(Handle(decodeString('handle)))
           case Cmd.PostConv              => PostConv(convId, decodeStringSeq('users).map(UserId(_)), 'name, 'team)
           case Cmd.PostConvName          => PostConvName(convId, 'name)
           case Cmd.PostConvState         => PostConvState(convId, JsonDecoder[ConversationState]('state))
@@ -369,6 +374,7 @@ object SyncRequest {
         case SyncUser(users)                  => o.put("users", arrString(users.toSeq map ( _.str)))
         case SyncConversation(convs)          => o.put("convs", arrString(convs.toSeq map (_.str)))
         case SyncSearchQuery(queryCacheKey)   => o.put("queryCacheKey", queryCacheKey.cacheKey)
+        case ExactMatchHandle(handle)         => o.put("handle", handle.string)
         case SyncTeamMember(userId)           => o.put("user", userId.str)
         case DeletePushToken(token)           => putId("token", token)
         case RegisterPushToken(token)         => putId("token", token)

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -19,10 +19,12 @@ package com.waz.service
 
 import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
-import com.waz.content.{MessagesStorageImpl, SearchQueryCacheStorage, UsersStorageImpl}
+import com.waz.content.{MembersStorage, MessagesStorage, SearchQueryCacheStorage, UsersStorage}
 import com.waz.model.SearchQuery.{Recommended, RecommendedHandle, TopPeople}
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
 import com.waz.model.{SearchQuery, _}
+import com.waz.service.conversation.ConversationsUiService
+import com.waz.service.teams.TeamsService
 import com.waz.sync.SyncServiceHandle
 import com.waz.sync.client.UserSearchClient.UserSearchEntry
 import com.waz.threading.Threading
@@ -32,15 +34,42 @@ import com.waz.utils.events._
 import org.threeten.bp.Instant
 
 import scala.collection.breakOut
+import scala.collection.immutable.Set
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class UserSearchService(queryCache: SearchQueryCacheStorage,
+
+case class SearchState(filter: String, hasSelectedUsers: Boolean, addingToConversation: Option[ConvId]){
+  def shouldShowTopUsers(isTeam: Boolean) = filter.isEmpty && !isTeam && addingToConversation.isEmpty
+  def shouldShowAbContacts(isTeam: Boolean) = addingToConversation.isEmpty && !hasSelectedUsers && !isTeam
+  lazy val shouldShowGroupConversations = filter.nonEmpty && !hasSelectedUsers && addingToConversation.isEmpty
+  lazy val shouldShowDirectorySearch = filter.nonEmpty && !hasSelectedUsers && addingToConversation.isEmpty
+
+  lazy val empty = filter.isEmpty
+  lazy val isHandle = Handle.containsSymbol(filter)
+  lazy val stripSymbol = if (isHandle) Handle.stripSymbol(filter) else filter
+  lazy val query = if (isHandle) RecommendedHandle(filter) else Recommended(filter)
+}
+
+case class SearchResults(topPeople: Option[IndexedSeq[UserData]], localResults: Option[IndexedSeq[UserData]],
+                         conversations: Option[IndexedSeq[ConversationData]], directoryResults: Option[IndexedSeq[UserData]]) {
+  lazy val allHandles = topPeople.getOrElse(IndexedSeq.empty).flatMap(_.handle) ++
+                        localResults.getOrElse(IndexedSeq.empty).flatMap(_.handle) ++
+                        directoryResults.getOrElse(IndexedSeq.empty).flatMap(_.handle)
+}
+
+class UserSearchService(selfUserId: UserId,
+                        queryCache: SearchQueryCacheStorage,
                         teamId: Option[TeamId],
                         userService: UserService,
-                        usersStorage: UsersStorageImpl,
-                        timeouts: Timeouts, sync: SyncServiceHandle,
-                        messages: MessagesStorageImpl) {
+                        usersStorage: UsersStorage,
+                        teamsService: TeamsService,
+                        membersStorage: MembersStorage,
+                        timeouts: Timeouts,
+                        sync: SyncServiceHandle,
+                        messages: MessagesStorage,
+                        convsUi: ConversationsUiService
+                       ) {
 
   import Threading.Implicits.Background
   import com.waz.service.UserSearchService._
@@ -48,17 +77,79 @@ class UserSearchService(queryCache: SearchQueryCacheStorage,
 
   ClockSignal(1.day)(i => queryCache.deleteBefore(i - cacheExpiryTime))(EventContext.Global)
 
-  def searchUserData(query: SearchQuery, limit: Option[Int] = None): Signal[SeqMap[UserId, UserData]] =
+  def search(searchState: SearchState, excludedUsers: Set[UserId]): Signal[SearchResults] = {
+    if (searchState.empty) Future {
+      System.gc() // TODO: [AN-5497] the user search should not create so many objects to trigger GC in-between
+    }(Threading.Background)
+
+    val topUsersSignal =
+      if (searchState.shouldShowTopUsers(teamId.isDefined)) searchUserData(TopPeople).map(_.values.filter(u => !excludedUsers.contains(u.id)))
+      else Signal.const(IndexedSeq.empty[UserData])
+
+    val localSearchSignal = for {
+      acceptedOrBlocked   <- userService.acceptedOrBlockedUsers
+      members             <- searchTeamMembersForState(searchState)
+      usersAlreadyInConv  <- searchConvMembersForState(searchState)
+    } yield mergeUsers(acceptedOrBlocked.values, members, excludedUsers ++ usersAlreadyInConv, searchState)
+
+    val conversationsSignal: Signal[IndexedSeq[ConversationData]] =
+      if (searchState.shouldShowGroupConversations)
+        Signal.future(convsUi.findGroupConversations(SearchKey(searchState.filter), Int.MaxValue, handleOnly = searchState.isHandle))
+          .map(_.filter(conv => teamId.forall(conv.team.contains)).distinct.toIndexedSeq)
+      else Signal.const(IndexedSeq.empty[ConversationData])
+
+    val searchSignal =
+      if (searchState.shouldShowDirectorySearch) searchUserData(searchState.query).map(_.values.filter(u => !excludedUsers.contains(u.id)))
+      else Signal.const(IndexedSeq.empty[UserData])
+
+    (for {
+      topUsers              <- topUsersSignal.map(Option(_)).orElse(Signal.const(Option.empty[IndexedSeq[UserData]]))
+      localResults          <- localSearchSignal.map(Option(_)).orElse(Signal.const(Option.empty[IndexedSeq[UserData]]))
+      conversations         <- conversationsSignal.map(Option(_)).orElse(Signal.const(Option.empty[IndexedSeq[ConversationData]]))
+      directoryResults      <- searchSignal.map(Option(_)).orElse(Signal.const(Option.empty[IndexedSeq[UserData]]))
+    } yield SearchResults(topUsers, localResults, conversations, directoryResults)).map { res =>
+      if (searchState.isHandle && searchState.stripSymbol.length > 1 && !res.allHandles.exists(_.exactMatchQuery(searchState.filter)))
+        sync.exactMatchHandle(Handle(searchState.stripSymbol))
+      res
+    }
+
+  }
+
+  def updateSearchResults(query: SearchQuery, results: Seq[UserSearchEntry]) = {
+    def updating(ids: Vector[UserId])(cached: SearchQueryCache) = cached.copy(query, Instant.now, if (ids.nonEmpty || cached.entries.isEmpty) Some(ids) else cached.entries)
+
+    for {
+      updated <- userService.updateUsers(results)
+      _       <- userService.syncIfNeeded(updated.toSeq: _*)
+      ids      = results.map(_.id)(breakOut): Vector[UserId]
+      _        = verbose(s"updateSearchResults($query, $ids)")
+      _       <- queryCache.updateOrCreate(query, updating(ids), SearchQueryCache(query, Instant.now, Some(ids)))
+    } yield ()
+  }
+
+  def updateExactMatch(handle: Handle, userId: UserId) = {
+    val query = RecommendedHandle(handle.withSymbol)
+    val cache = SearchQueryCache(query, Instant.now, Some(Vector(userId)))
+    def updating(id: UserId)(cached: SearchQueryCache) = cached.copy(query, Instant.now, Some(cached.entries.map(_.toSet ++ Set(userId)).getOrElse(Set(userId)).toVector))
+
+    for {
+      _ <- userService.getUser(userId)
+      _ = verbose(s"user synced($query, $userId)")
+      _ <- queryCache.updateOrCreate(query, updating(userId), cache)
+    } yield ()
+  }
+
+  def searchUserData(query: SearchQuery): Signal[SeqMap[UserId, UserData]] = {
+   
     queryCache.optSignal(query).flatMap {
       case _ if query == TopPeople =>
         if (teamId.isEmpty) topPeople else Signal.empty[Vector[UserData]]
 
       case r if r.forall(cached => (cacheExpiryTime elapsedSince cached.timestamp) || cached.entries.isEmpty) =>
-        verbose(s"no cached entries for query $query")
 
         def fallbackToLocal = query match {
           case Recommended(prefix) =>
-            usersStorage.find[UserData, Vector[UserData]](recommendedPredicate(prefix, withinThreeLevels), db => UserDataDao.recommendedPeople(prefix)(db), identity)
+            usersStorage.find[UserData, Vector[UserData]](recommendedPredicate(prefix), db => UserDataDao.recommendedPeople(prefix)(db), identity)
           case RecommendedHandle(prefix) =>
             usersStorage.find[UserData, Vector[UserData]](recommendedHandlePredicate(prefix), db => UserDataDao.recommendedPeople(prefix)(db), identity)
           case _ => Future.successful(Vector())
@@ -66,31 +157,33 @@ class UserSearchService(queryCache: SearchQueryCacheStorage,
 
         fallbackToLocal.map(_.sortBy(_.name)(currentLocaleOrdering)).flatMap { users =>
           lazy val fresh = SearchQueryCache(query, Instant.now, Some(users.map(_.id)))
+
           def update(q: SearchQueryCache): SearchQueryCache = if ((cacheExpiryTime elapsedSince q.timestamp) || q.entries.isEmpty) fresh else q
 
           queryCache.updateOrCreate(query, update, fresh)
         }.flatMap(_ => sync.syncSearchQuery(query)).logFailure()
 
-        Signal.empty[Vector[UserData]]
+        Signal.const(Vector.empty[UserData])
 
       case Some(cached) =>
-        verbose(s"query $query cached: ${cached.entries.map(_.size)} (${cached.timestamp})")
-        if (cacheRefreshInterval elapsedSince cached.timestamp) queryCache.getOrCreate(query, SearchQueryCache(query, Instant.now, None)).flatMap(_ => sync.syncSearchQuery(query)).logFailure()
+        if (cacheRefreshInterval elapsedSince cached.timestamp)
+          queryCache.getOrCreate(query, SearchQueryCache(query, Instant.now, None)).flatMap(_ => sync.syncSearchQuery(query)).logFailure()
 
         cached.entries match {
           case Some(ids) => usersStorage.listSignal(ids)
-          case _         => Signal.const(Vector.empty[UserData])
+          case _ => Signal.const(Vector.empty[UserData])
         }
 
       case _ => Signal.const(Vector.empty[UserData])
     }.map { users =>
       query match {
         case TopPeople if teamId.isEmpty => users filter topPeoplePredicate
-        case Recommended(prefix) => users filter recommendedPredicate(prefix, atAnyLevel)
+        case Recommended(prefix) => users filter recommendedPredicate(prefix)
         case RecommendedHandle(prefix) => users filter recommendedHandlePredicate(prefix)
         case _ => users
       }
-    }.map(users => SeqMap(limit.fold2(users, users.take))(_.id, identity))
+    }.map { users => SeqMap(users)(_.id, identity) }
+  }
 
   private def topPeople = {
     def messageCount(u: UserData) = messages.countLaterThan(ConvId(u.id.str), Instant.now - topPeopleMessageInterval)
@@ -106,27 +199,54 @@ class UserSearchService(queryCache: SearchQueryCacheStorage,
   }
 
   private val topPeoplePredicate: UserData => Boolean = u => ! u.deleted && u.connection == ConnectionStatus.Accepted
-  private def recommendedPredicate(prefix: String, levels: Set[Relation]): UserData => Boolean = {
+
+  private def recommendedPredicate(prefix: String): UserData => Boolean = {
     val key = SearchKey(prefix)
-    u => ! u.deleted && ! u.isConnected && ((key.isAtTheStartOfAnyWordIn(u.searchKey) && levels(u.relation)) || u.email.exists(_.str == prefix) || u.handle.exists(_.containsQuery(prefix)))
+    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.email.exists(_.str == prefix) || u.handle.exists(_.containsQuery(prefix)))
   }
+
   private def recommendedHandlePredicate(prefix: String): UserData => Boolean = {
     u => ! u.deleted && ! u.isConnected && u.handle.exists(_.containsQuery(prefix))
   }
-  private val withinThreeLevels = Set(Relation.First, Relation.Second, Relation.Third)
-  private val atAnyLevel = Relation.values.toSet
 
-  def updateSearchResults(query: SearchQuery, results: Seq[UserSearchEntry]): Future[Unit] = {
-    def updating(ids: Vector[UserId])(cached: SearchQueryCache) = cached.copy(query, Instant.now, if (ids.nonEmpty || cached.entries.isEmpty) Some(ids) else cached.entries)
-
-    for {
-      updated <- userService.updateUsers(results)
-      _       <- userService.syncIfNeeded(updated.toSeq: _*)
-      ids      = results.map(_.id)(breakOut): Vector[UserId]
-      _        = verbose(s"updateSearchResults($query, $ids)")
-      _       <- queryCache.updateOrCreate(query, updating(ids), SearchQueryCache(query, Instant.now, Some(ids)))
-    } yield ()
+  private def searchTeamMembersForState(searchState: SearchState) = teamId match {
+    case None => Signal.const(Set.empty[UserData])
+    case Some(_) =>
+      val searchKey = if (searchState.filter.isEmpty) None else Some(SearchKey(searchState.filter))
+      teamsService.searchTeamMembers(searchKey, handleOnly = Handle.containsSymbol(searchState.filter))
   }
+
+  private def searchConvMembersForState(searchState: SearchState) = searchState.addingToConversation match {
+    case None => Signal.const(Set.empty[UserId])
+    case Some(convId) => Signal.future(membersStorage.getByConv(convId)).map(_.map(_.userId).toSet)
+  }
+
+  private def mergeUsers(connected: Iterable[UserData], members: Iterable[UserData], excludedIds: Set[UserId], searchState: SearchState): IndexedSeq[UserData] = {
+    val users = if (!searchState.empty) connected.filter(connectedUsersPredicate(
+      searchState.filter,
+      excludedIds.map(_.str),
+      alsoSearchByEmail = true,
+      showBlockedUsers = true,
+      searchByHandleOnly = searchState.isHandle)) else connected
+
+    val includedIds = (users.map(_.id).toSet ++ members.map(_.id).toSet).filterNot(id => id == selfUserId || excludedIds.contains(id))
+    (connected ++ members).filter(u => includedIds.contains(u.id)).toIndexedSeq
+  }
+
+  private def connectedUsersPredicate(searchTerm: String,
+                                      filteredIds: Set[String],
+                                      alsoSearchByEmail: Boolean,
+                                      showBlockedUsers: Boolean,
+                                      searchByHandleOnly: Boolean): UserData => Boolean = {
+    val query = SearchKey(searchTerm)
+    user =>
+      ((query.isAtTheStartOfAnyWordIn(user.searchKey) && !searchByHandleOnly) ||
+        user.handle.exists(_.containsQuery(searchTerm)) ||
+        (alsoSearchByEmail && user.email.exists(e => searchTerm.trim.equalsIgnoreCase(e.str)))) &&
+        !filteredIds.contains(user.id.str) &&
+        (showBlockedUsers || (user.connection != ConnectionStatus.Blocked))
+  }
+
 }
 
 object UserSearchService {

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -47,8 +47,10 @@ trait UserService {
   def withSelfUserFuture[A](f: UserId => Future[A]): Future[A]
   def updateConnectionStatus(id: UserId, status: UserData.ConnectionStatus, time: Option[Date] = None, message: Option[String] = None): Future[Option[UserData]]
   def getUsers(ids: Seq[UserId]): Future[Seq[UserData]]
+  def getUser(id: UserId): Future[Option[UserData]]
   def syncIfNeeded(users: UserData*): Future[Unit]
   def updateUsers(entries: Seq[UserSearchEntry]): Future[Set[UserData]]
+  val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]]
 }
 
 class UserServiceImpl(val selfUserId: UserId,
@@ -73,7 +75,7 @@ class UserServiceImpl(val selfUserId: UserId,
       Signal.empty
   }
 
-  val lastSlowSyncTimestamp = preference(LastSlowSyncTimeKey)
+  lazy val lastSlowSyncTimestamp = preference(LastSlowSyncTimeKey)
   val userUpdateEventsStage = EventScheduler.Stage[UserUpdateEvent]((c, e) => for {
       _ <- updateSyncedUsers(e.filterNot(_.removeIdentity).map(_.user)(breakOut))
       _ <- removeIdentityFromSyncedUsers(e.filter(_.removeIdentity).map(_.user)(breakOut))
@@ -92,10 +94,14 @@ class UserServiceImpl(val selfUserId: UserId,
     sync.syncSelfUser().map(dependency => sync.syncConnections(Some(dependency)))
   }
 
-  lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] = new AggregatingSignal[Seq[UserData], Map[UserId, UserData]](usersStorage.onChanged, usersStorage.listUsersByConnectionStatus(acceptedOrBlocked), { (accu, us) =>
-    val (toAdd, toRemove) = us.partition(u => acceptedOrBlocked(u.connection))
-    accu -- toRemove.map(_.id) ++ toAdd.map(u => u.id -> u)
-  })
+  override lazy val acceptedOrBlockedUsers: Signal[Map[UserId, UserData]] =
+    new AggregatingSignal[Seq[UserData], Map[UserId, UserData]](
+      usersStorage.onChanged, usersStorage.listUsersByConnectionStatus(acceptedOrBlocked),
+      { (accu, us) =>
+        val (toAdd, toRemove) = us.partition(u => acceptedOrBlocked(u.connection))
+        accu -- toRemove.map(_.id) ++ toAdd.map(u => u.id -> u)
+      }
+    )
 
   private lazy val acceptedOrBlocked = Set(ConnectionStatus.Accepted, ConnectionStatus.Blocked)
 
@@ -130,7 +136,7 @@ class UserServiceImpl(val selfUserId: UserId,
     usersStorage.updateOrCreateAll(entries.map(entry => entry.id -> updateOrAdd(entry)).toMap)
   }
 
-  def getUser(id: UserId): Future[Option[UserData]] = {
+  override def getUser(id: UserId): Future[Option[UserData]] = {
     debug(s"getUser($id)")
 
     usersStorage.get(id) map {
@@ -143,7 +149,7 @@ class UserServiceImpl(val selfUserId: UserId,
     }
   }
 
-  def userSignal(id: UserId) =
+  def userSignal(id: UserId): Signal[UserData] =
     usersStorage.optSignal(id) flatMap {
       case None =>
         sync.syncUsers(id)

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -83,7 +83,7 @@ class StorageModule(context: Context, accountId: AccountId, dbPrefix: String, gl
   lazy val notifStorage                           = wire[NotificationStorage]
   lazy val convsStorage                           = wire[ConversationStorageImpl]
   lazy val msgDeletions:      MsgDeletionStorage  = wire[MsgDeletionStorageImpl]
-  lazy val searchQueryCache                       = wire[SearchQueryCacheStorage]
+  lazy val searchQueryCache: SearchQueryCacheStorage = wire[SearchQueryCacheStorageImpl]
   lazy val msgEdits:          EditHistoryStorage  = wire[EditHistoryStorageImpl]
 }
 
@@ -199,7 +199,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, val userMod
   lazy val conversations: ConversationsService        = wire[ConversationsService]
   lazy val convsNotifier                              = wire[ConversationsNotifier]
   lazy val convOrder: ConversationOrderEventsService  = wire[ConversationOrderEventsService]
-  lazy val convsUi                                    = wire[ConversationsUiService]
+  lazy val convsUi: ConversationsUiService            = wire[ConversationsUiServiceImpl]
   lazy val convsStats                                 = wire[ConversationsListStateService]
   lazy val teams: TeamsServiceImpl                    = wire[TeamsServiceImpl]
   lazy val messages: MessagesServiceImpl              = wire[MessagesServiceImpl]

--- a/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/HandlesClient.scala
@@ -62,3 +62,5 @@ object UsersHandleResponseContent {
     }
   }
 }
+
+

--- a/zmessaging/src/main/scala/com/waz/sync/handler/HandlesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/HandlesSyncHandler.scala
@@ -20,7 +20,7 @@ package com.waz.sync.handler
 import com.waz.api.UsernameValidation
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.Handle
-import com.waz.service.HandlesService
+import com.waz.service.{HandlesService, UserSearchService}
 import com.waz.sync.SyncResult
 import com.waz.sync.client.HandlesClient
 import com.waz.threading.Threading
@@ -29,7 +29,7 @@ import com.waz.znet.Response.Status
 
 import scala.concurrent.Future
 
-class HandlesSyncHandler(handlesClient: HandlesClient, handlesService: HandlesService) {
+class HandlesSyncHandler(handlesClient: HandlesClient, handlesService: HandlesService, userSearch: UserSearchService) {
   import Threading.Implicits.Background
 
   val responseSignal = Signal[Option[Seq[UsernameValidation]]](None)
@@ -47,4 +47,5 @@ class HandlesSyncHandler(handlesClient: HandlesClient, handlesService: HandlesSe
       case Left(error) => SyncResult.Failure(Some(error), shouldRetry = true)
     }
   }
+
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -20,7 +20,7 @@ package com.waz.sync.handler
 import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.SearchQueryCacheStorage
-import com.waz.model.SearchQuery
+import com.waz.model.{Handle, SearchQuery}
 import com.waz.service.UserSearchService
 import com.waz.sync.SyncResult
 import com.waz.sync.client.UserSearchClient
@@ -29,7 +29,7 @@ import com.waz.threading.Threading
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
-class UserSearchSyncHandler(storage: SearchQueryCacheStorage, userSearch: UserSearchService, client: UserSearchClient) {
+class UserSearchSyncHandler(storage: SearchQueryCacheStorage, userSearch: UserSearchService, client: UserSearchClient, usersSyncHandler: UsersSyncHandler) {
   import Threading.Implicits.Background
 
   def syncSearchQuery(query: SearchQuery): Future[SyncResult] = {
@@ -42,5 +42,11 @@ class UserSearchSyncHandler(storage: SearchQueryCacheStorage, userSearch: UserSe
         warn("graphSearch request failed")
         successful(SyncResult(error))
     }
+  }
+
+  def exactMatchHandle(handle: Handle): Future[SyncResult] = client.exactMatchHandle(handle).future.flatMap {
+    case Right(Some(userId)) => userSearch.updateExactMatch(handle, userId).map(_ => SyncResult.Success)
+    case Right(None)         => successful(SyncResult.Success)
+    case Left(error)         => successful(SyncResult(error))
   }
 }

--- a/zmessaging/src/main/scala/com/waz/utils/Locales.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/Locales.scala
@@ -28,6 +28,7 @@ import android.os.Build.VERSION_CODES.{JELLY_BEAN_MR2, LOLLIPOP}
 import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.service.ZMessaging
+import com.waz.utils
 
 import scala.annotation.tailrec
 import scala.util.Try
@@ -113,7 +114,7 @@ trait Transliteration {
 object Transliteration {
   private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z] Remove"
   def chooseImplementation(id: String = id): Transliteration =
-    if (Try(Class.forName("libcore.icu.Transliterator")).isSuccess) LibcoreTransliteration.create(id)
+    if (!utils.isTest && Try(Class.forName("libcore.icu.Transliterator")).isSuccess) LibcoreTransliteration.create(id)
     else ICU4JTransliteration.create(id)
 }
 


### PR DESCRIPTION
* Lots of user searching functionality moved from UI to SE
* If `UserData` with the exact handle match is not found with the standard search, a new request is used to search for that on the backend
* Refactoring to allow android-free unit tests of `UserSearchService` and unit tests covering the standard search
* A hack: garbage collection is enforced before the search to lower the risk of GC suspending the search in-between
* Still to do: more unit tests!