### PR TITLE
[AN-5534] [AN-5541] [AN-5542] makes loading entries priority queue thread-safe

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoaderService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoaderService.scala
@@ -27,8 +27,8 @@ import com.waz.service.ZMessaging.clock
 import com.waz.service.downloads.AssetLoader.DownloadException
 import com.waz.threading.CancellableFuture.CancelException
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
-import com.waz.utils._
 import com.waz.utils.events._
+import com.waz.utils.{Backoff, ExponentialBackoff, returning}
 import org.threeten.bp.Instant
 
 import scala.collection.mutable
@@ -50,7 +50,7 @@ class AssetLoaderService {
   private implicit val ev = EventContext.Global
 
   private val requests  = new mutable.HashMap[AssetId, LoadEntry]()
-  private val active    = new mutable.HashSet[AssetId]
+  private val active    = new mutable.HashSet[AssetId]()
   private val queue     = new mutable.PriorityQueue[QueueEntry]()(QueueOrdering)
 
   private val onAdded   = EventStream[LoadEntry]()
@@ -72,8 +72,8 @@ class AssetLoaderService {
   private def removeTaskIfIdle(id: AssetId) = {
     if (!active.contains(id)) {
       verbose(s"Cancelling idle task: $id")
-      requests.remove(id) foreach { _.cancel() }
-      checkQueue()
+      updateQueue(toRemove = Some(id))
+      requests.get(id).foreach(_.cancel())
       true
     } else false
   }
@@ -84,65 +84,60 @@ class AssetLoaderService {
   //reveals attempted load count - useful for testing retry logic
   def loadRevealAttempts(asset: AssetData, force: Boolean = false)(implicit loader: AssetLoader): CancellableFuture[(Option[CacheEntry], Int)] = {
     verbose(s"loadRevealAttempts: ${asset.id}")
-    new CancellableFuture(loadEntry(asset, force).promise) {
-      override def cancel()(implicit tag: LogTag) = {
+
+    val loadEntry =
+      updateQueue(toAdd = Some(asset, loader), force = force)
+      .getOrElse(throw new IllegalArgumentException(s"Failed to load asset ${asset.id} with force = $force"))
+
+    new CancellableFuture(loadEntry.promise) {
+      override def cancel()(implicit tag: LogTag) =
         returning(removeTaskIfIdle(asset.id)) { removed =>
           verbose(s"Tried to cancel loadEntry: ${asset.id}: removed?: $removed")(tag)
         }
-      }
     }.map {
       case (entry, attempts) => (Some(entry), attempts)
     }
   }
 
-  private def loadEntry(asset: AssetData, force: Boolean = false)(implicit loader: AssetLoader) = {
-    verbose(s"loadEntry(${asset.id}, $force)")
+  // All operations modifying the queue and associated data structures (active, requests) has to be performed inside this method
+  // or in methods which are called only through this one. Outside updateQueue only getters are allowed.
+  private def updateQueue(toAdd: Option[(AssetData, AssetLoader)] = None,
+                          toRemove: Option[AssetId] = None,
+                          force: Boolean = false): Option[LoadEntry] = synchronized {
+    verbose(s"updateQueue(${toAdd.map(_._1.id)}, $toRemove, $force)")
     verbose(s"load requests: ${requests.keys.map(_.toString).toSeq.sorted}")
     verbose(s"active:        ${active.map(_.toString).toSeq.sorted}")
 
-    if (!active(asset.id)) {
-      def createOrUpdate(cur: Option[LoadEntry]) = {
-        cur.map { e =>
-          verbose(s"Found existing for id: ${asset.id}, updating.")
-          e.copy(asset = asset, force = e.force || force)
-        }.getOrElse {
-          verbose(s"No existing entry for: ${asset.id}, creating.")
-          returning(LoadEntry(asset, loader, force))(onAdded ! _)
-        }
-      }
-
-      returning(createOrUpdate(requests.get(asset.id))) { entry =>
-        requests.update(asset.id, entry)
-        verbose(s"adding entry to the queue: ${asset.id}")
-        queue.enqueue(entry.queuePlaceHolder)
-        checkQueue()
-      }
-
-    } else {
-      verbose(s"Load entry: ${asset.id} was already active, not updating")
-      requests.getOrElse(asset.id, throw new Exception("Active load operation was missing from request map"))
+    val ret = toAdd.map { case (asset, loader) =>
+      requests.getOrElse(asset.id,
+        if (!active.contains(asset.id)) {
+          verbose(s"adding entry to the queue: ${asset.id}")
+          returning(LoadEntry(asset, loader, force)) { entry =>
+            requests += asset.id -> entry
+            queue.enqueue(entry.queuePlaceHolder)
+            onAdded ! entry
+          }
+        } else throw new Exception("Active load operation was missing from request map")
+      )
     }
-  }
 
-  private def checkQueue(): Unit = Future {
-    verbose(s"checkQueue()")
-    verbose(s"queue: $queue")
+    toRemove.foreach { id =>
+      requests -= id
+      active -= id
+    }
 
     if (queue.nonEmpty && active.size < MaxConcurrentLoadRequests) {
       val id = queue.dequeue().id
       requests.get(id).fold(verbose(s"De-queued load entry: $id has been cancelled - discarding")) { entry =>
         if (active.add(id)) {
           verbose(s"starting load for $entry")
-          load(entry).onComplete { res =>
-            requests -= id
-            active -= id
-            checkQueue() //check queue again in case we're blocked and waiting (in which case we won't reach the next checkQueue call)
-          }
-        } else
-          verbose(s"entry: $id was already active, doing nothing")
+          load(entry).onComplete { _ => updateQueue(toRemove = Some(id)) } //check queue again in case we're blocked and waiting (in which case we won't reach the next checkQueue call)
+        } else verbose(s"entry: $id was already active, doing nothing")
       }
-      checkQueue() //effectively causes a while(queue.nonEmpty && active.size < MaxConcurrentLoadRequests)
+      Future { updateQueue() } //effectively causes a while(queue.nonEmpty && active.size < MaxConcurrentLoadRequests)
     }
+
+    ret
   }
 
   //Returns a Future, since once actual loading has started, it doesn't make sense to cancel it and waste the work.
@@ -211,7 +206,7 @@ object AssetLoaderService {
 
     override def toString: LogTag = s"LoadEntry(${asset.id}) { force: $force, state: $state, time: $time }"
 
-    def queuePlaceHolder: QueueEntry = QueueEntry(asset.id, time)
+    lazy val queuePlaceHolder: QueueEntry = QueueEntry(asset.id, time)
   }
 
   case class QueueEntry(id: AssetId, time: Instant)


### PR DESCRIPTION
The bugs are difficult to reproduce. I suspect they are all related to that the Scala's mutable PriorityQueue is not thread-safe and when many threads try to modify it concurrently this may cause weird behaviour. 

Especially the `IndexOutOfBoundsException` from AN-5534 hints to that, as explained here in the first comment: https://stackoverflow.com/questions/31847852/is-scalas-collection-mutable-priorityqueue-thread-safe

I've rewritten the code so that all operations modifying the queue are now in a synchronized block. 