### PR TITLE
Update AndroidAsync library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ lazy val zmessaging = project
     },
     libraryDependencies ++= Seq(
       Deps.supportV4 % Provided,
-      "com.koushikdutta.async" % "androidasync" % "2.1.8",
+      "com.koushikdutta.async" % "androidasync" % "2.2.1",
       "com.googlecode.libphonenumber" % "libphonenumber" % "7.1.1", // 7.2.x breaks protobuf
       "com.softwaremill.macwire" %% "macros" % "2.2.2" % Provided,
       "com.google.android.gms" % "play-services-base" % "11.0.0" % Provided exclude("com.android.support", "support-v4"),


### PR DESCRIPTION
It seems as though the Android Async library has been updated to handle the SNI problem we had to hack recently. 

For convenience here is a comparison of the changes to the library since the last version we imported: https://github.com/koush/AndroidAsync/compare/54c55a47e14653e62ddfe96489d25b28cb079268...master#diff-1854451d46929eb681631dc3ebfec0d6L9

Would like to test this a lot more before merging.