### PR TITLE
Split duplicate/outdated otr error and save exception

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -138,8 +138,12 @@ class OtrServiceImpl(selfUserId: UserId, clientId: ClientId, val clients: OtrCli
           case e: CryptoException =>
             import CryptoException.Code._
             e.code match {
-              case DUPLICATE_MESSAGE | OUTDATED_MESSAGE =>
+              case DUPLICATE_MESSAGE =>
                 verbose(s"detected duplicate message for event: $ev")
+                Future successful Left(Duplicate)
+              case OUTDATED_MESSAGE =>
+                error(s"detected outdated message for event: $ev")
+                reportOtrError(e, ev)
                 Future successful Left(Duplicate)
               case REMOTE_IDENTITY_CHANGED =>
                 reportOtrError(e, ev)


### PR DESCRIPTION
Decided to make a separate entry instead of relying on the catch all, since I'm not sure how often this happens and don't want to spam the user's conversations