### PR TITLE
saves multiple assets from link previews

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -87,16 +87,15 @@ class MessageEventProcessor(selfUserId:          UserId,
       otr.decryptAssetData(assetData.id, assetData.otrKey, assetData.sha, data, assetData.encryption)
 
     //ensure we always save the preview to the same id (GenericContent.Asset.unapply always creates new assets and previews))
-    def saveAssetAndPreview(asset: AssetData, preview: Option[AssetData]) = {
+    def saveAssetAndPreview(asset: AssetData, preview: Option[AssetData]) =
       assets.mergeOrCreateAsset(asset).flatMap {
         case Some(asset) => preview.fold(Future.successful(Option.empty[AssetData]))(p => assets.mergeOrCreateAsset(p.copy(id = asset.previewId.getOrElse(p.id))))
         case _ => Future.successful(Option.empty[AssetData])
-      }
-    }
+      }.map( _.map( Seq(_) ).getOrElse(Seq.empty[AssetData]) )
 
     //For assets v3, the RAssetId will be contained in the proto content. For v2, it will be passed along with in the GenericAssetEvent
     //A defined convId marks that the asset is a v2 asset.
-    def update(id: Uid, convId: Option[RConvId], ct: Any, v2RId: Option[RAssetId], data: Option[Array[Byte]]): Future[Option[AssetData]] = {
+    def update(id: Uid, convId: Option[RConvId], ct: Any, v2RId: Option[RAssetId], data: Option[Array[Byte]]): Future[Seq[AssetData]] = {
       verbose(s"update asset for event: $id, convId: $convId, ct: $ct, v2RId: $v2RId, data: $data")
 
       (ct, v2RId) match {
@@ -105,14 +104,13 @@ class MessageEventProcessor(selfUserId:          UserId,
           verbose(s"Received asset v3: $asset with preview: $preview")
           saveAssetAndPreview(asset, preview)
         case (Text(_, _, linkPreviews), _) =>
-          //TODO Dean - handle link previews with multiple images
-          linkPreviews.headOption.fold(Future.successful(Option.empty[AssetData])) {
+          Future.sequence(linkPreviews.map {
             case LinkPreview.WithAsset(a@AssetData.WithRemoteId(_)) =>
               val asset = a.copy(id = AssetId(id.str))
               verbose(s"Received link preview asset: $asset")
               saveAssetAndPreview(asset, None)
-            case _ => Future successful None
-          }
+            case _ => Future successful Seq.empty[AssetData]
+          }).map(_.flatten)
         case (Asset(a, p), Some(rId)) =>
           val forPreview = a.otrKey.isEmpty //For assets containing previews, the second GenericMessage contains remote information about the preview, not the asset
           val asset = a.copy(id = AssetId(id.str), remoteId = if (forPreview) None else Some(rId), convId = convId, data = if (forPreview) None else decryptAssetData(a, data))
@@ -121,14 +119,14 @@ class MessageEventProcessor(selfUserId:          UserId,
           saveAssetAndPreview(asset, preview)
         case (ImageAsset(a@AssetData.IsImageWithTag(Preview)), _) =>
           verbose(s"Received image preview for msg: $id. Dropping")
-          Future successful None
+          Future successful Seq.empty[AssetData]
         case (ImageAsset(a@AssetData.IsImageWithTag(Medium)), Some(rId)) =>
           val asset = a.copy(id = AssetId(id.str), remoteId = Some(rId), convId = convId, data = decryptAssetData(a, data))
           verbose(s"Received asset v2 image: $asset")
-          assets.mergeOrCreateAsset(asset)
+          assets.mergeOrCreateAsset(asset).map( _.map( Seq(_) ).getOrElse(Seq.empty[AssetData]) )
         case (Asset(a, _), _) if a.status == UploadFailed && a.isImage =>
           verbose(s"Received a message about a failed image upload: $id. Dropping")
-          Future successful None
+          Future successful Seq.empty[AssetData]
         case (Asset(a, preview), _ ) =>
           val asset = a.copy(id = AssetId(id.str))
           verbose(s"Received asset without remote data - we will expect another update: $asset")
@@ -136,7 +134,7 @@ class MessageEventProcessor(selfUserId:          UserId,
         case (Ephemeral(_, content), _)=>
           update(id, convId, content, v2RId, data)
         case res =>
-          Future successful None
+          Future successful Seq.empty[AssetData]
       }
     }
 


### PR DESCRIPTION
A small refactoring I did while working on AssetLoaderService.
MessageEventProcessor correctly handles link previews with multiple images.