### PR TITLE
Fix a 1:1 conv with bot allowing adding other participants

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -36,7 +36,7 @@ import com.waz.sync.client.ConversationsClient.ConversationResponse
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.threading.Threading
 import com.waz.utils._
-import com.waz.utils.events.EventContext
+import com.waz.utils.events.{EventContext, Signal}
 import com.waz.sync.client.ErrorOr
 
 import scala.collection.{breakOut, mutable}
@@ -53,6 +53,7 @@ trait ConversationsService {
   def setConversationArchived(id: ConvId, archived: Boolean): Future[Option[ConversationData]]
   def forceNameUpdate(id: ConvId): Future[Option[(ConversationData, ConversationData)]]
   def onMemberAddFailed(conv: ConvId, users: Set[UserId], error: Option[ErrorType], resp: ErrorResponse): Future[Unit]
+  def groupConversation(convId: ConvId): Signal[Boolean]
   def isGroupConversation(convId: ConvId): Future[Boolean]
   def isWithService(convId: ConvId): Future[Boolean]
 
@@ -306,14 +307,14 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     _ <- messages.removeLocalMemberJoinMessage(conv, users)
   } yield ()
 
-  def isGroupConversation(convId: ConvId) =
-    for {
-      Some(conv) <- convsStorage.get(convId)
-      res <-
-        if (conv.convType != ConversationType.Group) Future.successful(false)
-        else if (conv.name.isDefined || conv.team.isEmpty) Future.successful(true)
-        else membersStorage.getActiveUsers(convId).map(ms => !(ms.contains(selfUserId) && ms.size == 2))
-    } yield res
+  def groupConversation(convId: ConvId) =
+    convsStorage.signal(convId).flatMap { conv =>
+      if (conv.convType != ConversationType.Group) Signal.const(false)
+      else if (conv.name.isDefined || conv.team.isEmpty) Signal.const(true)
+      else membersStorage.activeMembers(convId).map(ms => !(ms.contains(selfUserId) && ms.size <= 2))
+    }
+
+  def isGroupConversation(convId: ConvId) = groupConversation(convId).head
 
   def isWithService(convId: ConvId) =
     membersStorage.getActiveUsers(convId)


### PR DESCRIPTION
When creating a conv with a bot, the app first creates a conv with only the user and then adds the bot to it. But until now the check if the conv is a group one was at one point checking if the number of users in the conv is exactly 2. 

I also noticed that in most cases the original `isGroupConversation` method, which returns a future, is immediately wrapped in a signal. So, I created a `groupConversation` method, which returns a signal and can be used without that intermediate step. 
Actually, this bug shows that the one-to-one/group status of the conversation might change during initialization and only then is stable, so using a signal instead of a future might be safer.