### PR TITLE
Improve performance of creating large conversations and syncing users

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -40,7 +40,7 @@ class UsersClient(netClient: ZNetClient) {
 
   def loadUsers(ids: Seq[UserId]): ErrorOrResponse[IndexedSeq[UserInfo]] =
     if (ids.isEmpty) CancellableFuture.successful(Right(Vector())) else {
-      CancellableFuture.lift(Future.traverse(ids.grouped(IdsCountThreshold).toSeq) { ids => // split up every 45 user ids so that the request uri remains short enough
+      CancellableFuture.lift(Future.traverse(ids.grouped(IdsCountThreshold).toSeq) { ids => // split up every IdsCountThreshold user ids so that the request uri remains short enough (ca. 2400 bytes for 64 ids)
         netClient(Request.Get(usersPath(ids))) map {
           case Response(SuccessHttpStatus(), UserResponseExtractor(users@_*), _) => users
           case Response(status, ErrorResponse(code, msg, label), _) =>
@@ -83,7 +83,7 @@ object UsersClient {
   val SelfPath = "/self"
   val ConnectionsPath = "/self/connections"
   val SearchablePath = "/self/searchable"
-  val IdsCountThreshold = 45
+  val IdsCountThreshold = 64
 
   def usersPath(ids: Seq[UserId]) = Request.query(UsersPath, "ids" -> ids.mkString(","))
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -40,7 +40,7 @@ import scala.concurrent.Future
 import scala.util.control.NonFatal
 
 object ConversationsSyncHandler {
-  val PostMembersLimit = 64
+  val PostMembersLimit = 256
 }
 
 class ConversationsSyncHandler(selfUserId:          UserId,

--- a/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/AsyncClient.scala
@@ -87,7 +87,7 @@ class AsyncClientImpl(bodyDecoder: ResponseBodyDecoder = DefaultResponseBodyDeco
             p.tryFailure(if (cancelled) CancellableFuture.DefaultCancelException else ex)
           } else {
             val networkActivityCallback = () => lastNetworkActivity = System.currentTimeMillis
-            debug(s"got connection response for request: ${request.absoluteUri}")
+            debug(s"got connection response ${response.message()} for request: ${request.absoluteUri}")
             val future = responseWorker.processResponse(request.absoluteUri, response, request.decoder.getOrElse(bodyDecoder), request.downloadCallback, networkActivityCallback)
             p.tryCompleteWith(future)
 

--- a/zmessaging/src/main/scala/com/waz/znet/HttpResponse.scala
+++ b/zmessaging/src/main/scala/com/waz/znet/HttpResponse.scala
@@ -97,7 +97,7 @@ class ResponseImplWorker extends ResponseWorker {
     val contentLength = response.headers("Content-Length").map(_.toInt).getOrElse(-1)
     val contentType = response.headers("Content-Type").getOrElse("")
 
-    debug(s"got connection response for $requestUri, status: '$httpStatus', length: '$contentLength', type: '$contentType'")
+    debug(s"got connection response, status: '$httpStatus', length: '$contentLength', type: '$contentType', for request $requestUri")
 
     progressCallback foreach (_(ProgressIndicator.ProgressData(0L, contentLength, api.ProgressIndicator.State.RUNNING)))
     if (contentLength == 0) {


### PR DESCRIPTION
The most important change here is simply increasing the limit for user ids sent in the "create conversation" request. It's now set to 256 which means that we practically won't use the "add members to the conversation" request at this point, as 256 is the conversation size limit anyway. 

Also, in merging sync jobs, I changed the `forall` check to `subsetOf` - it does the same but is optimized for hash sets, so we can expect a bit better performance.

The limit for the number of user ids in one sync request was increased from 45 to 64. It doesn't do much, but again, it might improve performance a little (fewer requests). Increasing this limit more than that results in a failure response (uri too large). 

~~I created methods `syncUsers` in `UserService`, and `take(number: Int)` in `StorageDao` and `CachedStorage` - they can be used in tests.~~