### PR TITLE
[AN-5845] fix for availability messages being counted as unread

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -149,7 +149,7 @@ class MessagesStorageImpl(context: Context,
   def countUnread(conv: ConvId, lastReadTime: Instant): Future[UnreadCount] = {
     storage { MessageDataDao.findMessagesFrom(conv, lastReadTime)(_) }.future.map { msgs =>
       msgs.acquire { msgs =>
-        val unread = msgs.filter { m => !m.isLocal && m.convId == conv && m.time.isAfter(lastReadTime) && !m.isDeleted && m.userId != userId } .toVector
+        val unread = msgs.filter { m => !m.isLocal && m.convId == conv && m.time.isAfter(lastReadTime) && !m.isDeleted && m.userId != userId && m.msgType != Message.Type.UNKNOWN } .toVector
         UnreadCount(
           unread.count(m => !m.isSystemMessage && m.msgType != Message.Type.KNOCK),
           unread.count(_.msgType == Message.Type.MISSED_CALL),


### PR DESCRIPTION
This is a quick fix for the unread dot: If an availability status is received by an old client, it is counted as a message of the type UNKNOWN. It does not appear anywhere, but is still counted as unread.

Here I just added one more check to counting unread messages - if the message is of the type UNKNOWN, it's not counted. (Status changes are already filtered out in the new clients, so they are not counted at all). We should also implement to clear all UNKNOWN messages already in the database.

APK for testing: https://drive.google.com/open?id=1rNBHVZ7Kn7BtWfmOSGc4-o-gVz3CkpQO 