### PR TITLE
Retry getToken and deleteInstanceId until successful

### DIFF
--- a/tests/unit/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/push/PushTokenServiceSpec.scala
@@ -17,15 +17,18 @@
  */
 package com.waz.service.push
 
+import java.io.IOException
+
+import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.PushEnabledKey
 import com.waz.content.{AccountsStorage, GlobalPreferences}
 import com.waz.model._
-import com.waz.service.{BackendConfig, ZmsLifeCycle}
+import com.waz.service.{BackendConfig, NetworkModeService, ZmsLifeCycle}
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncServiceHandle
-import com.waz.testutils.TestGlobalPreferences
+import com.waz.testutils.{TestBackoff, TestGlobalPreferences}
 import com.waz.threading.Threading
-import com.waz.utils.events.Signal
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.utils.returning
 import com.waz.utils.wrappers.GoogleApi
 
@@ -33,10 +36,11 @@ import scala.concurrent.Future
 
 class PushTokenServiceSpec extends AndroidFreeSpec {
 
-  val google      = mock[GoogleApi]
-  val lifecycle   = mock[ZmsLifeCycle]
-  val accStorage  = mock[AccountsStorage]
-  val prefs       = new TestGlobalPreferences()
+  val google         = mock[GoogleApi]
+  val lifecycle      = mock[ZmsLifeCycle]
+  val accStorage     = mock[AccountsStorage]
+  val networkService = mock[NetworkModeService]
+  val prefs          = new TestGlobalPreferences()
 
   val sync        = mock[SyncServiceHandle]
   val accountId   = AccountId()
@@ -50,13 +54,15 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
 
   val loggedInAccounts    = Signal(Set.empty[AccountData])
 
+  val networkMode         = Signal(NetworkMode.WIFI)
+
   def accountData(accountId: AccountId, token: PushToken): AccountData = AccountData(accountId, registeredPush = Some(token))
   def accountData(accountId: AccountId, token: Option[PushToken]): AccountData = AccountData(accountId, registeredPush = token)
 
   feature("Token generation") {
     scenario("Fetches token on init if GCM available") {
       val token = PushToken("token")
-      (google.getPushToken _).expects().returning(Some(token))
+      (google.getPushToken _).expects().returning(token)
       val service = initTokenService()
 
       pushEnabled := true
@@ -72,8 +78,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       currentToken := Some(oldToken)
       googlePlayAvailable ! true
 
-      (google.getPushToken _).expects().once().returning(Some(newToken))
-
+      (google.getPushToken _).expects().once().returning(newToken)
       //This needs to be called
       (google.deleteAllPushTokens _).expects().once()
 
@@ -85,6 +90,67 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       service.eventProcessingStage(RConvId(), Vector(PushTokenRemoveEvent(oldToken, "sender", Some("client"))))
       //new token should be set
       result(service.currentToken.signal.filter(_.contains(newToken)).head)
+    }
+
+    scenario("Failing push token generation should continually retry on IOException, if there is a network connection") {
+
+      googlePlayAvailable ! true
+
+      /*
+      The network starts offline - we want the global token service to try registering once - this is because I'm not entirely sure
+      what happens inside the google play services. Maybe sometimes, a token can be available if there is no internet, no idea. Anyway,
+      try once, and then if it fails with an IOException - it's most likely because there is no connection, so then wait for the device
+      to come back online, then try again
+      */
+      networkMode ! NetworkMode.OFFLINE
+
+      val newToken = PushToken("new_token")
+      var calls = 0
+      (google.getPushToken _).expects.twice().onCall { _ =>
+        calls += 1
+        calls match {
+          case 1 => throw new IOException()
+          case 2 => newToken
+          case _ => fail("unexpected number of calls")
+        }
+      }
+
+      PushTokenService.ResetBackoff = TestBackoff()
+
+      val (global, _) = initTokenServicesWithGlobal()
+
+      global.setNewToken()
+
+      awaitAllTasks
+      calls shouldEqual 1
+      networkMode ! NetworkMode._4G
+      result(currentToken.signal.filter(_.contains(newToken)).head)
+
+    }
+
+    scenario("Multiple simultaneous calls to set token only generate one while still processing") {
+
+      googlePlayAvailable ! true
+
+      await(currentToken := Some(PushToken("oldToken")))
+
+      val token1 = PushToken("token1")
+      val token2 = PushToken("token2")
+      (google.getPushToken _).expects.returning(token1)
+      (google.getPushToken _).expects.returning(token2)
+
+      val (global, _) = initTokenServicesWithGlobal()
+
+      //it's hard to only call `setNewToken` while currently setting one for the sake of the test, so just fire two calls
+      //quickly, and hope the second one always slips in before the first one is set.
+      global.setNewToken()
+      global.setNewToken()
+      result(currentToken.signal.filter(_.contains(token1)).head)
+
+      //Repeat to make sure the future is freed up
+      global.setNewToken()
+      global.setNewToken()
+      result(currentToken.signal.filter(_.contains(token2)).head)
     }
   }
 
@@ -133,14 +199,16 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
           SyncId()
         } (Threading.Background)
       }
+      (google.getPushToken _).expects().returning(newToken)
 
       result(service.currentToken.signal.filter(_.contains(oldToken)).head)
       result(loggedInAccounts.filter(_.exists(acc => acc.id == accountId && acc.registeredPush.contains(oldToken))).head)
 
-      globalToken.setNewToken(Some(newToken)) //InstanceIDService triggers new token
+      globalToken.setNewToken() //InstanceIDService triggers new token
 
       result(service.currentToken.signal.filter(_.contains(newToken)).head)
-      result(loggedInAccounts.filter(_.exists(acc => acc.id == accountId && acc.registeredPush.contains(newToken))).head)
+
+      result(accountSignal(accountId).filter(_.registeredPush.contains(newToken)).head)
     }
 
     scenario("After user is logged out, clearing their current push token should NOT trigger new registration") {
@@ -163,7 +231,7 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       result(service.pushActive.filter(_ == false).head)
 
       /**
-        * It seems as though there can be a couple of instances of zms (and therefore the push token service) available.
+        * There can be a couple of instances of zms (and therefore the push token service) available.
         * So lets make sure we only register the account assigned to our instance. Logging in then with another account
         * shouldn't change the state of this instance.
         */
@@ -242,9 +310,10 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       val newToken = PushToken("newToken")
 
       currentToken := Some(oldToken)
+      googlePlayAvailable ! true
       await(currentToken.signal.filter(_.contains(oldToken)).head)
 
-      (google.getPushToken _).expects().once().returning(Some(newToken))
+      (google.getPushToken _).expects().once().returning(newToken)
       //This needs to be called
       (google.deleteAllPushTokens _).expects().once()
 
@@ -282,19 +351,20 @@ class PushTokenServiceSpec extends AndroidFreeSpec {
       service1
       service2
 
-      await(loggedInAccounts.filter { accs =>
-        accs.exists(acc => acc.id == accountId && acc.registeredPush.contains(token)) &&
-        accs.exists(acc => acc.id == account2.id && acc.registeredPush.contains(token))
-      }.head)
+      result(accountSignal(accountId).filter(_.registeredPush.contains(token)).head)
+      result(accountSignal(account2.id).filter(_.registeredPush.contains(token)).head)
     }
   }
+
+  def accountSignal(id: AccountId) = loggedInAccounts.map(_.find(_.id == id)).collect { case Some(acc) => acc }
 
   def initTokenService(accountId: AccountId = accountId, sync: SyncServiceHandle = sync) = initTokenServicesWithGlobal(Seq(accountId), Seq(sync))._2.head
 
   def initTokenServicesWithGlobal(accountIds: Seq[AccountId] = Seq(accountId), syncs: Seq[SyncServiceHandle] = Seq(sync)) = {
 
     (google.isGooglePlayServicesAvailable _).expects().anyNumberOfTimes().returning(googlePlayAvailable)
-    val global = new GlobalTokenService(google, prefs)
+    (networkService.networkMode _).expects.anyNumberOfTimes().returning(networkMode)
+    val global = new GlobalTokenService(google, prefs, networkService)
 
     (accStorage.signal _).expects(*).anyNumberOfTimes().onCall { id: AccountId =>
       loggedInAccounts.map(_.find(_.id == id)).collect { case Some(acc) => acc }

--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -306,6 +306,8 @@ object GlobalPreferences {
 
   lazy val GPSErrorDialogShowCount    = PrefKey[Int]("PREF_PLAY_SERVICES_ERROR_SHOW_COUNT")
 
+  lazy val ResetPushToken             = PrefKey[Boolean]("RESET_PUSH_TOKEN", customDefault = true)
+
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts              = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")
   lazy val _DarkTheme                  = PrefKey[Boolean]("DarkTheme")

--- a/zmessaging/src/main/scala/com/waz/service/BackendConfig.scala
+++ b/zmessaging/src/main/scala/com/waz/service/BackendConfig.scala
@@ -20,9 +20,9 @@ package com.waz.service
 import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.waz.service.BackendConfig.FirebaseOptions
+import com.waz.utils.LoggedTry
 import com.waz.utils.wrappers.URI
-
-import scala.util.Try
+import com.waz.ZLog.ImplicitTag._
 
 case class BackendConfig(baseUrl: URI, websocketUrl: String, firebaseOptions: FirebaseOptions, environment: String) {
   val pushSenderId = firebaseOptions.pushSenderId
@@ -32,7 +32,7 @@ object BackendConfig {
 
   case class FirebaseOptions(pushSenderId: String, appId: String, apiKey: String) {
 
-    def apply(context: Context) = Try {
+    def apply(context: Context) = LoggedTry {
       FirebaseApp.initializeApp(context, new com.google.firebase.FirebaseOptions.Builder()
         .setApplicationId(appId)
         .setApiKey(apiKey)

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -90,7 +90,9 @@ class GlobalModuleImpl(val context: AContext, val backend: BackendConfig) extend
   val prefs:                    GlobalPreferences                = GlobalPreferences(context)
   //trigger initialization of Firebase in onCreate - should prevent problems with Firebase setup
   val googleApi:                GoogleApi                        = new GoogleApiImpl(context, backend, prefs)
-  lazy val tokenService:        GlobalTokenService               = wire[GlobalTokenService]
+  val lifecycle:                ZmsLifeCycle                     = new ZmsLifeCycleImpl()
+  val network:                  DefaultNetworkModeService        = wire[DefaultNetworkModeService]
+  val tokenService:             GlobalTokenService               = wire[GlobalTokenService]
 
   lazy val notifications:       GlobalNotificationsService       = wire[GlobalNotificationsService]
   lazy val calling:             GlobalCallingService             = new GlobalCallingService
@@ -104,7 +106,6 @@ class GlobalModuleImpl(val context: AContext, val backend: BackendConfig) extend
   lazy val trimmingLruCache:    Cache[Key, Entry]                = MemoryImageCache.newTrimmingLru(context)
   lazy val imageCache:          MemoryImageCache                 = wire[MemoryImageCache]
 
-  lazy val network                                               = wire[DefaultNetworkModeService]
   lazy val phoneNumbers:        PhoneNumberService               = wire[PhoneNumberServiceImpl]
   lazy val timeouts                                              = wire[Timeouts]
   lazy val permissions:         PermissionsService               = wire[PermissionsService]
@@ -147,7 +148,7 @@ class GlobalModuleImpl(val context: AContext, val backend: BackendConfig) extend
   lazy val flowmanager: DefaultFlowManagerService                = wire[DefaultFlowManagerService]
   lazy val mediaManager                                          = wire[DefaultMediaManagerService]
 
-  val lifecycle: ZmsLifeCycle = new ZmsLifeCycleImpl()
+
 
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -90,7 +90,7 @@ class GlobalModuleImpl(val context: AContext, val backend: BackendConfig) extend
   val prefs:                    GlobalPreferences                = GlobalPreferences(context)
   //trigger initialization of Firebase in onCreate - should prevent problems with Firebase setup
   val googleApi:                GoogleApi                        = new GoogleApiImpl(context, backend, prefs)
-  val tokenService:             GlobalTokenService               = wire[GlobalTokenService]
+  lazy val tokenService:        GlobalTokenService               = wire[GlobalTokenService]
 
   lazy val notifications:       GlobalNotificationsService       = wire[GlobalNotificationsService]
   lazy val calling:             GlobalCallingService             = new GlobalCallingService

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -360,7 +360,6 @@ object ZMessaging { self =>
 
       globalReady.success(_global)
       accsReady.success(_accounts)
-
       Threading.Background { Locales.preloadTransliterator(); ContentSearchQuery.preloadTransliteration(); } // "preload"... - this should be very fast, normally, but slows down to 10 to 20 seconds when multidexed...
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/FlowManagerService.scala
@@ -40,7 +40,7 @@ trait FlowManagerService {
 
 class DefaultFlowManagerService(context:      Context,
                                 globalPrefs:  GlobalPreferences,
-                                network:      DefaultNetworkModeService) extends FlowManagerService {
+                                network:      NetworkModeService) extends FlowManagerService {
   import FlowManagerService._
 
   val avsAudioTestFlag: Long = 1 << 1

--- a/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushTokenService.scala
@@ -165,8 +165,8 @@ class GlobalTokenService(googleApi: GoogleApi,
     }
 
     if (settingToken.isCompleted) {
-      attempts = 0
       settingToken = for {
+        _ <- dispatcher(attempts = 0)
         t <- generateToken().map(Some(_))
         _ <- CancellableFuture.lift(currentToken := t)
       } yield {}

--- a/zmessaging/src/main/scala/com/waz/utils/wrappers/GoogleApi.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/wrappers/GoogleApi.scala
@@ -22,7 +22,6 @@ import java.io.IOException
 import android.app.Activity
 import com.google.android.gms.common.ConnectionResult._
 import com.google.android.gms.common.GoogleApiAvailability
-import com.google.firebase.FirebaseApp
 import com.google.firebase.iid.FirebaseInstanceId
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.{info, warn}

--- a/zmessaging/src/main/scala/com/waz/utils/wrappers/GoogleApi.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/wrappers/GoogleApi.scala
@@ -17,9 +17,12 @@
  */
 package com.waz.utils.wrappers
 
+import java.io.IOException
+
 import android.app.Activity
 import com.google.android.gms.common.ConnectionResult._
-import com.google.android.gms.common.{ConnectionResult, GoogleApiAvailability}
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.firebase.FirebaseApp
 import com.google.firebase.iid.FirebaseInstanceId
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.{info, warn}
@@ -27,7 +30,6 @@ import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.GPSErrorDialogShowCount
 import com.waz.model.PushToken
 import com.waz.service.BackendConfig
-import com.waz.utils.LoggedTry
 import com.waz.utils.events.Signal
 
 import scala.util.Try
@@ -36,7 +38,7 @@ trait GoogleApi {
   def isGooglePlayServicesAvailable: Signal[Boolean]
   def checkGooglePlayServicesAvailable(activity: Activity): Unit
   def onActivityResult(requestCode: Int, resultCode: Int): Unit
-  def getPushToken: Option[PushToken]
+  def getPushToken: PushToken
   def deleteAllPushTokens(): Unit
 }
 
@@ -74,11 +76,13 @@ class GoogleApiImpl(context: Context, beConfig: BackendConfig, prefs: GlobalPref
     case _ => //
   }
 
-  override def getPushToken =
-    firebaseApp.flatMap(app => LoggedTry(FirebaseInstanceId.getInstance(app).getToken(beConfig.pushSenderId, "FCM")).toOption.map(PushToken(_)))
+  @throws(classOf[IOException])
+  override def getPushToken = withFcmInstanceId(id => PushToken(id.getToken(beConfig.pushSenderId, "FCM")))
 
-  override def deleteAllPushTokens(): Unit =
-    firebaseApp.foreach(app => LoggedTry(FirebaseInstanceId.getInstance(app).deleteInstanceId()))
+  @throws(classOf[IOException])
+  override def deleteAllPushTokens(): Unit = withFcmInstanceId(_.deleteInstanceId())
+
+  private def withFcmInstanceId[A](f: FirebaseInstanceId => A): A = firebaseApp.fold(throw new IllegalStateException("No Firebase app instance available"))(app => f(FirebaseInstanceId.getInstance(app)))
 }
 
 object GoogleApi {

--- a/zmessaging/src/main/scala/com/waz/zms/FCMHandlerService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/FCMHandlerService.scala
@@ -127,7 +127,9 @@ object FCMHandlerService {
         case NoticeNotification(nId) =>
           addNotificationToProcess(nId)
 
-        case _ => warn(s"Unexpected notification"); Future.successful({})
+        case _ =>
+          warn(s"Unexpected notification, sync anyway")
+          push.syncHistory()
       }
     }
 
@@ -168,8 +170,8 @@ object FCMHandlerService {
 
   object PlainNotification {
     def unapply(data: Map[String, String]): Option[PushNotification] =
-      data.get(DataKey) match {
-        case Some(content) => LoggedTry(PushNotification.NotificationDecoder(new JSONObject(content))).toOption
+      (data.get(TypeKey), data.get(DataKey)) match {
+        case (Some("plain"), Some(content)) => LoggedTry(PushNotification.NotificationDecoder(new JSONObject(content))).toOption
         case _ => None
       }
   }

--- a/zmessaging/src/main/scala/com/waz/zms/InstanceIdListenerService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/InstanceIdListenerService.scala
@@ -24,11 +24,9 @@ import com.waz.service.ZMessaging
 
 class InstanceIdListenerService extends FirebaseInstanceIdService with ZMessagingService {
 
-
   override def onTokenRefresh(): Unit = {
-    val token = Option(ZMessaging.currentGlobal).flatMap(_.googleApi.getPushToken)
-    info(s"FCM: onTokenRefresh() called. Got token: $token")
-    Option(ZMessaging.currentGlobal).foreach(_.tokenService.setNewToken(token))
+    info(s"FCM: onTokenRefresh()")
+    Option(ZMessaging.currentGlobal).foreach(_.tokenService.setNewToken())
   }
 
 }

--- a/zmessaging/src/main/scala/com/waz/zms/InstanceIdListenerService.scala
+++ b/zmessaging/src/main/scala/com/waz/zms/InstanceIdListenerService.scala
@@ -21,12 +21,15 @@ import com.google.firebase.iid.FirebaseInstanceIdService
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog._
 import com.waz.service.ZMessaging
+import com.waz.threading.Threading
 
 class InstanceIdListenerService extends FirebaseInstanceIdService with ZMessagingService {
 
   override def onTokenRefresh(): Unit = {
-    info(s"FCM: onTokenRefresh()")
-    Option(ZMessaging.currentGlobal).foreach(_.tokenService.setNewToken())
+    ZMessaging.globalModule.map {
+      info(s"FCM: onTokenRefresh()")
+      _.tokenService.setNewToken()
+    } (Threading.Background)
   }
 
 }


### PR DESCRIPTION
Should ensure that `getToken` and `deleteInstanceId` are continually retried until successful in case of IOExceptions from `FCMInstanceId`