### PR TITLE
fix: corrects the way we update remoteMap in ConversationStorage

### DIFF
--- a/tests/unit/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -112,7 +112,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         )
       }
 
-      (convsStorage.getByRemoteIds2 _).expects(*).returning(Future.successful(Map.empty))
+      (convsStorage.getByRemoteIds2 _).expects(*).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
         Future.successful(keys.map(id => updater(id, None)).toSet)
@@ -155,7 +155,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
 
       (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(SyncId()))
       (usersStorage.listAll _).expects(*).returning(Future.successful(Vector(otherUser)))
-      (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).returning(Future.successful(Map.empty))
+      (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
       (convsStorage.updateOrCreateAll2 _).expects(*, *).onCall { (keys: Iterable[ConvId], updater: ((ConvId, Option[ConversationData]) => ConversationData)) =>
         Future.successful(keys.map {

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -276,6 +276,9 @@ class ConnectionServiceImpl(selfUserId:      UserId,
             remotes(remoteId).id -> convIdForUser(toUser)
         }.toMap)
 
+        // remotes need to be refreshed after updating local ids
+        remotes <- convsStorage.getByRemoteIds2(convsInfo.flatMap(_.remoteId).toSet)
+
         result <- convsStorage.updateOrCreateAll2(newConvs.keys, {
           case (cId, Some(conv)) =>
             remoteIds(cId).fold(conv)(rId => remotes.getOrElse(rId, conv.copy(remoteId = rId)))

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -213,4 +213,5 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
 
   override def updateAccessMode(id: ConvId, access: Set[Access], accessRole: Option[AccessRole], link: Option[ConversationData.Link] = None) =
     storage.update(id, conv => conv.copy(access = access, accessRole = accessRole, link = if (!access.contains(Access.CODE)) None else link.orElse(conv.link)))
+
 }


### PR DESCRIPTION
When the user puts a device in the airplane mode or switched it off, and then created a new conversation (or just a connection request) using another device, and then switched on the first device, the syncing resulted in duplicated entries in the conversations table.

Note: This commit fixes the bug, but does not correct the already duplicated entries. For that a method introduced in another commit (63bdf03), `ConversationsContentUpdater.fixDuplicatedConversations`, has to be used.

fixes: https://github.com/wireapp/android-project/issues/260