### PR TITLE
[AN-5476] Specialized sendMessage methods in ConversationsUiService

### DIFF
--- a/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
+++ b/actors/base/src/main/scala/com/waz/provision/DeviceActor.scala
@@ -24,7 +24,6 @@ import akka.actor.SupervisorStrategy._
 import akka.actor._
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
-import com.waz.api.MessageContent.{Image, Text}
 import com.waz.api.OtrClient.DeleteCallback
 import com.waz.api.ZMessagingApi.RegistrationListener
 import com.waz.api._
@@ -242,14 +241,14 @@ class DeviceActor(val deviceName: String,
 
     case SendText(remoteId, msg) =>
       whenConversationExists(remoteId) { conv =>
-        conv.sendMessage(new Text(msg))
+        zmessaging.convsUi.sendMessage(conv.id, msg)
         Successful
       }
 
     case UpdateText(msgId, text) =>
       zmessaging.messagesStorage.getMessage(msgId) flatMap {
         case Some(msg) if msg.userId == zmessaging.selfUserId =>
-          zmessaging.convsUi.updateMessage(msg.convId, msgId, new MessageContent.Text(text)) map { _ => Successful }
+          zmessaging.convsUi.updateMessage(msg.convId, msgId, text) map { _ => Successful }
         case Some(_) =>
           Future successful Failed("Can not update messages from other user")
         case None =>
@@ -271,15 +270,15 @@ class DeviceActor(val deviceName: String,
         searchQuery match {
           case "" =>
             waitUntil(api.getGiphy.random())(_.isReady == true) map { results =>
-              conv.sendMessage(new Text("Via giphy.com"))
-              conv.sendMessage(new Image(results.head))
+              zmessaging.convsUi.sendMessage(conv.id, "Via giphy.com")
+              zmessaging.convsUi.sendMessage(conv.id, results.head)
               Successful
             }
 
           case _ =>
             waitUntil(api.getGiphy.search(searchQuery))(_.isReady == true) map { results =>
-              conv.sendMessage(new Text("%s · via giphy.com".format(searchQuery)))
-              conv.sendMessage(new Image(results.head))
+              zmessaging.convsUi.sendMessage(conv.id, "%s · via giphy.com".format(searchQuery))
+              zmessaging.convsUi.sendMessage(conv.id, results.head)
               Successful
             }
         }
@@ -316,13 +315,13 @@ class DeviceActor(val deviceName: String,
 
     case SendImage(remoteId, path) =>
       whenConversationExists(remoteId) { conv =>
-        conv.sendMessage(new Image(ui.images.createImageAssetFrom(IoUtils.toByteArray(new FileInputStream(path)))))
+        zmessaging.convsUi.sendMessage(conv.id, ui.images.createImageAssetFrom(IoUtils.toByteArray(new FileInputStream(path))))
         Successful
       }
 
     case SendImageData(remoteId, bytes) =>
       whenConversationExistsFuture(remoteId) { conv =>
-        zmessaging.convsUi.sendMessage(conv.id, new Image(ui.images.createImageAssetFrom(bytes))).map { _ =>
+        zmessaging.convsUi.sendMessage(conv.id, ui.images.createImageAssetFrom(bytes)).map { _ =>
           Successful
         }
       }
@@ -330,9 +329,11 @@ class DeviceActor(val deviceName: String,
     case SendAsset(remoteId, bytes, mime, name, delay) =>
       whenConversationExistsFuture(remoteId) { conv =>
         delayNextAssetPosting.set(delay)
-        zmessaging.convsUi.sendMessage(conv.id, new MessageContent.Asset(impl.AssetForUpload(AssetId(), Some(name), Mime(mime), Some(bytes.length.toLong)) {
+        val asset = impl.AssetForUpload(AssetId(), Some(name), Mime(mime), Some(bytes.length.toLong)){
           _ => new ByteArrayInputStream(bytes)
-        }, DoNothingAndProceed)).map(_.fold2(Failed("no message sent"), m => Successful(m.id.str)))
+        }
+
+        zmessaging.convsUi.sendMessage(conv.id, asset, DoNothingAndProceed).map(_.fold2(Failed("no message sent"), m => Successful(m.id.str)))
       }
 
     case SendLocation(remoteId, lon, lat, name, zoom) =>
@@ -355,13 +356,13 @@ class DeviceActor(val deviceName: String,
         zmessaging.cache.addStream(CacheKey(assetId.str), new FileInputStream(file), Mime(mime)).map { cacheEntry =>
           Mime(mime) match {
             case Mime.Image() =>
-              zmessaging.convsUi.sendMessage(conv.id, new Image(api.ui.images.createImageAssetFrom(IoUtils.toByteArray(cacheEntry.inputStream))))
+              zmessaging.convsUi.sendMessage(conv.id, api.ui.images.createImageAssetFrom(IoUtils.toByteArray(cacheEntry.inputStream)))
               Successful
             case _ =>
               val asset = impl.AssetForUpload(assetId, Some(file.getName), Mime(mime), Some(file.length())) {
                 _ => new FileInputStream(file)
               }
-              zmessaging.convsUi.sendMessage(conv.id, new MessageContent.Asset(asset, DoNothingAndProceed))
+              zmessaging.convsUi.sendMessage(conv.id, asset, DoNothingAndProceed)
               Successful
           }
         }

--- a/tests/integration/src/test/scala/com/waz/connections/ConnectionSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/connections/ConnectionSpec.scala
@@ -18,7 +18,6 @@
 package com.waz.connections
 
 import akka.pattern.ask
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.model.ConversationData.{ConversationDataDao, ConversationType}
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
@@ -102,7 +101,7 @@ class ConnectionSpec extends FeatureSpec with Matchers with ProvisionedApiSpec w
         conv.getName shouldEqual "auto2 user"
       }
 
-      conv.sendMessage(new Text("first msg"))
+      zmessaging.convsUi.sendMessage(conv.id,"first msg")
       withDelay {
         lastMessage(conv.id).map(_.contentString) shouldEqual Some("first msg")
       }

--- a/tests/integration/src/test/scala/com/waz/conv/AddMemberToGroupConvSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/conv/AddMemberToGroupConvSpec.scala
@@ -19,8 +19,8 @@ package com.waz.conv
 
 import akka.pattern.ask
 import com.waz.api.IConversation.Type._
-import com.waz.api.MessageContent.Text
 import com.waz.api._
+import com.waz.model.UserId
 import com.waz.provision.ActorMessage._
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
@@ -62,7 +62,7 @@ class AddMemberToGroupConvSpec extends FeatureSpec with Matchers with OptionValu
     }
 
     auto2 ? SendText(groupConv.data.remoteId, "Hey evrywun!")
-    groupConv.sendMessage(new Text("Wassup?!", Array.empty[User]))
+    zmessaging.convsUi.sendMessage(groupConv.id, "first msg", Set.empty[UserId])
     auto3 ? SendText(groupConv.data.remoteId, "Sky.")
 
     soon {

--- a/tests/integration/src/test/scala/com/waz/messages/AssetReceivingSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AssetReceivingSpec.scala
@@ -19,7 +19,6 @@ package com.waz.messages
 
 import akka.pattern.ask
 import com.waz.api.Asset.LoadCallback
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.model.{AssetStatus => _, MessageContent => _, _}
 import com.waz.provision.ActorMessage._
@@ -129,8 +128,8 @@ class AssetReceivingSpec extends FeatureSpec with Matchers with BeforeAndAfter w
         asset.getStatus shouldEqual AssetStatus.UPLOAD_IN_PROGRESS
       }
 
-      conv.sendMessage(new Text("txt message 1"))
-      conv.sendMessage(new Text("txt message 2"))
+      zmessaging.convsUi.sendMessage(conv.id, "txt message 1")
+      zmessaging.convsUi.sendMessage(conv.id, "txt message 2")
 
       within(20.seconds)(asset.getStatus shouldEqual AssetStatus.UPLOAD_DONE)
 

--- a/tests/integration/src/test/scala/com/waz/messages/AudioMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/AudioMessageSpec.scala
@@ -48,7 +48,7 @@ class AudioMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
     auto2 ? Login(provisionedEmail("auto2"), "auto2_pass") should eventually(be(Successful))
     auto2 ? AwaitSyncCompleted should eventually(be(Successful))
     (messages should have size 1).soon
-    conv.sendMessage(new MessageContent.Text("meep"))
+    zmessaging.convsUi.sendMessage(conv.id, "meep")
     (messages should have size 2).soon
   }
 
@@ -58,7 +58,7 @@ class AudioMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
       val audio = audioForUpload
       isAudioMessageFromTest += audio.cacheKey
 
-      conv.sendMessage(new MessageContent.Asset(audio, DoNothingAndProceed))
+      zmessaging.convsUi.sendMessage(conv.id, audio, DoNothingAndProceed)
 
       within(1.second)(messages should have size (fromBefore + 1))
 

--- a/tests/integration/src/test/scala/com/waz/messages/DeleteMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/DeleteMessageSpec.scala
@@ -18,7 +18,6 @@
 package com.waz.messages
 
 import akka.pattern.ask
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.model.MessageData
 import com.waz.provision.ActorMessage._
@@ -92,7 +91,7 @@ class DeleteMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll
     }
 
     scenario("Send new text message") {
-      conv.sendMessage(new Text("test msg to recall"))
+      zmessaging.convsUi.sendMessage(conv.id, "test msg to recall")
       withDelay {
         msgs should have size 2
         msgs.last.state shouldEqual Message.Status.SENT
@@ -107,7 +106,7 @@ class DeleteMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll
     }
 
     scenario("Send another message") {
-      conv.sendMessage(new Text("second recall"))
+      zmessaging.convsUi.sendMessage(conv.id, "second recall")
       withDelay {
         msgs should have size 2
         msgs.last.state shouldEqual Message.Status.SENT
@@ -133,7 +132,7 @@ class DeleteMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll
     }
 
     scenario("Send and recall link message") {
-      conv.sendMessage(new Text("http://wire.com"))
+      zmessaging.convsUi.sendMessage(conv.id, "http://wire.com")
       withDelay { msgs should have size 3 }
       val msg = msgs.last
       zmessaging.convsUi.recallMessage(conv.id, msgs.last.id)

--- a/tests/integration/src/test/scala/com/waz/messages/DeliveryReceiptsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/DeliveryReceiptsSpec.scala
@@ -21,7 +21,6 @@ import akka.pattern.ask
 import com.waz.ZLog._
 import com.waz.api.IConversation.Type.{GROUP, ONE_TO_ONE}
 import com.waz.api.Message.Status.{DELIVERED, SENT}
-import com.waz.api.MessageContent._
 import com.waz.api._
 import com.waz.model.UserId
 import com.waz.provision.ActorMessage._
@@ -64,14 +63,14 @@ class DeliveryReceiptsSpec extends FeatureSpec with Matchers with BeforeAndAfter
 
   feature("Delivery receipts") {
     scenario("Receipt in 1-on-1 conv") {
-      friend1Conv.sendMessage(new Text("meep"))
+      zmessaging.convsUi.sendMessage(friend1Conv.id, "meep")
       (listMessages(friend1Conv.id) should have size 2).soon
       (lastMessage(friend1Conv.id).get.state shouldEqual SENT).soon
       (lastMessage(friend1Conv.id).get.state shouldEqual DELIVERED).soon
     }
 
     scenario("No receipt in group conv") {
-      groupConv.sendMessage(new Text("moop"))
+      zmessaging.convsUi.sendMessage(groupConv.id, "moop")
       (listMessages(groupConv.id) should have size 2).soon
       (lastMessage(groupConv.id).get.state shouldEqual SENT).soon
       forAsLongAs(3.seconds)(lastMessage(groupConv.id).get.state shouldEqual SENT)

--- a/tests/integration/src/test/scala/com/waz/messages/EditMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/EditMessageSpec.scala
@@ -20,7 +20,6 @@ package com.waz.messages
 import akka.pattern.ask
 import android.net.Uri
 import com.waz.api.Message.Part
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.provision.ActorMessage._
 import com.waz.testutils.Implicits._
@@ -55,7 +54,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
   feature("Edit text messages") {
 
     scenario("Send text message and edit it") {
-      conv.sendMessage(new Text("test msg to edit"))
+      zmessaging.convsUi.sendMessage(conv.id, "test msg to edit")
       withDelay {
         msgs should have size 2
         msgs.last.state shouldEqual Message.Status.SENT
@@ -63,7 +62,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
       val msg = msgs.last
 
-      zmessaging.convsUi.updateMessage(conv.id, msg.id, new Text("edited message"))
+      zmessaging.convsUi.updateMessage(conv.id, msg.id, "edited message")
 
       withDelay {
         msgs should have size 2
@@ -80,8 +79,8 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
       val service = zmessaging.convsUi
       val lock = zmessaging.syncRequests.scheduler.queue.acquire(conv.id).await() // block sync service
 
-      val m = service.sendMessage(conv.id, new Text("test msg to edit")).await().get
-      val m1 = service.updateMessage(conv.id, m.id, new Text("updated")).await()
+      val m = service.sendMessage(conv.id, "test msg to edit").await().get
+      val m1 = service.updateMessage(conv.id, m.id, "updated").await()
 
       withDelay { msgs should have size 3 }
 
@@ -107,7 +106,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
     scenario("Send emoji only message and edit it") {
       val count = msgs.size
-      conv.sendMessage(new Text("\u263A"))
+      zmessaging.convsUi.sendMessage(conv.id, "\u263A")
       withDelay {
         msgs should have size (count + 1)
         msgs.last.msgType shouldEqual Message.Type.TEXT_EMOJI_ONLY
@@ -116,7 +115,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
       val msg = msgs.last
 
-      zmessaging.convsUi.updateMessage(conv.id, msg.id, new Text("\u263B"))
+      zmessaging.convsUi.updateMessage(conv.id, msg.id, "\u263B")
 
       withDelay {
         msgs should have size (count + 1)
@@ -140,7 +139,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
       val msg = msgs.last
 
-      conv.sendMessage(new Text("test"))
+      zmessaging.convsUi.sendMessage(conv.id, "test")
 
       withDelay(msgs should have size (count + 2))
 
@@ -166,7 +165,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
       val msg = msgs.last
       secondClient ? UpdateText(msg.id, "updated on remote") //should eventually(be(Successful))
-      zmessaging.convsUi.updateMessage(conv.id, msg.id, new Text("updated locally"))
+      zmessaging.convsUi.updateMessage(conv.id, msg.id, "updated locally")
 
       withDelay {
         getMessage(msg.id) shouldBe 'empty
@@ -186,7 +185,8 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
   feature("Edit link message") {
     scenario("Send link with text and edit it") {
       val count = msgs.size
-      conv.sendMessage(new Text("test wire.com edit"))
+      zmessaging.convsUi.sendMessage(conv.id, "test wire.com edit")
+
       withDelay {
         msgs should have size (count + 1)
         msgs.last.state shouldEqual Message.Status.SENT
@@ -195,7 +195,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
       }
 
       val msg = msgs.last
-      zmessaging.convsUi.updateMessage(conv.id, msg.id, new Text("edited message facebook.com"))
+      zmessaging.convsUi.updateMessage(conv.id, msg.id, "edited message facebook.com")
 
       withDelay {
         msgs should have size (count + 1)
@@ -221,7 +221,7 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
 
       val msg = msgs.last
 
-      conv.sendMessage(new Text("test"))
+      zmessaging.convsUi.sendMessage(conv.id, "test")
 
       withDelay(msgs should have size (count + 2))
 
@@ -251,9 +251,9 @@ class EditMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
       otherUserClient ? SendText(conv.data.remoteId, "other 3") should eventually(be(Successful))
       otherUserClient ? SendText(conv.data.remoteId, "other 4") should eventually(be(Successful))
 
-      conv.sendMessage(new Text("self 1"))
-      conv.sendMessage(new Text("self 2"))
-      conv.sendMessage(new Text("self 3"))
+      zmessaging.convsUi.sendMessage(conv.id, "self 1")
+      zmessaging.convsUi.sendMessage(conv.id, "self 2")
+      zmessaging.convsUi.sendMessage(conv.id, "self 3")
 
       withDelay {
         msgs should have size (count + 7)

--- a/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/ImageAssetMessageSpec.scala
@@ -20,7 +20,6 @@ package com.waz.messages
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.pattern.ask
-import com.waz.api.MessageContent.Image
 import com.waz.api._
 import com.waz.api.impl.LocalImageAsset
 import com.waz.cache.CacheEntry
@@ -58,7 +57,7 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
   }
 
   scenario("Post text in new conv") {
-    conv.sendMessage(new MessageContent.Text("first msg"))
+    zmessaging.convsUi.sendMessage(conv.id, "first msg")
     withDelay {
       messages.last.msgType shouldEqual Message.Type.TEXT
       messages.last.state shouldEqual Message.Status.SENT
@@ -67,7 +66,7 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
 
   scenario("Post image asset followed by text") {
     val asset = ImageAssetFactory.getImageAsset(IoUtils.toByteArray(getClass.getResourceAsStream("/images/big.png")))
-    conv.sendMessage(new MessageContent.Image(asset))
+    zmessaging.convsUi.sendMessage(conv.id, asset)
 
     withDelay {
       messages.last.msgType shouldEqual Message.Type.ASSET
@@ -75,7 +74,7 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
     }
     val assetMsg = messages.last
 
-    conv.sendMessage(new MessageContent.Text("test message"))
+    zmessaging.convsUi.sendMessage(conv.id, "test message")
 
     withDelay {
       assetMsg.state shouldEqual Message.Status.SENT
@@ -91,7 +90,8 @@ class ImageAssetMessageSpec extends FeatureSpec with Matchers with ProvisionedAp
 
     (messages should have size 1).soon
     downloads.set(0)
-    conv.sendMessage(new Image(imageFromGiphy))
+
+    zmessaging.convsUi.sendMessage(conv.id, imageFromGiphy)
     (messages should have size 2).soon
 
     val postedImage = new com.waz.api.impl.ImageAsset(messages(1).assetId)

--- a/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/LastReadSpec.scala
@@ -20,7 +20,6 @@ package com.waz.messages
 import java.util.Date
 
 import akka.pattern.ask
-import com.waz.api.MessageContent._
 import com.waz.api._
 import com.waz.api.impl.ErrorResponse
 import com.waz.model.GenericContent.LastRead
@@ -124,7 +123,7 @@ class LastReadSpec extends FeatureSpec with Matchers with BeforeAndAfterAll with
     val fromBefore = msgs.size
 
     for (i <- 0 until 5) {
-      conv.sendMessage(new Text(s"own mesage: $i"))
+      zmessaging.convsUi.sendMessage(conv.id, s"own mesage: $i")
     }
 
     withDelay {

--- a/tests/integration/src/test/scala/com/waz/messages/LocationMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/LocationMessageSpec.scala
@@ -53,7 +53,7 @@ class LocationMessageSpec extends FeatureSpec with Matchers with BeforeAndAfterA
 
     scenario("Send location message") {
       val loc = new MessageContent.Location(-10.45f, 23.43f, "location name", 10)
-      conv.sendMessage(loc)
+      zmessaging.convsUi.sendMessage(conv.id, loc)
       withDelay {
         msgs should have size 2
         msgs.last.msgType shouldEqual Message.Type.LOCATION

--- a/tests/integration/src/test/scala/com/waz/messages/MessageReactionsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/MessageReactionsSpec.scala
@@ -21,7 +21,6 @@ import akka.pattern.ask
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.api.IConversation.Type.GROUP
-import com.waz.api.MessageContent._
 import com.waz.api._
 import com.waz.model.Liking.Action._
 import com.waz.model._
@@ -119,7 +118,7 @@ class MessageReactionsSpec extends FeatureSpec with Matchers with BeforeAndAfter
     otherUserDoes(Like, message, conv)
     (message should (beLiked and not(beLikedByThisUser) and haveLikesFrom(otherUser))).soon
 
-    message.update(new Text("woo"))
+    message.update("woo")
     soon {
       val editedMessage = msgs(n)
       editedMessage should (not(beLiked) and not(beLikedByThisUser) and notHaveLikes)
@@ -165,7 +164,7 @@ class MessageReactionsSpec extends FeatureSpec with Matchers with BeforeAndAfter
   def addMessage(text: String, c: IConversation): (Int, MessageData) = {
     def m = listMessages(c.id)
     val n = m.size
-    c.sendMessage(new Text(text))
+    zmessaging.convsUi.sendMessage(conv.id, text)
     (m should have size (n + 1)).soon
     (n, m(n))
   }

--- a/tests/integration/src/test/scala/com/waz/messages/RichMediaSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/RichMediaSpec.scala
@@ -22,10 +22,8 @@ import java.util
 import akka.pattern.ask
 import com.waz.api.MediaAsset.StreamingCallback
 import com.waz.api.Message.Part
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.provision.ActorMessage.{AwaitSyncCompleted, Login, SendText, Successful}
-import com.waz.testutils.BitmapSpy
 import com.waz.testutils.Implicits._
 import com.waz.testutils.Matchers._
 import com.waz.utils.returning
@@ -69,8 +67,7 @@ class RichMediaSpec extends FeatureSpec with Matchers with EitherValues with Bef
 
     scenario("Send message with single web link") {
       val count = msgs.size
-
-      conv.sendMessage(new Text("http://www.wire.com"))
+      zmessaging.convsUi.sendMessage(conv.id, "http://www.wire.com")
 
       withDelay {
         msgs should have size (count + 1)
@@ -86,7 +83,7 @@ class RichMediaSpec extends FeatureSpec with Matchers with EitherValues with Bef
     scenario("Send message with facebook link") {
       val count = msgs.size
 
-      conv.sendMessage(new Text("Http://Facebook.com"))
+      zmessaging.convsUi.sendMessage(conv.id, "Http://Facebook.com")
 
       withDelay {
         msgs should have size (count + 1)
@@ -101,8 +98,7 @@ class RichMediaSpec extends FeatureSpec with Matchers with EitherValues with Bef
 
     scenario("Send message with text and link") {
       val count = msgs.size
-
-      conv.sendMessage(new Text("test http://www.github.com"))
+      zmessaging.convsUi.sendMessage(conv.id, "test http://www.github.com")
 
       withDelay {
         msgs should have size (count + 1)

--- a/tests/integration/src/test/scala/com/waz/messages/VideoMessageSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/messages/VideoMessageSpec.scala
@@ -49,7 +49,7 @@ class VideoMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
     auto2 ? Login(provisionedEmail("auto2"), "auto2_pass") should eventually(be(Successful))
     auto2 ? AwaitSyncCompleted should eventually(be(Successful))
     (messages should have size 1).soon
-    conv.sendMessage(new MessageContent.Text("meep"))
+    zmessaging.convsUi.sendMessage(conv.id, "meep")
     (messages should have size 2).soon
   }
 
@@ -58,8 +58,7 @@ class VideoMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
       val fromBefore = messages.size
       val video = videoForUpload
       isDownloadingFromProvider += video.cacheKey
-
-      conv.sendMessage(new MessageContent.Asset(video, DoNothingAndProceed))
+      zmessaging.convsUi.sendMessage(conv.id, video, DoNothingAndProceed)
 
       within(1.second)(messages should have size (fromBefore + 1))
 
@@ -102,7 +101,7 @@ class VideoMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
       lazy val asset = new com.waz.api.impl.Asset(msg.assetId, msg.id)
 
       reusableLatch.ofSize(1) { latch =>
-        conv.sendMessage(new MessageContent.Asset(video, DoNothingAndProceed))
+        zmessaging.convsUi.sendMessage(conv.id, video, DoNothingAndProceed)
         within(1.second)(messages should have size (fromBefore + 1))
 
         soon {
@@ -129,7 +128,7 @@ class VideoMessageSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
       lazy val asset = new com.waz.api.impl.Asset(msg.assetId, msg.id)
 
       reusableLatch.ofSize(1) { latch =>
-        conv.sendMessage(new MessageContent.Asset(video, DoNothingAndProceed))
+        zmessaging.convsUi.sendMessage(conv.id, video, DoNothingAndProceed)
         within(1.second)(messages should have size (fromBefore + 1))
 
         soon {

--- a/tests/integration/src/test/scala/com/waz/service/RemoteZmsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/RemoteZmsSpec.scala
@@ -75,8 +75,6 @@ class RemoteZms(ui: UiModule) extends ZMessagingApi()(ui) {
     case None => Future.successful(Vector.empty[MessageData])
   }, 5.seconds)
 
-
-  def postMessage(conv: RConvId, msg: MessageContent) = findConv(conv).map { _.sendMessage(msg) }
 }
 
 trait RemoteZmsSpec extends RobolectricTests with BeforeAndAfterAll { suite: Suite with ApiSpec =>

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrIntegrationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrIntegrationSpec.scala
@@ -20,7 +20,6 @@ package com.waz.service.otr
 import akka.pattern.ask
 import android.graphics.{Bitmap, BitmapFactory}
 import com.waz.api.Message.Status
-import com.waz.api.MessageContent.Image
 import com.waz.api.OtrClient.DeleteCallback
 import com.waz.api._
 import com.waz.model.AssetId
@@ -113,7 +112,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
     scenario("Send otr message") {
       withDelay(msgs should have size 1)
 
-      conv.sendMessage(new MessageContent.Text("Test message"))
+      zmessaging.convsUi.sendMessage(conv.id, "Test message")
 
       withDelay {
         msgs should have size 2
@@ -126,7 +125,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
       withDelay(msgs should have size 2)
 
       for (i <- 0 until 15) {
-        conv.sendMessage(new MessageContent.Text(s"ordered message $i"))
+        zmessaging.convsUi.sendMessage(conv.id, s"ordered message $i")
         awaitUi(1.millis)
       }
 
@@ -210,7 +209,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
     scenario("Send image asset") {
       val count = msgs.size
       val bmp = BitmapFactory.decodeStream(getClass.getResourceAsStream("/images/penguin.png"))
-      conv.sendMessage(new Image(ImageAssetFactory.getImageAsset(bmp)))
+      zmessaging.convsUi.sendMessage(conv.id, ImageAssetFactory.getImageAsset(bmp))
 
       withDelay {
         msgs should have size (count + 1)
@@ -282,7 +281,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
     }
 
     scenario("Send message") {
-      conv.sendMessage(new MessageContent.Text("Test message 4"))
+      zmessaging.convsUi.sendMessage(conv.id, "Test message 4")
       withDelay {
         val last = msgs.last
         last.contentString shouldEqual "Test message 4"
@@ -412,7 +411,7 @@ class OtrIntegrationSpec extends FeatureSpec with Matchers with BeforeAndAfterAl
     scenario("Send image asset2") {
       val count = msgs.size
       val bmp = BitmapFactory.decodeStream(getClass.getResourceAsStream("/images/penguin.png"))
-      conv.sendMessage(new Image(ImageAssetFactory.getImageAsset(bmp)))
+      zmessaging.convsUi.sendMessage(conv.id, ImageAssetFactory.getImageAsset(bmp))
 
       withDelay {
         msgs should have size (count + 1)

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrLostSessionRecoverySpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrLostSessionRecoverySpec.scala
@@ -20,7 +20,7 @@ package com.waz.service.otr
 import java.io.File
 
 import akka.pattern.ask
-import com.waz.api.{Message, MessageContent, ProvisionedApiSpec, ThreadActorSpec}
+import com.waz.api.{Message, ProvisionedApiSpec, ThreadActorSpec}
 import com.waz.model.RConvId
 import com.waz.provision.ActorMessage.{Login, SendText, Successful}
 import com.waz.testutils.Implicits._
@@ -60,7 +60,7 @@ class OtrLostSessionRecoverySpec extends FeatureSpec with Matchers with BeforeAn
       zmessaging.otrClientsService.getSelfClient should eventually(be('defined))
     }
 
-    conv.sendMessage(new MessageContent.Text("Test message"))
+    zmessaging.convsUi.sendMessage(conv.id,"Test message")
 
     conv.getId shouldEqual provisionedUserId("auto2").str
     auto2 ? SendText(RConvId(provisionedUserId("auto1").str), "Test message 1") should eventually(be(Successful))
@@ -72,7 +72,7 @@ class OtrLostSessionRecoverySpec extends FeatureSpec with Matchers with BeforeAn
       }
     }
 
-    conv.sendMessage(new MessageContent.Text("Test message 2"))
+    zmessaging.convsUi.sendMessage(conv.id, "Test message 2")
     auto2 ? SendText(RConvId(provisionedUserId("auto1").str), "Test message 3") should eventually(be(Successful))
 
     withDelay {
@@ -89,7 +89,7 @@ class OtrLostSessionRecoverySpec extends FeatureSpec with Matchers with BeforeAn
     zmessaging.otrService.sessions.deleteSession(session.getName).futureValue
     session.exists() shouldEqual false
 
-    conv.sendMessage(new MessageContent.Text("Test message 4"))
+    zmessaging.convsUi.sendMessage(conv.id, "Test message 4")
 
     withDelay {
       session.exists() shouldEqual true // session should be recreated

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrMultipleClientsSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrMultipleClientsSpec.scala
@@ -17,7 +17,6 @@
  */
 package com.waz.service.otr
 
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.service.RemoteZmsSpec
 import com.waz.testutils.Implicits._
@@ -70,7 +69,7 @@ class OtrMultipleClientsSpec extends FeatureSpec with Matchers with OptionValues
         msgs should have size 1
       }
 
-      auto1_1.findConv(conv.data.remoteId) map { _.sendMessage(new Text("self message 1")) }
+      auto1_1.findConv(conv.data.remoteId) map { conv => zmessaging.convsUi.sendMessage(conv.id, "self message 1") }
 
       withDelay {
         msgs should have size 2
@@ -103,7 +102,7 @@ class OtrMultipleClientsSpec extends FeatureSpec with Matchers with OptionValues
     scenario("send message to remote client") {
       val count = msgs.size
 
-      conv.sendMessage(new Text("test message 1"))
+      zmessaging.convsUi.sendMessage(conv.id, "test message 1")
 
       withDelay {
         msgs should have size (count + 1)
@@ -114,7 +113,7 @@ class OtrMultipleClientsSpec extends FeatureSpec with Matchers with OptionValues
     scenario("receive message from remote client") {
       val count = msgs.size
 
-      auto2.findConv(conv.data.remoteId) map { _.sendMessage(new Text("remote message 1")) }
+      auto1_1.findConv(conv.data.remoteId) map { conv => zmessaging.convsUi.sendMessage(conv.id, "remote message 1") }
 
       withDelay {
         msgs should have size (count + 1)

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrRecoverySpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrRecoverySpec.scala
@@ -19,7 +19,6 @@ package com.waz.service.otr
 
 import java.io.{ByteArrayInputStream, File}
 
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.service.RemoteZmsSpec
 import com.waz.testutils.Implicits._
@@ -60,10 +59,12 @@ class OtrRecoverySpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
         zmessaging.otrClientsService.getSelfClient should eventually(be('defined))
       }
 
-      conv.sendMessage(new MessageContent.Text("Test message"))
+      zmessaging.convsUi.sendMessage(conv.id, "Test message")
 
       conv.getId shouldEqual provisionedUserId("auto2").str
-      awaitUiFuture(auto2.findConv(conv.data.remoteId).map(_.sendMessage(new Text("Test message 1"))))
+      awaitUiFuture(auto2.findConv(conv.data.remoteId).map { c =>
+        zmessaging.convsUi.sendMessage(c.id, "Test message 1")
+      })
 
       withDelay {
         msgs.map(_.contentString) should contain allOf("Test message", "Test message 1")
@@ -135,7 +136,7 @@ class OtrRecoverySpec extends FeatureSpec with Matchers with BeforeAndAfterAll w
       val conv2 = awaitUiFuture(auto2_1.findConv(conv.data.remoteId)).get
       def msgs2 = listMessages(conv2.id)
 
-      conv.sendMessage(new MessageContent.Text("Test message 2"))
+      zmessaging.convsUi.sendMessage(conv.id, "Test message 2")
 
       withDelay {
         auto2Clients should have size 2 // login with broken cryptobox created new device

--- a/tests/integration/src/test/scala/com/waz/service/otr/OtrVerificationSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/service/otr/OtrVerificationSpec.scala
@@ -18,7 +18,6 @@
 package com.waz.service.otr
 
 import akka.pattern._
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.model.ConversationData.ConversationType
 import com.waz.provision.ActorMessage.{Login, SendText, Successful}
@@ -90,7 +89,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
 
     scenario("Send message in unverified conv") {
       conv.getVerified shouldEqual Verification.UNKNOWN
-      conv.sendMessage(new Text("test msg"))
+      zmessaging.convsUi.sendMessage(conv.id, "test msg")
       withDelay {
         msgs.last.contentString shouldEqual "test msg"
         msgs.last.state shouldEqual Message.Status.SENT
@@ -109,7 +108,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
     }
 
     scenario("Send message in verified conv") {
-      conv.sendMessage(new Text("test msg 1"))
+      zmessaging.convsUi.sendMessage(conv.id, "test msg 1")
       withDelay {
         msgs.last.contentString shouldEqual "test msg 1"
         msgs.last.state shouldEqual Message.Status.SENT
@@ -142,7 +141,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
 
     scenario("Sending a message in unverified conv fails") {
       conv.getVerified shouldEqual Verification.UNVERIFIED
-      conv.sendMessage(new Text("failing msg 1"))
+      zmessaging.convsUi.sendMessage(conv.id, "failing msg 1")
       withDelay {
         msgs.last.contentString shouldEqual "failing msg 1"
         msgs.last.state shouldEqual Message.Status.FAILED
@@ -178,7 +177,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
     }
 
     scenario("Send message in verified conv") {
-      conv.sendMessage(new Text("test msg 1"))
+      zmessaging.convsUi.sendMessage(conv.id, "test msg 1")
       withDelay {
         msgs.last.contentString shouldEqual "test msg 1"
         msgs.last.state shouldEqual Message.Status.SENT
@@ -193,7 +192,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
     scenario("Sending to conv with new client fails and conv gets unverified") {
       val count = msgs.size
       conv.getVerified shouldEqual Verification.VERIFIED
-      conv.sendMessage(new Text("failing msg 2"))
+      zmessaging.convsUi.sendMessage(conv.id, "failing msg 2")
       withDelay {
         conv.getVerified shouldEqual Verification.UNVERIFIED
         withClue(msgs.map(_.msgType).mkString(", ")) {
@@ -205,7 +204,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
     }
 
     scenario("Trying to send another message also fails") {
-      conv.sendMessage(new Text("failing msg 3"))
+      zmessaging.convsUi.sendMessage(conv.id, "failing msg 3")
       withDelay {
         msgs.last.contentString shouldEqual "failing msg 3"
         msgs.last.state shouldEqual Message.Status.FAILED
@@ -262,7 +261,7 @@ class OtrVerificationSpec extends FeatureSpec with Matchers with BeforeAndAfterA
       val count = msgs.size
       val errors = api.getErrors
       conv.getVerified shouldEqual Verification.VERIFIED
-      conv.sendMessage(new Text("failing msg 4"))
+      zmessaging.convsUi.sendMessage(conv.id, "failing msg 4")
       withDelay {
         conv.getVerified shouldEqual Verification.UNVERIFIED
         withClue(msgs.map(_.msgType).mkString(", ")) {

--- a/tests/integration/src/test/scala/com/waz/users/BlockingSpec.scala
+++ b/tests/integration/src/test/scala/com/waz/users/BlockingSpec.scala
@@ -18,7 +18,7 @@
 package com.waz.users
 
 import akka.pattern.ask
-import com.waz.api.{UpdateListener, _}
+import com.waz.api._
 import com.waz.model.ConversationData.ConversationDataDao
 import com.waz.model.MessageData.MessageDataDao
 import com.waz.model.UserData.ConnectionStatus

--- a/tests/mocked/src/test/scala/com/waz/mocked/messages/ClearConversationSpec.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/messages/ClearConversationSpec.scala
@@ -33,6 +33,7 @@ import com.waz.utils._
 import com.waz.znet.ZNetClient.ErrorOrResponse
 import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Inside, Matchers}
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ClearConversationSpec extends FeatureSpec with Matchers with Inside with BeforeAndAfterAll with MockedClientApiSpec with MockBackend with RobolectricUtils {
@@ -201,7 +202,7 @@ class ClearConversationSpec extends FeatureSpec with Matchers with Inside with B
       withDelay(listMessages(conv.id) should have size 11)
 
       latch.ofSize(1) { l =>
-        (1 to 5).foreach(i => conv.sendMessage(new com.waz.api.MessageContent.Text(s"meep: $i")))
+        (1 to 5).foreach(i => zmessaging.convsUi.sendMessage(conv.id, s"meep: $i"))
         awaitUi(1.second)
         conv.clear()
         awaitUi(1.second)

--- a/tests/mocked/src/test/scala/com/waz/mocked/messages/PostMessageSpec.scala
+++ b/tests/mocked/src/test/scala/com/waz/mocked/messages/PostMessageSpec.scala
@@ -18,7 +18,6 @@
 package com.waz.mocked.messages
 
 import com.waz.RobolectricUtils
-import com.waz.api.MessageContent.Text
 import com.waz.api._
 import com.waz.api.impl.ErrorResponse
 import com.waz.mocked.{MockBackend, SystemTimeline}
@@ -77,7 +76,7 @@ class PostMessageSpec extends FeatureSpec with Matchers with Inside with BeforeA
 
     scenario("Retry when post fails with server error") {
       postMessageResponse = serverError
-      conv.sendMessage(new Text("test"))
+      zmessaging.convsUi.sendMessage(conv.id, "test")
 
       withDelay { listMessages(conv.id) should have size 9 }
 
@@ -100,7 +99,7 @@ class PostMessageSpec extends FeatureSpec with Matchers with Inside with BeforeA
     scenario("Mark message failed after sending timeout") {
       sendingTimeout = 5.seconds
       postMessageResponse = serverError
-      conv.sendMessage(new Text("test 1"))
+      zmessaging.convsUi.sendMessage(conv.id, "test 1")
 
       withDelay { listMessages(conv.id) should have size 10 }
 
@@ -120,7 +119,7 @@ class PostMessageSpec extends FeatureSpec with Matchers with Inside with BeforeA
       val inputState = conv.getInputStateIndicator
       inputState.textChanged()
       awaitUi(1.second)
-      conv.sendMessage(new Text("test 2"))
+      zmessaging.convsUi.sendMessage(conv.id, "test 2")
       inputState.textCleared()
 
       withDelay { listMessages(conv.id) should have size 11 }

--- a/tests/unit/src/test/scala/com/waz/service/conversation/TypingSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/conversation/TypingSpec.scala
@@ -22,7 +22,7 @@ import java.util.Date
 import com.waz._
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model._
-import com.waz.service.{StorageModule, Timeouts, ZmsLifecycle}
+import com.waz.service.{StorageModule, Timeouts, ZmsLifecycle, ZmsLifecycleImpl}
 import com.waz.testutils.EmptySyncService
 import com.waz.testutils.Matchers._
 import com.waz.utils.events.EventContext
@@ -47,7 +47,7 @@ class TypingSpec extends FeatureSpec with Matchers with BeforeAndAfter with Robo
     convsStorage.insert(conv)
   }
 
-  lazy val lifecycle = new ZmsLifecycle {
+  lazy val lifecycle: ZmsLifecycle = new ZmsLifecycleImpl {
     setLoggedIn(true)
     acquireUi()
   }

--- a/tests/unit/src/test/scala/com/waz/service/push/WebSocketClientServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/push/WebSocketClientServiceSpec.scala
@@ -43,7 +43,7 @@ class WebSocketClientServiceSpec extends FeatureSpec with Matchers with Robolect
     }
   }
 
-  lazy val lifecycle = new ZmsLifecycle
+  lazy val lifecycle: ZmsLifecycle = new ZmsLifecycleImpl
   lazy val network = new DefaultNetworkModeService(context, lifecycle)
   lazy val prefs = GlobalPreferences(context)
   lazy val meta = new MetaDataService(context)

--- a/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
+++ b/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
@@ -45,7 +45,6 @@ import net.hockeyapp.android.Constants
 import org.scalatest._
 import org.scalatest.enablers.{Containing, Emptiness, Length}
 import com.waz.ZLog.ImplicitTag._
-import com.waz.api.MessageContent.Text
 import com.waz.content.Likes
 import com.waz.model.MessageData.MessageDataDao
 import org.threeten.bp.Instant
@@ -148,7 +147,7 @@ trait ApiSpec extends BeforeAndAfterEach with BeforeAndAfterAll with Matchers wi
   implicit class RichMessage(msg: MessageData) {
     def like() = zmessaging.reactions.like(msg.convId, msg.id)
     def unlike() = zmessaging.reactions.unlike(msg.convId, msg.id)
-    def update(text: Text) = zmessaging.convsUi.updateMessage(msg.convId, msg.id, text)
+    def update(text: String) = zmessaging.convsUi.updateMessage(msg.convId, msg.id, text)
   }
 
   def netClient = zmessaging.zNetClient

--- a/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ConversationsList.scala
@@ -17,8 +17,6 @@
  */
 package com.waz.api.impl
 
-import java.lang.Iterable
-
 import android.net.Uri
 import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
@@ -26,7 +24,7 @@ import com.waz.api
 import com.waz.api.ConversationsList.{ConversationCallback, VerificationStateCallback}
 import com.waz.api.impl.ConversationsListState.Data
 import com.waz.api.impl.conversation.{BaseConversationsList, SelfConversation}
-import com.waz.api.{IConversation, LoadHandle, User}
+import com.waz.api.{IConversation, LoadHandle}
 import com.waz.content.Uris
 import com.waz.content.Uris.{SelfConversationUri, SyncIndicatorUri}
 import com.waz.model.ConversationData.ConversationType

--- a/zmessaging/src/main/scala/com/waz/api/impl/Message.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/Message.scala
@@ -178,7 +178,7 @@ class Message(val id: MessageId, var data: MessageData, var likes: IndexedSeq[Us
 
   override def recall(): Unit = context.zms.flatMapFuture(_.convsUi.recallMessage(data.convId, id))
 
-  override def update(content: Text): Unit = context.zms.flatMapFuture(_.convsUi.updateMessage(data.convId, id, content))
+  override def update(text: Text): Unit = context.zms.flatMapFuture(_.convsUi.updateMessage(data.convId, id, text.getContent))
 
   override def equals(other: Any): Boolean = other match {
     case other: Message => id == other.id
@@ -299,7 +299,7 @@ object EmptyMessage extends com.waz.api.Message {
   override def recall(): Unit = ()
   override def getEditTime: Instant = MessageData.UnknownInstant
   override def isEdited: Boolean = false
-  override def update(content: Text): Unit = ()
+  override def update(text: Text): Unit = ()
   override def isEphemeral: Boolean = false
   override def isExpired: Boolean = false
   override def getEphemeralExpiration = EphemeralExpiration.NONE

--- a/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
@@ -116,13 +116,13 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 
   override def getVerified: Verification = data.verified
 
-  def setConversationName(name: String) = conversations.setName(id, name.trim)
+  def setConversationName(name: String) = ??? //conversations.setName(id, name.trim)
 
   override def addMembers(users: java.lang.Iterable[_ <: api.User]): Unit = conversations.addMembers(id, users.asScala.toList)
 
   override def removeMember(user: api.User): Unit = conversations.removeMember(id, user)
 
-  override def leave(): Unit = conversations.leave(id)
+  override def leave(): Unit = ??? //conversations.leave(id)
 
   override def getOtherParticipant: api.User = {
     if ((data ne ConversationData.Empty) && data.convType != ONE_TO_ONE && data.convType != WAIT_FOR_CONNECTION && data.convType != INCOMING_CONNECTION)
@@ -137,7 +137,7 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 
   override def getInputStateIndicator: InputStateIndicator = ui.cached(Uris.InputStateIndicatorUri(id), new InputStateIndicator(id))
 
-  override def clear(): Unit = conversations.clear(id)
+  override def clear(): Unit = ??? //conversations.clear(id)
 
   override def toString: String = s"Conversation($id, $name, $data)"
 

--- a/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
@@ -116,13 +116,13 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 
   override def getVerified: Verification = data.verified
 
-  def setConversationName(name: String) = ??? //conversations.setName(id, name.trim)
+  def setConversationName(name: String) = conversations.setName(id, name.trim)
 
   override def addMembers(users: java.lang.Iterable[_ <: api.User]): Unit = conversations.addMembers(id, users.asScala.toList)
 
   override def removeMember(user: api.User): Unit = conversations.removeMember(id, user)
 
-  override def leave(): Unit = ??? //conversations.leave(id)
+  override def leave(): Unit = conversations.leave(id)
 
   override def getOtherParticipant: api.User = {
     if ((data ne ConversationData.Empty) && data.convType != ONE_TO_ONE && data.convType != WAIT_FOR_CONNECTION && data.convType != INCOMING_CONNECTION)
@@ -137,7 +137,7 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 
   override def getInputStateIndicator: InputStateIndicator = ui.cached(Uris.InputStateIndicatorUri(id), new InputStateIndicator(id))
 
-  override def clear(): Unit = ??? //conversations.clear(id)
+  override def clear(): Unit = conversations.clear(id)
 
   override def toString: String = s"Conversation($id, $name, $data)"
 

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -93,6 +93,6 @@ class GlobalModule(val context: AContext, val backend: BackendConfig) { global =
 
   lazy val factory = new ZMessagingFactory(this)
 
-  val lifecycle = new ZmsLifecycle()
+  val lifecycle: ZmsLifecycle = new ZmsLifecycleImpl()
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -21,7 +21,6 @@ import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.MessageContent.Asset.ErrorHandler
-import com.waz.api.MessageContent.Text
 import com.waz.api.impl._
 import com.waz.api.{EphemeralExpiration, ImageAssetFactory, Message, NetworkMode}
 import com.waz.content._
@@ -36,6 +35,7 @@ import com.waz.sync.SyncServiceHandle
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.Locales.currentLocaleOrdering
 import com.waz.utils.events.EventStream
+import com.waz.utils.wrappers.URI
 import com.waz.utils.{RichInstant, _}
 import org.threeten.bp.Instant
 
@@ -43,10 +43,21 @@ import scala.collection.breakOut
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.higherKinds
+import scala.language.implicitConversions
 
 trait ConversationsUiService {
-  def sendMessage(convId: ConvId, content: api.MessageContent): Future[Option[MessageData]]
-  def updateMessage(convId: ConvId, id: MessageId, content: Text): Future[Option[MessageData]]
+  @Deprecated
+  def sendMessage(convId: ConvId, content: api.MessageContent): Future[Option[MessageData]] // TODO: remove when all calls are migrated to respective specialized methods
+
+  def sendMessage(convId: ConvId, uri: URI, errorHandler: ErrorHandler): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, audioAsset: AssetForUpload, errorHandler: ErrorHandler): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, text: String): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, text: String, mentions: Set[UserId]): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, jpegData: Array[Byte]): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, imageAsset: ImageAsset): Future[Option[MessageData]]
+  def sendMessage(convId: ConvId, location: api.MessageContent.Location): Future[Option[MessageData]]
+
+  def updateMessage(convId: ConvId, id: MessageId, text: String): Future[Option[MessageData]]
   def deleteMessage(convId: ConvId, id: MessageId): Future[Unit]
   def recallMessage(convId: ConvId, id: MessageId): Future[Option[MessageData]]
   def setConversationArchived(id: ConvId, archived: Boolean): Future[Option[ConversationData]]
@@ -92,139 +103,88 @@ class ConversationsUiServiceImpl( self:            UserId,
   override val assetUploadCancelled = EventStream[Mime]() //size, mime
   override val assetUploadFailed    = EventStream[ErrorResponse]()
 
-  override def sendMessage(convId: ConvId, content: api.MessageContent): Future[Option[MessageData]] = {
+  @Deprecated
+  override def sendMessage(convId: ConvId, content: api.MessageContent): Future[Option[MessageData]] = content match {
+    case m: api.MessageContent.Text =>
+      debug(s"send text message ${m.getContent.take(4)}...")
+      if (m.getMentions.isEmpty) sendTextMessage(convId, m.getContent)
+      else mentionsMap(m.getMentions) flatMap { ms => sendTextMessage(convId, m.getContent, ms) }
 
-    def mentionsMap(us: Array[api.User]): Future[Map[UserId, String]] =
-      users.getUsers(us.map { u => UserId(u.getId) }) map { uss =>
-        uss.map(u => u.id -> u.getDisplayName)(breakOut)
+    case m: api.MessageContent.Location =>
+      sendLocationMessage(convId, Location(m.getLongitude, m.getLatitude, m.getName, m.getZoom))
+
+    case m: api.MessageContent.Image =>
+      convsContent.convById(convId) flatMap {
+        case Some(conv) => sendImageMessage(m.getContent, conv)
+        case None => Future.failed(new IllegalArgumentException(s"No conversation found for $convId"))
       }
 
-    def sendTextMessage(m: String, mentions: Map[UserId, String] = Map.empty) =
-      for {
-        msg <- messages.addTextMessage(convId, m, mentions)
-        _ <- updateLastRead(msg)
-        _ <- sync.postMessage(msg.id, convId, msg.editTime)
-      } yield Some(msg)
-
-    def sendLocationMessage(loc: Location) =
-      for {
-        msg <- messages.addLocationMessage(convId, loc)
-        _ <- updateLastRead(msg)
-        _ <- sync.postMessage(msg.id, convId, msg.editTime)
-      } yield Some(msg)
-
-    def sendImageMessage(img: api.ImageAsset, conv: ConversationData) = {
-      verbose(s"sendImageMessage($img, $conv)")
-      for {
-        data <- assets.addImageAsset(img, conv.remoteId, isSelf = false)
-        msg <- messages.addAssetMessage(convId, data)
-        _ <- updateLastRead(msg)
-        _ <- Future.successful(assetUploadStarted ! data)
-        _ <- sync.postMessage(msg.id, convId, msg.editTime)
-      } yield Some(msg)
-    }
-
-    def sendAssetMessage(in: AssetForUpload, conv: ConversationData, handler: ErrorHandler): Future[Option[MessageData]] = {
-
-      def isFileTooLarge(size: Long, mime: Mime) = mime match {
-        case Mime.Video() => false
-        case _ => size > AssetData.MaxAllowedAssetSizeInBytes
-      }
-
-      def shouldWarnAboutFileSize(size: Long) =
-        if (size < LargeAssetWarningThresholdInBytes) Future successful None
-        else network.networkMode.head map {
-          case api.NetworkMode.OFFLINE | api.NetworkMode.WIFI => None
-          case net if lifecycle.isUiActive => Some(net)
-          case _ => None
-        }
-
-      def showLargeFileWarning(size: Long, mime: Mime, net: NetworkMode, message: MessageData) = {
-        Threading.assertUiThread()
-
-        handler.noWifiAndFileIsLarge(size, net, new api.MessageContent.Asset.Answer {
-          override def ok(): Unit = messages.retryMessageSending(convId, message.id)
-
-          override def cancel(): Unit = messagesContent.deleteMessage(message).map(_ => assetUploadCancelled ! mime)
-        })
-      }
-
-      def checkSize(size: Option[Long], mime: Mime, message: MessageData) = size match {
-        case None => Future successful true
-        case Some(s) if isFileTooLarge(s, mime) =>
-          for {
-            _ <- messages.updateMessageState(convId, message.id, Message.Status.FAILED)
-            _ <- errors.addAssetTooLargeError(convId, message.id)
-            _ <- Future.successful(assetUploadFailed ! ErrorResponse.internalError("asset too large"))
-          } yield false
-        case Some(s) =>
-          shouldWarnAboutFileSize(s) flatMap {
-            case Some(net) =>
-              // will mark message as failed and ask user if it should really be sent
-              // marking as failed ensures that user has a way to retry even if he doesn't respond to this warning
-              // this is possible if app is paused or killed in meantime, we don't want to be left with message in state PENDING without a sync request
-              messages.updateMessageState(convId, message.id, Message.Status.FAILED).map { _ =>
-                showLargeFileWarning(s, mime, net, message)
-                false
+    case m: api.MessageContent.Asset =>
+      convsContent.convById(convId) flatMap {
+        case Some(conv) =>
+          debug(s"send asset message ${m.getContent}")
+          m.getContent match {
+            case a@ContentUriAssetForUpload(_, uri) =>
+              a.mimeType.flatMap {
+                case m@Mime.Image() =>
+                  sendImageMessage(ImageAssetFactory.getImageAsset(uri), conv) // XXX: this has to run on UI thread, so we can't make if part of the for-expression
+                case _ =>
+                  sendAssetMessage(a, conv, m.getErrorHandler)
               }(Threading.Ui)
-            case _ =>
-              Future successful true
+            case a: AssetForUpload => sendAssetMessage(a, conv, m.getErrorHandler)
           }
+        case None =>
+          Future.failed(new IllegalArgumentException(s"No conversation found for $convId"))
       }
 
-      for {
-        mime <- in.mimeType
-        asset <- assets.addAsset(in, conv.remoteId)
-        message <- messages.addAssetMessage(convId, asset)
-        size <- in.sizeInBytes
-        _ <- Future.successful(assetUploadStarted ! asset)
-        shouldSend <- checkSize(size, mime, message)
-        _ <- if (shouldSend) sync.postMessage(message.id, convId, message.editTime) else Future.successful(())
-      } yield Some(message)
-    }
-
-    content match {
-      case m: api.MessageContent.Text =>
-        debug(s"send text message ${m.getContent.take(4)}...")
-        if (m.getMentions.isEmpty) sendTextMessage(m.getContent)
-        else mentionsMap(m.getMentions) flatMap { ms => sendTextMessage(m.getContent, ms) }
-      case m: api.MessageContent.Location =>
-        sendLocationMessage(Location(m.getLongitude, m.getLatitude, m.getName, m.getZoom))
-      case m: api.MessageContent.Image =>
-        convsContent.convById(convId) flatMap {
-          case Some(conv) => sendImageMessage(m.getContent, conv)
-          case None => Future.failed(new IllegalArgumentException(s"No conversation found for $convId"))
-        }
-      case m: api.MessageContent.Asset =>
-        convsContent.convById(convId) flatMap {
-          case Some(conv) =>
-            debug(s"send asset message ${m.getContent}")
-            m.getContent match {
-              case a@ContentUriAssetForUpload(_, uri) =>
-                a.mimeType.flatMap {
-                  case m@Mime.Image() =>
-                    sendImageMessage(ImageAssetFactory.getImageAsset(uri), conv) // XXX: this has to run on UI thread, so we can't make if part of the for-expression
-                  case _ =>
-                    sendAssetMessage(a, conv, m.getErrorHandler)
-                }(Threading.Ui)
-              case a: AssetForUpload => sendAssetMessage(a, conv, m.getErrorHandler)
-            }
-          case None =>
-            Future.failed(new IllegalArgumentException(s"No conversation found for $convId"))
-        }
-      case _ =>
-        error(s"sendMessage($content) not supported yet")
-        Future.failed(new IllegalArgumentException(s"MessageContent: $content is not supported yet"))
-    }
+    case _ =>
+      error(s"sendMessage($content) not supported yet")
+      Future.failed(new IllegalArgumentException(s"MessageContent: $content is not supported yet"))
   }
 
-  override def updateMessage(convId: ConvId, id: MessageId, content: Text): Future[Option[MessageData]] = {
-    verbose(s"updateMessage($convId, $id, $content")
+  override def sendMessage(convId: ConvId, uri: URI, errorHandler: ErrorHandler): Future[Option[MessageData]] = withConv(convId) { conv =>
+    val asset = ContentUriAssetForUpload(AssetId(), uri)
+    asset.mimeType.flatMap {
+      case Mime.Image() => sendImageMessage(ImageAssetFactory.getImageAsset(uri), conv)
+      case _ => sendAssetMessage(asset, conv, errorHandler)
+    }(Threading.Ui)
+  }
+
+  override def sendMessage(convId: ConvId, audioAsset: AssetForUpload, errorHandler: ErrorHandler): Future[Option[MessageData]] =
+    withConv(convId){ conv => sendAssetMessage(audioAsset, conv, errorHandler) } // audio and video assets
+
+  override def sendMessage(convId: ConvId, text: String): Future[Option[MessageData]] = withConv(convId){ _ => sendTextMessage(convId, text) }
+
+  override def sendMessage(convId: ConvId, text: String, mentions: Set[UserId]): Future[Option[MessageData]] = withConv(convId){ _ =>
+    mentionsMap(mentions) flatMap { ms => sendTextMessage(convId, text, ms) }
+  }
+
+  override def sendMessage(convId: ConvId, jpegData: Array[Byte]): Future[Option[MessageData]] = withConv(convId) { conv =>
+    sendImageMessage(ImageAssetFactory.getImageAsset(jpegData), conv)
+  }
+
+  override def sendMessage(convId: ConvId, imageAsset: ImageAsset): Future[Option[MessageData]] = withConv(convId) { conv =>
+    sendImageMessage(imageAsset, conv)
+  }
+
+  override def sendMessage(convId: ConvId, location: api.MessageContent.Location): Future[Option[MessageData]] = withConv(convId) { _ =>
+    sendLocationMessage(convId, location) // TODO: maybe simply use GenericContent.Location
+  }
+
+  private def withConv(convId: ConvId)(use: (ConversationData) => Future[Option[MessageData]]) = convsContent.convById(convId).flatMap {
+    case Some(conv) => use(conv)
+    case None => Future.failed(new IllegalArgumentException(s"No conversation found for $convId"))
+  }
+
+  implicit private def toLocation(l: api.MessageContent.Location): GenericContent.Location = Location(l.getLongitude, l.getLatitude, l.getName, l.getZoom)
+
+  override def updateMessage(convId: ConvId, id: MessageId, text: String): Future[Option[MessageData]] = {
+    verbose(s"updateMessage($convId, $id, $text")
     messagesContent.updateMessage(id) {
       case m if m.convId == convId && m.userId == self =>
-        val (tpe, ct) = MessageData.messageContent(content.getContent, weblinkEnabled = true)
+        val (tpe, ct) = MessageData.messageContent(text, weblinkEnabled = true)
         verbose(s"updated content: ${(tpe, ct)}")
-        m.copy(msgType = tpe, content = ct, protos = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(content.getContent)))), state = Message.Status.PENDING, editTime = (m.time max m.editTime).plus(1.millis) max Instant.now)
+        m.copy(msgType = tpe, content = ct, protos = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(text)))), state = Message.Status.PENDING, editTime = (m.time max m.editTime).plus(1.millis) max Instant.now)
       case m =>
         warn(s"Can not update msg: $m")
         m
@@ -415,6 +375,99 @@ class ConversationsUiServiceImpl( self:            UserId,
 
   override def setEphemeral(id: ConvId, expiration: EphemeralExpiration): Future[Option[(ConversationData, ConversationData)]] =
     convStorage.update(id, _.copy(ephemeral = expiration))
+
+  private def mentionsMap(us: Array[api.User]): Future[Map[UserId, String]] =
+    users.getUsers(us.map { u => UserId(u.getId) }) map { uss =>
+      uss.map(u => u.id -> u.getDisplayName)(breakOut)
+    }
+
+  private def mentionsMap(us: Set[UserId]): Future[Map[UserId, String]] =
+    users.getUsers(us.toSeq) map { uss =>
+      uss.map(u => u.id -> u.getDisplayName)(breakOut)
+    }
+
+  private def sendTextMessage(convId: ConvId, m: String, mentions: Map[UserId, String] = Map.empty) =
+    for {
+      msg <- messages.addTextMessage(convId, m, mentions)
+      _ <- updateLastRead(msg)
+      _ <- sync.postMessage(msg.id, convId, msg.editTime)
+    } yield Some(msg)
+
+  private def sendLocationMessage(convId: ConvId, loc: Location) =
+    for {
+      msg <- messages.addLocationMessage(convId, loc)
+      _ <- updateLastRead(msg)
+      _ <- sync.postMessage(msg.id, convId, msg.editTime)
+    } yield Some(msg)
+
+  private def sendImageMessage(img: api.ImageAsset, conv: ConversationData) = {
+    verbose(s"sendImageMessage($img, $conv)")
+    for {
+      data <- assets.addImageAsset(img, conv.remoteId, isSelf = false)
+      msg <- messages.addAssetMessage(conv.id, data)
+      _ <- updateLastRead(msg)
+      _ <- Future.successful(assetUploadStarted ! data)
+      _ <- sync.postMessage(msg.id, conv.id, msg.editTime)
+    } yield Some(msg)
+  }
+
+  private def sendAssetMessage(in: AssetForUpload, conv: ConversationData, handler: ErrorHandler): Future[Option[MessageData]] =
+    for {
+      mime <- in.mimeType
+      asset <- assets.addAsset(in, conv.remoteId)
+      message <- messages.addAssetMessage(conv.id, asset)
+      size <- in.sizeInBytes
+      _ <- Future.successful(assetUploadStarted ! asset)
+      shouldSend <- checkSize(conv.id, size, mime, message, handler)
+      _ <- if (shouldSend) sync.postMessage(message.id, conv.id, message.editTime) else Future.successful(())
+    } yield Some(message)
+
+  def isFileTooLarge(size: Long, mime: Mime) = mime match {
+    case Mime.Video() => false
+    case _ => size > AssetData.MaxAllowedAssetSizeInBytes
+  }
+
+  private def shouldWarnAboutFileSize(size: Long) =
+    if (size < LargeAssetWarningThresholdInBytes) Future successful None
+    else network.networkMode.head map {
+      case api.NetworkMode.OFFLINE | api.NetworkMode.WIFI => None
+      case net if lifecycle.isUiActive => Some(net)
+      case _ => None
+    }
+
+  private def showLargeFileWarning(convId: ConvId, size: Long, mime: Mime, net: NetworkMode, message: MessageData, handler: ErrorHandler) = {
+    Threading.assertUiThread()
+
+    handler.noWifiAndFileIsLarge(size, net, new api.MessageContent.Asset.Answer {
+      override def ok(): Unit = messages.retryMessageSending(convId, message.id)
+
+      override def cancel(): Unit = messagesContent.deleteMessage(message).map(_ => assetUploadCancelled ! mime)
+    })
+  }
+
+  private def checkSize(convId: ConvId, size: Option[Long], mime: Mime, message: MessageData, handler: ErrorHandler) = size match {
+    case None => Future successful true
+    case Some(s) if isFileTooLarge(s, mime) =>
+      for {
+        _ <- messages.updateMessageState(convId, message.id, Message.Status.FAILED)
+        _ <- errors.addAssetTooLargeError(convId, message.id)
+        _ <- Future.successful(assetUploadFailed ! ErrorResponse.internalError("asset too large"))
+      } yield false
+    case Some(s) =>
+      shouldWarnAboutFileSize(s) flatMap {
+        case Some(net) =>
+          // will mark message as failed and ask user if it should really be sent
+          // marking as failed ensures that user has a way to retry even if he doesn't respond to this warning
+          // this is possible if app is paused or killed in meantime, we don't want to be left with message in state PENDING without a sync request
+          messages.updateMessageState(convId, message.id, Message.Status.FAILED).map { _ =>
+            showLargeFileWarning(convId, s, mime, net, message, handler)
+            false
+          }(Threading.Ui)
+        case _ =>
+          Future successful true
+      }
+  }
+
 }
 
 object ConversationsUiService {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -21,6 +21,7 @@ import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api
 import com.waz.api.MessageContent.Asset.ErrorHandler
+import com.waz.api.MessageContent.Text
 import com.waz.api.impl._
 import com.waz.api.{EphemeralExpiration, ImageAssetFactory, Message, NetworkMode}
 import com.waz.content._
@@ -57,7 +58,11 @@ trait ConversationsUiService {
   def sendMessage(convId: ConvId, imageAsset: ImageAsset): Future[Option[MessageData]]
   def sendMessage(convId: ConvId, location: api.MessageContent.Location): Future[Option[MessageData]]
 
+  @Deprecated
+  def updateMessage(convId: ConvId, id: MessageId, text: Text): Future[Option[MessageData]]
+
   def updateMessage(convId: ConvId, id: MessageId, text: String): Future[Option[MessageData]]
+
   def deleteMessage(convId: ConvId, id: MessageId): Future[Unit]
   def recallMessage(convId: ConvId, id: MessageId): Future[Option[MessageData]]
   def setConversationArchived(id: ConvId, archived: Boolean): Future[Option[ConversationData]]
@@ -177,6 +182,9 @@ class ConversationsUiServiceImpl( self:            UserId,
   }
 
   implicit private def toLocation(l: api.MessageContent.Location): GenericContent.Location = Location(l.getLongitude, l.getLatitude, l.getName, l.getZoom)
+
+  @Deprecated
+  override def updateMessage(convId: ConvId, id: MessageId, text: Text): Future[Option[MessageData]] = updateMessage(convId, id, text.getContent)
 
   override def updateMessage(convId: ConvId, id: MessageId, text: String): Future[Option[MessageData]] = {
     verbose(s"updateMessage($convId, $id, $text")

--- a/zmessaging/src/main/scala/com/waz/ui/Conversations.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/Conversations.scala
@@ -54,7 +54,7 @@ class Conversations(implicit ui: UiModule, ec: EventContext) {
   def sendMessage(id: ConvId, content: MessageContent): Unit = zms(_.convsUi.sendMessage(id, content))
 
   def setName(id: ConvId, name: String): Unit = zms(_.convsUi.setConversationName(id, name))
-  
+
   def addMembers(id: ConvId, users: Seq[User]): Unit = zms(_.convsUi.addConversationMembers(id, users.map(u => UserId(u.getId))))
 
   def removeMember(id: ConvId, user: User): Unit = zms(_.convsUi.removeConversationMember(id, UserId(user.getId)))


### PR DESCRIPTION
Apart from one general `sendMessage`, `ConversationsUiService` has now a list of specialized versions of the method. They can be used from UI and from other places in SE directly, without the need to go through the old conversation API. Eventually we should be able to replace all uses of the general method with the specialized ones and remove the old API.
To do:
* Tests in `MessageSendingSpec`
* In UI, use the specialized methods in `ConversationFragment`. 