### PR TITLE
[AN-5406] user search waits for UserData for the exact match before asking for it

### DIFF
--- a/tests/unit/src/test/scala/com/waz/api/impl/UsernamesSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/api/impl/UsernamesSpec.scala
@@ -71,6 +71,11 @@ class UsernamesSpec extends FeatureSpec with Matchers with BeforeAndAfter with B
     genName should be("wire")
   }
 
+  scenario ("Username generation with underscores") {
+    val genName = usernames.generateUsernameFromName("maciek_wire", null)
+    genName should be("maciek_wire")
+  }
+
   scenario ("Username generation with latin characters and space") {
     val genName = usernames.generateUsernameFromName("Wire Wireson", null)
     genName should be("wirewireson")
@@ -103,11 +108,11 @@ class UsernamesSpec extends FeatureSpec with Matchers with BeforeAndAfter with B
 
   scenario("Querying for usernames with @") {
     val handle = Handle("abcd")
-    handle.containsQuery("@AbC") should be(true)
+    handle.startsWithQuery("@AbC") should be(true)
   }
 
   scenario("Querying for usernames without @") {
     val handle = Handle("abcd")
-    handle.containsQuery("AbC") should be(true)
+    handle.startsWithQuery("AbC") should be(true)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/api/impl/ConnectionsSearch.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/ConnectionsSearch.scala
@@ -32,7 +32,7 @@ class ConnectionsSearch(searchTerm: String, limit: Int, filter: Array[String], a
   private val filteredIds = filter.toSet
   private val query = SearchKey(searchTerm)
   private val predicate: UserData => Boolean = u =>
-    ((query.isAtTheStartOfAnyWordIn(u.searchKey) && !searchByHandleOnly) || u.handle.exists(_.containsQuery(searchTerm)) || (alsoSearchByEmail && u.email.exists(e => searchTerm.trim.equalsIgnoreCase(e.str)))) && ! filteredIds.contains(u.id.str) && (showBlockedUsers || (u.connection != BLOCKED))
+    ((query.isAtTheStartOfAnyWordIn(u.searchKey) && !searchByHandleOnly) || u.handle.exists(_.startsWithQuery(searchTerm)) || (alsoSearchByEmail && u.email.exists(e => searchTerm.trim.equalsIgnoreCase(e.str)))) && ! filteredIds.contains(u.id.str) && (showBlockedUsers || (u.connection != BLOCKED))
   
   private var users = Option.empty[Vector[UserData]]
   

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -21,11 +21,11 @@ import java.util.UUID
 
 import com.waz.utils.Locales
 
-case class Handle(string: String) extends AnyVal{
+case class Handle(string: String) extends AnyVal {
   override def toString : String = string
 
-  def containsQuery(query: String): Boolean = {
-    string.contains(Handle.transliterated(Handle.stripSymbol(query)).toLowerCase)
+  def startsWithQuery(query: String): Boolean = {
+     string.startsWith(Handle.transliterated(Handle.stripSymbol(query)).toLowerCase)
   }
 
   def exactMatchQuery(query: String): Boolean = {

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -25,11 +25,11 @@ case class Handle(string: String) extends AnyVal {
   override def toString : String = string
 
   def startsWithQuery(query: String): Boolean = {
-     string.startsWith(Handle.transliterated(Handle.stripSymbol(query)).toLowerCase)
+     string.startsWith(Handle.stripSymbol(query).toLowerCase)
   }
 
   def exactMatchQuery(query: String): Boolean = {
-    string == Handle.transliterated(Handle.stripSymbol(query)).toLowerCase
+    string == Handle.stripSymbol(query).toLowerCase
   }
 
   def withSymbol: String = if (string.startsWith("@")) string else s"@$string"

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -219,11 +219,11 @@ class UserSearchService(selfUserId: UserId,
 
   private def recommendedPredicate(prefix: String): UserData => Boolean = {
     val key = SearchKey(prefix)
-    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.email.exists(_.str == prefix) || u.handle.exists(_.containsQuery(prefix)))
+    u => ! u.deleted && ! u.isConnected && (key.isAtTheStartOfAnyWordIn(u.searchKey) || u.email.exists(_.str == prefix) || u.handle.exists(_.startsWithQuery(prefix)))
   }
 
   private def recommendedHandlePredicate(prefix: String): UserData => Boolean = {
-    u => ! u.deleted && ! u.isConnected && u.handle.exists(_.containsQuery(prefix))
+    u => ! u.deleted && ! u.isConnected && u.handle.exists(_.startsWithQuery(prefix))
   }
 
   private def searchTeamMembersForState(searchState: SearchState) = teamId match {
@@ -258,7 +258,7 @@ class UserSearchService(selfUserId: UserId,
     val query = SearchKey(searchTerm)
     user =>
       ((query.isAtTheStartOfAnyWordIn(user.searchKey) && !searchByHandleOnly) ||
-        user.handle.exists(_.containsQuery(searchTerm)) ||
+        user.handle.exists(_.startsWithQuery(searchTerm)) ||
         (alsoSearchByEmail && user.email.exists(e => searchTerm.trim.equalsIgnoreCase(e.str)))) &&
         !filteredIds.contains(user.id.str) &&
         (showBlockedUsers || (user.connection != ConnectionStatus.Blocked))

--- a/zmessaging/src/main/scala/com/waz/utils/Locales.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/Locales.scala
@@ -112,7 +112,7 @@ trait Transliteration {
 }
 
 object Transliteration {
-  private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z_] Remove"
+  private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z] Remove"
   def chooseImplementation(id: String = id): Transliteration =
     if (!utils.isTest && Try(Class.forName("libcore.icu.Transliterator")).isSuccess) LibcoreTransliteration.create(id)
     else ICU4JTransliteration.create(id)

--- a/zmessaging/src/main/scala/com/waz/utils/Locales.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/Locales.scala
@@ -112,7 +112,7 @@ trait Transliteration {
 }
 
 object Transliteration {
-  private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z] Remove"
+  private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z_] Remove"
   def chooseImplementation(id: String = id): Transliteration =
     if (!utils.isTest && Try(Class.forName("libcore.icu.Transliterator")).isSuccess) LibcoreTransliteration.create(id)
     else ICU4JTransliteration.create(id)


### PR DESCRIPTION
Also, transliteration may remove the underscore signs from handles, so I introduced an "or" in matching the query with the handle. Either the transliterated or the raw version should match.
And the standard (ie. not exact) handle match is now "startsWith", not "contains". In case of handles, since the query has to start with '@', we don't look for handles which have the query somewhere inside, but only at the beginning.