### PR TITLE
[AN-5752] Fix bounds checking in LzwDecoder

### DIFF
--- a/zmessaging/src/main/jni/Android.mk
+++ b/zmessaging/src/main/jni/Android.mk
@@ -2,10 +2,10 @@ TOP_DIR := $(call my-dir)
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := lzw-decoder
-LOCAL_SRC_FILES := LzwDecoder.cpp
-LOCAL_LDLIBS    := -llog
-LOCAL_CFLAGS    := -O2 -Wall -pedantic -Wno-variadic-macros -fstack-protector-all
+LOCAL_MODULE       := lzw-decoder
+LOCAL_SRC_FILES    := LzwDecoder.cpp
+LOCAL_LDLIBS       := -llog
+LOCAL_CFLAGS       := -O2 -Wall -pedantic -Wno-variadic-macros -fstack-protector-all
 include $(BUILD_SHARED_LIBRARY)
 
 include $(CLEAR_VARS)

--- a/zmessaging/src/main/jni/LzwDecoder.h
+++ b/zmessaging/src/main/jni/LzwDecoder.h
@@ -26,7 +26,7 @@ typedef unsigned char byte;
 class LzwDecoder {
 
     public:
-        LzwDecoder(byte* image, int* pixels, int* colors, int width, int height);
+        LzwDecoder(byte* image, int* pixels, int* colors, int width, int height, int* failed);
 	~LzwDecoder();
 
         void clear(int x, int y, int w, int h, int color);
@@ -50,8 +50,8 @@ class LzwDecoder {
 extern "C" {
 #endif
 
-JNIEXPORT long JNICALL Java_com_waz_bitmap_gif_LzwDecoder_init(JNIEnv *env, jobject obj, jobject image, jobject pixels, jobject colors, jint width, jint height) {
-    return (long) (new LzwDecoder((byte*) env->GetDirectBufferAddress(image), (int*) env->GetDirectBufferAddress(pixels), (int*) env->GetDirectBufferAddress(colors), width, height));
+JNIEXPORT long JNICALL Java_com_waz_bitmap_gif_LzwDecoder_init(JNIEnv *env, jobject obj, jobject image, jobject pixels, jobject colors, jint width, jint height, jobject failed) {
+    return (long) (new LzwDecoder((byte*) env->GetDirectBufferAddress(image), (int*) env->GetDirectBufferAddress(pixels), (int*) env->GetDirectBufferAddress(colors), width, height, (int*) env->GetDirectBufferAddress(failed)));
 }
 
 JNIEXPORT void JNICALL Java_com_waz_bitmap_gif_LzwDecoder_destroy(JNIEnv *env, jobject obj, jlong decoder) {

--- a/zmessaging/src/main/scala/com/waz/bitmap/gif/LzwDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/gif/LzwDecoder.scala
@@ -45,7 +45,14 @@ class LzwDecoder(gif: Gif) {
   // temp, used only when frame disposal is set to PREVIOUS
   lazy val pixelsSwap = ByteBuffer.allocateDirect(imageWidth * imageHeight * 4).order(ByteOrder.BIG_ENDIAN).asIntBuffer()
 
-  val decoder = init(inputData, pixels, colors, imageWidth, imageHeight)
+  val failed = ByteBuffer.allocateDirect(4).asIntBuffer()
+
+  val decoder = init(inputData, pixels, colors, imageWidth, imageHeight, failed)
+
+  if(failed.get(0) == -1) {
+    throw new IllegalArgumentException("Invalid parameters given to decoder")
+  }
+
   private var destroyed = false
 
   def destroy(): Unit = {
@@ -104,7 +111,7 @@ class LzwDecoder(gif: Gif) {
 
   @native protected def clear(decoder: Long, x: Int, y: Int, w: Int, h: Int, color: Int): Unit
   @native protected def decode(decoder: Long, x: Int, y: Int, w: Int, h: Int, inputSize: Int, transIndex: Int, bgColor: Int, interlace: Boolean, transparency: Boolean): Unit
-  @native protected def init(image: ByteBuffer, pixels: IntBuffer, colors: IntBuffer, width: Int, height: Int): Long
+  @native protected def init(image: ByteBuffer, pixels: IntBuffer, colors: IntBuffer, width: Int, height: Int, failed: IntBuffer): Long
   @native protected def destroy(decoder: Long): Unit
 }
 


### PR DESCRIPTION
This PR adds some missing bounds checking as pointed out in the security review.

Another approach to this would be changing the types from signed to unsigned, but this seemed simpler. @marcoconti83 can you take a look at this? My C++ is pretty rusty.

For the 3rd and final issue stated in the report, the review states that values other than 31 could cause overflow, but I couldn't replicate this in testing, so I think this is erroneous. `clear = 0` should never cause the check to pass. However, overflow/underflow is one of those super tricky things so I'd appreciate some other eyes on this.