### PR TITLE
Add more granular unread messages counting.

### DIFF
--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -24,7 +24,7 @@ import java.util.{Date, Locale}
 
 import com.waz.api.{InvitationTokenFactory, Invitations}
 import com.waz.model.AssetMetaData.Image.Tag.{Medium, Preview}
-import com.waz.model.ConversationData.ConversationType
+import com.waz.model.ConversationData.{ConversationType, UnreadCount}
 import com.waz.model.GenericContent.{EncryptionAlgorithm, Text}
 import com.waz.model.SearchQuery.{Recommended, TopPeople}
 import com.waz.model.UserData.ConnectionStatus
@@ -90,7 +90,7 @@ object Generators {
     cleared <- arbitrary[Instant]
     generatedName <- arbitrary[String]
     searchKey = name map SearchKey
-    unreadCount <- posNum[Int]
+    unreadCount <- arbitrary[UnreadCount]
     failedCount <- posNum[Int]
     missedCall <- arbitrary[Option[MessageId]]
     incomingKnock <- arbitrary[Option[MessageId]]
@@ -153,6 +153,7 @@ object Generators {
   implicit lazy val arbAssetToken: Arbitrary[AssetToken] = Arbitrary(resultOf(AssetToken))
   implicit lazy val arbOtrKey: Arbitrary[AESKey] = Arbitrary(sideEffect(AESKey()))
   implicit lazy val arbSha256: Arbitrary[Sha256] = Arbitrary(arbitrary[Array[Byte]].map(b => Sha256(sha2(b))))
+  implicit lazy val arbUnreadCount: Arbitrary[UnreadCount] = Arbitrary(for (n <- chooseNum(0,1000); c <- chooseNum(0,1000); p <- chooseNum(0,1000)) yield UnreadCount(n, c, p))
 
   object MediaAssets {
     implicit lazy val arbArtistData: Arbitrary[ArtistData] = Arbitrary(resultOf(ArtistData))

--- a/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
+++ b/tests/utils/src/main/scala/com/waz/api/ApiSpec.scala
@@ -115,7 +115,7 @@ trait ApiSpec extends BeforeAndAfterEach with BeforeAndAfterAll with Matchers wi
   }, 5.seconds)
 
   def getUnreadCount(conv: ConvId) = Await.result(api.zmessaging.flatMap {
-    case Some(zms) => zms.convsStorage.get(conv).map(_.fold(0)(_.unreadCount))
+    case Some(zms) => zms.convsStorage.get(conv).map(_.fold(0)(_.unreadCount.messages))
     case None => Future.successful(0)
   }, 5.seconds)
 

--- a/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
+++ b/zmessaging/src/main/scala/com/waz/api/impl/conversation/BaseConversation.scala
@@ -95,7 +95,7 @@ abstract class BaseConversation(implicit ui: UiModule) extends IConversation wit
 
   override def hasMissedCall: Boolean = data.missedCallMessage.isDefined
 
-  override def getUnreadCount: Int = data.unreadCount
+  override def getUnreadCount: Int = data.unreadCount.messages
 
   override def getFailedCount: Int = data.failedCount
 

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -23,6 +23,7 @@ import android.content.Context
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.api.{ErrorResponse, Message, MessageFilter}
+import com.waz.model.ConversationData.UnreadCount
 import com.waz.model.MessageData.{MessageDataDao, MessageEntry}
 import com.waz.model._
 import com.waz.service.Timeouts
@@ -137,10 +138,15 @@ class MessagesStorageImpl(context: Context, storage: ZmsDatabase, userId: UserId
 
   override def addMessage(msg: MessageData) = put(msg.id, msg)
 
-  def countUnread(conv: ConvId, lastReadTime: Instant): Future[Int] = {
+  def countUnread(conv: ConvId, lastReadTime: Instant): Future[UnreadCount] = {
     storage { MessageDataDao.findMessagesFrom(conv, lastReadTime)(_) }.future.map { msgs =>
-      msgs.acquire { _.count { m =>
-        !m.isLocal && m.convId == conv && m.time.isAfter(lastReadTime) && !m.isDeleted && !m.isSystemMessage }
+      msgs.acquire { msgs =>
+        val unread = msgs filter { m => !m.isLocal && m.convId == conv && m.time.isAfter(lastReadTime) && !m.isDeleted }
+        UnreadCount(
+          unread.count(m => !m.isSystemMessage && m.msgType != Message.Type.KNOCK),
+          unread.count(_.msgType == Message.Type.MISSED_CALL),
+          unread.count(_.msgType == Message.Type.KNOCK)
+        )
       }
     }
   }
@@ -165,7 +171,7 @@ class MessagesStorageImpl(context: Context, storage: ZmsDatabase, userId: UserId
 
   def getLastSentMessage(conv: ConvId) = msgsIndex(conv).flatMap(_.getLastSentMessage)
 
-  def unreadCount(conv: ConvId): Signal[Int] = Signal.future(msgsIndex(conv)).flatMap(_.signals.unreadCount)
+  def unreadCount(conv: ConvId): Signal[Int] = Signal.future(msgsIndex(conv)).flatMap(_.signals.unreadCount).map(_.messages)
 
   def lastRead(conv: ConvId) = Signal.future(msgsIndex(conv)).flatMap(_.signals.lastReadTime)
 

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -19,7 +19,6 @@ package com.waz.db
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
-import com.waz.api.ZmsVersion
 import com.waz.db.ZMessagingDB.{DbVersion, daos, migrations}
 import com.waz.db.migrate._
 import com.waz.model.AddressBook.ContactHashesDao
@@ -53,7 +52,7 @@ class ZMessagingDB(context: Context, dbName: String) extends DaoDB(context.getAp
 }
 
 object ZMessagingDB {
-  val DbVersion = 94
+  val DbVersion = 95
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao,
@@ -166,6 +165,10 @@ object ZMessagingDB {
     },
     Migration(93, 94) { db =>
       db.execSQL("UPDATE KeyValues SET value = 'true' WHERE key = 'should_sync_teams'")
+    },
+    Migration(94, 95) { db =>
+      db.execSQL("ALTER TABLE Conversations ADD COLUMN unread_call_count INTEGER DEFAULT 0")
+      db.execSQL("ALTER TABLE Conversations ADD COLUMN unread_ping_count INTEGER DEFAULT 0")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsListStateService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsListStateService.scala
@@ -71,7 +71,7 @@ class ConversationsListStateService(convs: ConversationStorageImpl, userPrefs: U
   private def addToCounts(c: ConversationData, sign: Int): Unit = listStats mutate { stats =>
     val sgn = math.signum(sign)
     stats.copy(
-      unreadCount = stats.unreadCount + sgn * c.unreadCount,
+      unreadCount = stats.unreadCount + sgn * c.unreadCount.messages,
       unsentCount = stats.unsentCount + sgn * c.failedCount,
       pendingCount = stats.pendingCount + (if (c.convType == ConversationType.WaitForConnection) sgn else 0)
     )


### PR DESCRIPTION
Changed `ConversationData.unreadCount` to report separate counts for messages, calls and pings. This info can be used to display conversations list more efficiently.

We should also add unread `likes` counter in similar way, but we need to better define what 'unread' actually means for likes (there can be new likes for pretty old messages).