### PR TITLE
ConversationsList.createGroupConversation uses Seq instead of Java Iterable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
 
 jdk:
   - oraclejdk8
-
+dist: precise
 sudo: false
 
 cache:

--- a/tests/integration/src/test/scala/com/waz/conv/ConversationsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/ConversationsSpec.scala
@@ -84,7 +84,7 @@ class ConversationsSpec extends FeatureSpec with Matchers with OptionValues with
       val users = List("auto2", "auto3").map(k => api.getUser(provisionedUserId(k).str))
       val count = conversations.size()
       var conv = Option.empty[IConversation]
-      conversations.createGroupConversation(users.asJava, new ConversationCallback {
+      conversations.createGroupConversation(users, new ConversationCallback {
         override def onConversationsFound(conversations: Iterable[IConversation]): Unit = conv = conversations.asScala.headOption
       })
 
@@ -141,7 +141,7 @@ class ConversationsSpec extends FeatureSpec with Matchers with OptionValues with
       })
       val count = conversations.size()
       var msgs = Seq.empty[MessageData]
-      conversations.createGroupConversation(users.asJava, new ConversationCallback {
+      conversations.createGroupConversation(users, new ConversationCallback {
         override def onConversationsFound(conversations: Iterable[IConversation]): Unit =
           conversations.asScala.headOption foreach { c => msgs = listMessages(c.id) }
       })

--- a/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/CreateConversationSpec.scala
@@ -67,7 +67,7 @@ class CreateConversationSpec extends FeatureSpec with Matchers with OptionValues
       val users = allUserIds.slice(1, 3).map(id => api.getUser(id.str))
 
       var convResult = Seq.empty[IConversation]
-      conversations.createGroupConversation(users.asJava, new ConversationCallback {
+      conversations.createGroupConversation(users, new ConversationCallback {
         override def onConversationsFound(conversations: Iterable[IConversation]): Unit = convResult = conversations.asScala.toSeq
       })
 

--- a/tests/integration/src/test/scala/com/waz/conv/LargeConversationsListSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/LargeConversationsListSpec.scala
@@ -31,7 +31,6 @@ import com.waz.testutils.Implicits._
 import com.waz.threading.Threading
 import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Matchers}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
@@ -212,7 +211,7 @@ class LargeConversationsListSpec extends FeatureSpec with BeforeAndAfterAll with
       }) :+ api.getSelf.getUser
 
       val before = convs.size()
-      convs.createGroupConversation(usersToAdd.toSet.asJava, new ConversationCallback {
+      convs.createGroupConversation(usersToAdd.toSet.toSeq, new ConversationCallback {
         override def onConversationsFound(conversations: Iterable[IConversation]): Unit = ()
       })
       withDelay { convs should have size (before + 1) } (30.seconds)

--- a/zmessaging/src/main/scala/com/waz/api/ConversationsList.scala
+++ b/zmessaging/src/main/scala/com/waz/api/ConversationsList.scala
@@ -52,7 +52,7 @@ trait ConversationsList extends CoreList[IConversation] with EventualReadiness {
   def getConversation(id: String, callback: ConversationsList.ConversationCallback): LoadHandle
   def getConversationIndex(id: String): Int
 
-  def createGroupConversation(users: java.lang.Iterable[_ <: User], callback: ConversationsList.ConversationCallback): Unit
+  def createGroupConversation(users: Seq[User], callback: ConversationsList.ConversationCallback): Unit
 
   def getSyncIndicator: SyncIndicator
   def getState: ConversationsList.ConversationsListState

--- a/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
@@ -26,7 +26,7 @@ import com.waz.api
 import com.waz.api.ConversationsList.{ConversationCallback, VerificationStateCallback}
 import com.waz.api.impl.ConversationsListState.Data
 import com.waz.api.impl.conversation.{BaseConversationsList, SelfConversation}
-import com.waz.api.{IConversation, LoadHandle}
+import com.waz.api.{IConversation, LoadHandle, User}
 import com.waz.content.Uris
 import com.waz.content.Uris.{SelfConversationUri, SyncIndicatorUri}
 import com.waz.model.ConversationData.ConversationType
@@ -73,8 +73,8 @@ class ConversationsList(implicit val ui: UiModule) extends api.ConversationsList
 
   override protected val conversations: Conversations = ui.convs
 
-  override def createGroupConversation(users: Iterable[_ <: api.User], callback: ConversationCallback): Unit =
-    conversations.createGroupConversation(users.asScala.toSeq) .map { conv =>
+  override def createGroupConversation(users: Seq[api.User], callback: ConversationCallback): Unit =
+    conversations.createGroupConversation(users) .map { conv =>
       callback.onConversationsFound(Seq(conversations.getConversation(conv).asInstanceOf[IConversation]).asJava)
     } (Threading.Ui) .recoverWithLog()
 
@@ -98,6 +98,7 @@ class ConversationsList(implicit val ui: UiModule) extends api.ConversationsList
   override def getState = ui.cached(Uris.ConversationsStateUri, new ConversationsListState)
 
   override def onVerificationStateChange(callback: VerificationStateCallback): Unit = conversations.onVerificationStateChange(callback)
+
 }
 
 object ConversationsList {


### PR DESCRIPTION
A small change connected to rewriting ScalaConversationStore from Java to Scala. The rest of the code changes are in UI.