### PR TITLE
feat: new Mentions

### DIFF
--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -26,7 +26,7 @@ object SharedSettings {
     lazy val avs = "com.wire" % "avs" % avsVersion
     lazy val avsAudio = "com.wire.avs" % "audio-notifications" % audioVersion
     lazy val cryptobox = "com.wire" % "cryptobox-android" % cryptoboxVersion
-    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.20.0"
+    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.21.2"
     lazy val backendApi = "com.wire" % "backend-api-proto" % "1.1"
     lazy val supportV4 = "com.android.support" % "support-v4" % supportLibVersion
     lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.5" % Test

--- a/project/SharedSettings.scala
+++ b/project/SharedSettings.scala
@@ -26,7 +26,7 @@ object SharedSettings {
     lazy val avs = "com.wire" % "avs" % avsVersion
     lazy val avsAudio = "com.wire.avs" % "audio-notifications" % audioVersion
     lazy val cryptobox = "com.wire" % "cryptobox-android" % cryptoboxVersion
-    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.21.2"
+    lazy val genericMessage = "com.wire" % "generic-message-proto" % "1.21.6"
     lazy val backendApi = "com.wire" % "backend-api-proto" % "1.1"
     lazy val supportV4 = "com.android.support" % "support-v4" % supportLibVersion
     lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.5" % Test

--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -118,8 +118,14 @@ object Generators {
   implicit lazy val arbMessageContent: Arbitrary[MessageContent] = Arbitrary(resultOf(MessageContent))
   implicit lazy val arbGenericMessage: Arbitrary[GenericMessage] = Arbitrary(for {
     id <- arbitrary[Uid]
-    content = Text("test", Map.empty, Nil) // TODO: implement actual generator
+    content = Text("test", Nil, Nil) // TODO: implement actual generator
   } yield GenericMessage(id, content))
+
+  implicit lazy val arbMention: Arbitrary[Mention] = Arbitrary(for {
+    id     <- optGen(arbitrary[UserId])
+    start  <- posNum[Int]
+    offset <- chooseNum(1,10)
+  } yield Mention(id, start, start + offset))
 
   implicit lazy val arbMessageData: Arbitrary[MessageData] = Arbitrary(resultOf(MessageData))
 

--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -155,7 +155,7 @@ object Generators {
   implicit lazy val arbAssetToken: Arbitrary[AssetToken] = Arbitrary(resultOf(AssetToken))
   implicit lazy val arbOtrKey: Arbitrary[AESKey] = Arbitrary(sideEffect(AESKey()))
   implicit lazy val arbSha256: Arbitrary[Sha256] = Arbitrary(arbitrary[Array[Byte]].map(b => Sha256(sha2(b))))
-  implicit lazy val arbUnreadCount: Arbitrary[UnreadCount] = Arbitrary(for (n <- chooseNum(0,1000); c <- chooseNum(0,1000); p <- chooseNum(0,1000)) yield UnreadCount(n, c, p))
+  implicit lazy val arbUnreadCount: Arbitrary[UnreadCount] = Arbitrary(for (n <- chooseNum(0,1000); c <- chooseNum(0,1000); p <- chooseNum(0,1000); m <- chooseNum(0,1000)) yield UnreadCount(n, c, p, m))
 
   object MediaAssets {
     implicit lazy val arbArtistData: Arbitrary[ArtistData] = Arbitrary(resultOf(ArtistData))

--- a/tests/unit/src/test/scala/com/waz/Generators.scala
+++ b/tests/unit/src/test/scala/com/waz/Generators.scala
@@ -124,8 +124,8 @@ object Generators {
   implicit lazy val arbMention: Arbitrary[Mention] = Arbitrary(for {
     id     <- optGen(arbitrary[UserId])
     start  <- posNum[Int]
-    offset <- chooseNum(1,10)
-  } yield Mention(id, start, start + offset))
+    length <- chooseNum(1,10)
+  } yield Mention(id, start, length))
 
   implicit lazy val arbMessageData: Arbitrary[MessageData] = Arbitrary(resultOf(MessageData))
 

--- a/tests/unit/src/test/scala/com/waz/model/MessageDataDaoSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/MessageDataDaoSpec.scala
@@ -40,12 +40,12 @@ class MessageDataDaoSpec extends AndroidFreeSpec {
     val simpleMessageContent = MessageContent(Message.Part.Type.TEXT, "text content")
     val simpleMessageJson = Json("type" -> "Text", "content" -> "text content")
 
-    val contentWithMention = MessageContent(Message.Part.Type.TEXT, "text content @user", mentions = Seq(Mention(Some(knockUser), 13, 18)))
+    val contentWithMention = MessageContent(Message.Part.Type.TEXT, "text content @user", mentions = Seq(Mention(Some(knockUser), 13, 5)))
     val jsonWithMention =
       Json(
         "type" -> "Text",
         "content" -> "text content @user",
-        "mentions" -> Json(Seq(Map("user_id" -> knockUser.str, "start" -> 13, "end" -> 18)))
+        "mentions" -> Json(Seq(Map("user_id" -> knockUser.str, "start" -> 13, "length" -> 5)))
       )
 
     val complexMesageContent =
@@ -99,6 +99,7 @@ class MessageDataDaoSpec extends AndroidFreeSpec {
 
     scenario("Decode mentions") {
       val encoded = JsonEncoder.encode(contentWithMention)
+      println(encoded.toString)
       val decoded = JsonDecoder.decode[MessageContent](encoded.toString)
       decoded shouldEqual contentWithMention
     }

--- a/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
@@ -29,7 +29,7 @@ class MessageDataSpec extends AndroidFreeSpec {
     scenario("Wrap empty message in a text content") {
       val expected = MessageContent(Message.Part.Type.TEXT_EMOJI_ONLY, "") // TODO: empty content should return TEXT, not TEXT_EMOJI_ONLY
 
-      val result = MessageData.messageContent("", Nil, isSendingMessage = false)
+      val result = MessageData.messageContent("", Nil)
       result._1 shouldEqual Message.Type.TEXT
       result._2 shouldEqual Seq(expected)
     }
@@ -41,7 +41,7 @@ class MessageDataSpec extends AndroidFreeSpec {
 
       val expected = MessageContent(Message.Part.Type.TEXT, text, mentions = Seq(mention))
 
-      val result = MessageData.messageContent(text, Seq(mention), isSendingMessage = true)
+      val result = MessageData.messageContent(text, Seq(mention))
       result._1 shouldEqual Message.Type.TEXT
       result._2 shouldEqual Seq(expected)
     }
@@ -54,7 +54,7 @@ class MessageDataSpec extends AndroidFreeSpec {
 
       val expected = MessageContent(Message.Part.Type.TEXT, text, mentions = mentions)
 
-      val result = MessageData.messageContent(text, mentions, isSendingMessage = true)
+      val result = MessageData.messageContent(text, mentions)
       result._1 shouldEqual Message.Type.TEXT
       result._2 shouldEqual Seq(expected)
     }
@@ -72,7 +72,7 @@ class MessageDataSpec extends AndroidFreeSpec {
         MessageContent(Message.Part.Type.TEXT, "aaa @user2 aaa", mentions = Seq(mentions(1)))
       )
 
-      val result = MessageData.messageContent(text, mentions, isSendingMessage = true, links = Seq(linkPreview), weblinkEnabled = true)
+      val result = MessageData.messageContent(text, mentions, links = Seq(linkPreview), weblinkEnabled = true)
 
       result._1 shouldEqual Message.Type.RICH_MEDIA
       result._2 shouldEqual expected

--- a/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
@@ -67,9 +67,9 @@ class MessageDataSpec extends AndroidFreeSpec {
       val linkPreview = LinkPreview(URI.parse("http://bit.ly"), 15)
 
       val expected = List(
-        MessageContent(Message.Part.Type.TEXT, "Aaa @user1 aaa", mentions = Seq(mentions(0))),
+        MessageContent(Message.Part.Type.TEXT, "Aaa @user1 aaa ", mentions = Seq(mentions(0))),
         MessageContent(Message.Part.Type.WEB_LINK, "http://bit.ly", mentions = Nil),
-        MessageContent(Message.Part.Type.TEXT, "aaa @user2 aaa", mentions = Seq(mentions(1)))
+        MessageContent(Message.Part.Type.TEXT, " aaa @user2 aaa", mentions = Seq(mentions(1)))
       )
 
       val result = MessageData.messageContent(text, mentions, links = Seq(linkPreview), weblinkEnabled = true)
@@ -89,7 +89,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val mention = Mention(Some(UserId()), start, handle.length)
       val mentions = Seq(mention)
       println(s"mentions: $mentions")
-      val adjusted = MessageData.adjustMentions(text, mentions, isSendingMessage = true)
+      val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
       println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }
@@ -102,7 +102,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val mention2 = Mention(Some(UserId()), text.indexOf(handle2), handle2.length)
       val mentions = Seq(mention1, mention2)
       println(s"mentions: $mentions")
-      val adjusted = MessageData.adjustMentions(text, mentions, isSendingMessage = true)
+      val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
       println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }
@@ -114,7 +114,7 @@ class MessageDataSpec extends AndroidFreeSpec {
       val mention = Mention(Some(UserId()), start, handle.length)
       val mentions = Seq(mention)
       println(s"mentions: $mentions")
-      val adjusted = MessageData.adjustMentions(text, mentions, isSendingMessage = true)
+      val adjusted = MessageData.adjustMentions(text, mentions, forSending = true)
       println(s"adjusted: $adjusted")
       adjusted shouldEqual mentions
     }

--- a/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/model/MessageDataSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+import com.waz.api.Message
+import com.waz.model.GenericContent.LinkPreview
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.wrappers.URI
+import org.scalatest._
+
+class MessageDataSpec extends AndroidFreeSpec {
+  feature("Message content") {
+    scenario("Wrap empty message in a text content") {
+      val expected = MessageContent(Message.Part.Type.TEXT_EMOJI_ONLY, "") // TODO: empty content should return TEXT, not TEXT_EMOJI_ONLY
+
+      val result = MessageData.messageContent("")
+      result._1 shouldEqual Message.Type.TEXT
+      result._2 shouldEqual Seq(expected)
+    }
+
+    scenario("Insert a mention in the content") {
+      val userId = UserId()
+      val text = "Aaa @user aaa"
+      val mention = Mention(Some(userId), 4, 8)
+
+      val expected = MessageContent(Message.Part.Type.TEXT, text, mentions = Seq(mention))
+
+      val result = MessageData.messageContent(text, Seq(mention))
+      result._1 shouldEqual Message.Type.TEXT
+      result._2 shouldEqual Seq(expected)
+    }
+
+    scenario("Insert two mentions in the content") {
+      val userId1 = UserId()
+      val userId2 = UserId()
+      val text = "Aaa @user1 aaa @user2 aaa"
+      val mentions = Seq(Mention(Some(userId1), 4, 9), Mention(Some(userId2), 10, 15))
+
+      val expected = MessageContent(Message.Part.Type.TEXT, text, mentions = mentions)
+
+      val result = MessageData.messageContent(text, mentions)
+      result._1 shouldEqual Message.Type.TEXT
+      result._2 shouldEqual Seq(expected)
+    }
+
+    scenario("Insert two mentions and a link") {
+      val userId1 = UserId()
+      val userId2 = UserId()
+      val text = "Aaa @user1 aaa http://bit.ly aaa @user2 aaa"
+      val mentions = Seq(Mention(Some(userId1), 4, 9), Mention(Some(userId2), 32, 37))
+      val linkPreview = LinkPreview(URI.parse("http://bit.ly"), 15)
+
+      val expected = List(
+        MessageContent(Message.Part.Type.TEXT, "Aaa @user1 aaa", mentions = Seq(mentions(0))),
+        MessageContent(Message.Part.Type.WEB_LINK, "http://bit.ly", mentions = Nil),
+        MessageContent(Message.Part.Type.TEXT, "aaa @user2 aaa", mentions = Seq(mentions(1)))
+      )
+
+      val result = MessageData.messageContent(text, mentions, links = Seq(linkPreview), weblinkEnabled = true)
+
+      result._1 shouldEqual Message.Type.RICH_MEDIA
+      result._2 shouldEqual expected
+    }
+  }
+}

--- a/tests/unit/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -69,14 +69,14 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside {
       val processor = getProcessor
       inside(result(processor.processEvents(conv, Seq(event))).head) {
         case m =>
-          m.msgType       shouldEqual TEXT
-          m.convId        shouldEqual conv.id
-          m.userId        shouldEqual sender
-          m.content       shouldEqual MessageData.textContent(text)
-          m.time          shouldEqual event.time
-          m.localTime     shouldEqual event.localTime
-          m.state         shouldEqual Status.SENT
-          m.protos        shouldEqual Seq(event.asInstanceOf[GenericMessageEvent].content)
+          m.msgType              shouldEqual TEXT
+          m.convId               shouldEqual conv.id
+          m.userId               shouldEqual sender
+          m.content              shouldEqual MessageData.textContent(text)
+          m.time                 shouldEqual event.time
+          m.localTime            shouldEqual event.localTime
+          m.state                shouldEqual Status.SENT
+          m.protos.head.toString shouldEqual event.asInstanceOf[GenericMessageEvent].content.toString
       }
     }
 

--- a/tests/unit/src/test/scala/com/waz/service/conversation/MessageSendingSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/conversation/MessageSendingSpec.scala
@@ -88,7 +88,7 @@ class MessageSendingSpec extends AndroidFreeSpec { test =>
         conv.id,
         Message.Type.TEXT,
         UserId(),
-        MessageData.messageContent(text, mentions, isSendingMessage = true)._2,
+        MessageData.messageContent(text, mentions)._2,
         protos = Seq(GenericMessage(mId.uid, Text(text, mentions, Nil)))
       )
       val syncId = SyncId()

--- a/tests/unit/src/test/scala/com/waz/service/conversation/MessageSendingSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/conversation/MessageSendingSpec.scala
@@ -61,7 +61,7 @@ class MessageSendingSpec extends AndroidFreeSpec { test =>
     scenario("Add text message") {
 
       val mId = MessageId()
-      val msgData = MessageData(mId, conv.id, Message.Type.TEXT, UserId(), MessageData.textContent("test"), protos = Seq(GenericMessage(mId.uid, Text("test", Map.empty, Nil))))
+      val msgData = MessageData(mId, conv.id, Message.Type.TEXT, UserId(), MessageData.textContent("test"), protos = Seq(GenericMessage(mId.uid, Text("test", Nil, Nil))))
       val syncId = SyncId()
 
       (messages.addTextMessage _).expects(conv.id, "test", None).once().returning(Future.successful(msgData))

--- a/tests/unit/src/test/scala/com/waz/service/media/RichMediaContentParserSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/media/RichMediaContentParserSpec.scala
@@ -112,7 +112,7 @@ class RichMediaContentParserSpec extends AndroidFreeSpec with TableDrivenPropert
     }
 
     scenario("text with youtube link") {
-      splitContent("Here is some text. https://www.youtube.com/watch?v=MWdG413nNkI") shouldEqual List(MessageContent(TEXT, "Here is some text."), MessageContent(YOUTUBE, "https://www.youtube.com/watch?v=MWdG413nNkI"))
+      splitContent("Here is some text. https://www.youtube.com/watch?v=MWdG413nNkI") shouldEqual List(MessageContent(TEXT, "Here is some text. "), MessageContent(YOUTUBE, "https://www.youtube.com/watch?v=MWdG413nNkI"))
     }
 
     scenario("don't split proper uri") {
@@ -126,11 +126,11 @@ class RichMediaContentParserSpec extends AndroidFreeSpec with TableDrivenPropert
 
     scenario("text interleaved with multiple youtube links") {
       splitContent("Here is some text. https://www.youtube.com/watch?v=MWdG413nNkI more text https://www.youtube.com/watch?v=c0KYU2j0TM4 and even more") shouldEqual List(
-        MessageContent(TEXT, "Here is some text."),
+        MessageContent(TEXT, "Here is some text. "),
         MessageContent(YOUTUBE, "https://www.youtube.com/watch?v=MWdG413nNkI"),
-        MessageContent(TEXT, "more text"),
+        MessageContent(TEXT, " more text "),
         MessageContent(YOUTUBE, "https://www.youtube.com/watch?v=c0KYU2j0TM4"),
-        MessageContent(TEXT, "and even more")
+        MessageContent(TEXT, " and even more")
       )
     }
   }

--- a/tests/unit/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
+++ b/tests/unit/src/test/scala/com/waz/service/otr/OtrSyncHandlerSpec.scala
@@ -55,7 +55,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
   scenario("Encrypt and send message with no errors") {
 
     val conv = ConversationData(ConvId("conv-id"), RConvId("r-conv-id"))
-    val msg = TextMessage("content", Map.empty)
+    val msg = TextMessage("content", Nil)
 
     val otherUser = UserId("other-user-id")
     val otherUsersClient = ClientId("client-id")
@@ -108,7 +108,7 @@ class OtrSyncHandlerSpec extends AndroidFreeSpec {
   scenario("Unexpected users and/or clients in missing response should be updated and added to members, and previously encrypted content should be updated") {
 
     val conv = ConversationData(ConvId("conv-id"), RConvId("r-conv-id"))
-    val msg = TextMessage("content", Map.empty)
+    val msg = TextMessage("content", Seq.empty)
 
     val otherUser        = UserId("other-user-id")
     val otherUsersClient = ClientId("other-user-client-1")

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -160,7 +160,7 @@ class MessagesStorageImpl(context: Context,
       msgs.acquire { msgs =>
         val unread = msgs.filter { m => !m.isLocal && m.convId == conv && m.time.isAfter(lastReadTime) && !m.isDeleted && m.userId != userId && m.msgType != Message.Type.UNKNOWN } .toVector
         UnreadCount(
-          unread.count(m => !m.isSystemMessage && m.msgType != Message.Type.KNOCK),
+          unread.count(m => !m.isSystemMessage && m.msgType != Message.Type.KNOCK && !m.hasMentionOf(userId)),
           unread.count(_.msgType == Message.Type.MISSED_CALL),
           unread.count(_.msgType == Message.Type.KNOCK),
           unread.count(_.hasMentionOf(userId))

--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -162,7 +162,8 @@ class MessagesStorageImpl(context: Context,
         UnreadCount(
           unread.count(m => !m.isSystemMessage && m.msgType != Message.Type.KNOCK),
           unread.count(_.msgType == Message.Type.MISSED_CALL),
-          unread.count(_.msgType == Message.Type.KNOCK)
+          unread.count(_.msgType == Message.Type.KNOCK),
+          unread.count(_.hasMentionOf(userId))
         )
       }
     }

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -52,7 +52,7 @@ class ZMessagingDB(context: Context, dbName: String) extends DaoDB(context.getAp
 }
 
 object ZMessagingDB {
-  val DbVersion = 108
+  val DbVersion = 109
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao,
@@ -220,6 +220,9 @@ object ZMessagingDB {
       db.execSQL("UPDATE Messages SET ephemeral = null WHERE ephemeral = 0")
       db.execSQL("UPDATE Messages SET duration = null WHERE duration = 0")
       db.execSQL("UPDATE Conversations SET ephemeral = null WHERE ephemeral = 0")
+    },
+    Migration(108, 109) { db =>
+      db.execSQL("ALTER TABLE Conversations ADD COLUMN unread_mentions_count INTEGER DEFAULT 0")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/model/Mention.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Mention.scala
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+case class Mention(userId: Option[UserId], start: Int, end: Int)

--- a/zmessaging/src/main/scala/com/waz/model/Mention.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Mention.scala
@@ -17,4 +17,4 @@
  */
 package com.waz.model
 
-case class Mention(userId: Option[UserId], start: Int, end: Int)
+case class Mention(userId: Option[UserId], start: Int, length: Int)

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -27,7 +27,7 @@ import com.waz.api.{Message, TypeFilter}
 import com.waz.db.Col._
 import com.waz.db.Dao
 import com.waz.model.ConversationData.ConversationDataDao
-import com.waz.model.GenericContent.{Asset, ImageAsset, LinkPreview, Location, Text}
+import com.waz.model.GenericContent.{Asset, ImageAsset, LinkPreview, Location, MsgEdit, Text}
 import com.waz.model.GenericMessage.{GenericMessageContent, TextMessage}
 import com.waz.model.MessageData.MessageState
 import com.waz.model.messages.media.{MediaAssetData, MediaAssetDataProtocol}
@@ -142,26 +142,39 @@ case class MessageData(id:            MessageId              = MessageId(),
     msgType == m.msgType && content.zip(m.content).forall { case (c, c1) => c.tpe == c1.tpe && c.openGraph.isDefined == c1.openGraph.isDefined } // openGraph may affect message type
   }
 
-  def adjustMentions(forSending: Boolean): MessageData = {
-    verbose(s"adjustMentions(forSending = $forSending)")
-    val newContent =
-      if (mentions.isEmpty) content
-      else {
-        if (content.size == 1) content.map(_.copy(mentions = MessageData.adjustMentions(content.head.content, mentions, forSending)))
+  def adjustMentions(forSending: Boolean): Option[MessageData] =
+    if (mentions.isEmpty) None
+    else {
+      verbose(s"adjustMentions(forSending = $forSending)")
+      val newContent =
+        if (content.size == 1)
+          content.map(_.copy(mentions = MessageData.adjustMentions(content.head.content, mentions, forSending)))
         else
           content.foldLeft("", Seq.empty[MessageContent]) { case ((processedText, acc), ct) =>
             val newProcessedText = processedText + ct.content
             val start = processedText.length
-            val end = newProcessedText.length
-            val ms  = mentions.filter(m => m.start >= start && m.start + m.length < end) // we assume mentions are not split over many contents
-            (newProcessedText, acc ++ Seq(if (ms.isEmpty) ct else ct.copy(mentions = MessageData.adjustMentions(ct.content, ms, forSending, start))))
+            val end   = newProcessedText.length
+            val ms    = mentions.filter(m => m.start >= start && m.start + m.length < end) // we assume mentions are not split over many contents
+            (
+              newProcessedText,
+              acc ++ Seq(if (ms.isEmpty) ct else ct.copy(mentions = MessageData.adjustMentions(ct.content, ms, forSending, start)))
+            )
           }._2
+
+      val newMentions = newContent.flatMap(_.mentions)
+
+      val newProto = protos.lastOption match {
+        case Some(GenericMessage(uid, MsgEdit(ref, Text(_, _, links)))) =>
+          GenericMessage(uid, MsgEdit(ref, Text(contentString, newMentions, links)))
+        case Some(GenericMessage(uid, Text(_, _, links))) =>
+          GenericMessage(uid, ephemeral, Text(contentString, newMentions, links))
+        case _ =>
+          GenericMessage(id.uid, ephemeral, Text(contentString, newMentions, Nil))
       }
 
-    val newProto = GenericMessage(id.uid, ephemeral, Text(contentString, newContent.flatMap(_.mentions), Nil))
-    if (content == newContent && protos.lastOption.contains(newProto)) this
-    else copy(content = newContent, protos = Seq(newProto))
-  }
+      if (content == newContent && protos.lastOption.contains(newProto)) None
+      else Some(copy(content = newContent, protos = Seq(newProto)))
+    }
 }
 
 case class MessageContent(tpe:        Message.Part.Type,

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -100,10 +100,10 @@ case class MessageData(id:            MessageId              = MessageId(),
 
   def isDeleted = msgType == Message.Type.RECALLED
 
-  lazy val mentions = protos.lastOption match {
-    case Some(TextMessage(_, ms, _)) => ms
-    case _ => Nil
-  }
+  lazy val mentions = content.flatMap(_.mentions)
+  lazy val hasMentions = mentions.nonEmpty
+
+  def hasMentionOf(userId: UserId): Boolean = mentions.exists(_.userId.forall(_ == userId)) // a mention with userId == None is a "mention" of everyone, so it counts
 
   lazy val imageDimensions: Option[Dim2] = {
     val dims = protos.collectFirst {

--- a/zmessaging/src/main/scala/com/waz/model/package.scala
+++ b/zmessaging/src/main/scala/com/waz/model/package.scala
@@ -107,6 +107,13 @@ package object model {
         case _ =>
           None
       }
+
+      def updateMentions(msg: GenericMessage, newMentions: Seq[com.waz.model.Mention]): GenericMessage = msg match {
+        case GenericMessage(uid, Text(text, mentions, links)) if mentions != newMentions =>
+          GenericMessage(uid, Text(text, newMentions, links))
+        case _ =>
+          msg
+      }
     }
 
     //TODO Dean: this can lead to some very tricky problems - try to get around the Any...

--- a/zmessaging/src/main/scala/com/waz/model/package.scala
+++ b/zmessaging/src/main/scala/com/waz/model/package.scala
@@ -91,13 +91,13 @@ package object model {
     object TextMessage {
       import scala.concurrent.duration.DurationInt
 
-      def apply(text: String, mentions: Map[UserId, String]): GenericMessage = GenericMessage(Uid(), Text(text, mentions, Nil))
+      def apply(text: String, mentions: Seq[com.waz.model.Mention]): GenericMessage = GenericMessage(Uid(), Text(text, mentions, Nil))
 
-      def apply(text: String, mentions: Map[UserId, String], links: Seq[LinkPreview]): GenericMessage = GenericMessage(Uid(), Text(text, mentions, links))
+      def apply(text: String, mentions: Seq[com.waz.model.Mention], links: Seq[LinkPreview]): GenericMessage = GenericMessage(Uid(), Text(text, mentions, links))
 
-      def apply(msg: MessageData): GenericMessage = GenericMessage(msg.id.uid, msg.ephemeral, Text(msg.contentString, msg.content.flatMap(_.mentions).toMap, Nil))
+      def apply(msg: MessageData): GenericMessage = GenericMessage(msg.id.uid, msg.ephemeral, Text(msg.contentString, msg.content.flatMap(_.mentions), Nil))
 
-      def unapply(msg: GenericMessage): Option[(String, Map[UserId, String], Seq[LinkPreview])] = msg match {
+      def unapply(msg: GenericMessage): Option[(String, Seq[com.waz.model.Mention], Seq[LinkPreview])] = msg match {
         case GenericMessage(_, Text(content, mentions, links)) =>
           Some((content, mentions, links))
         case GenericMessage(_, Ephemeral(_, Text(content, mentions, links))) =>

--- a/zmessaging/src/main/scala/com/waz/service/SearchKey.scala
+++ b/zmessaging/src/main/scala/com/waz/service/SearchKey.scala
@@ -36,12 +36,14 @@ final class SearchKey private (val asciiRepresentation: String) extends Serializ
 
 object SearchKey extends (String => SearchKey) {
   val empty = new SearchKey("")
-  def apply(name: String): SearchKey = if(name.isEmpty) empty else new SearchKey(transliterated(name))
+  def apply(name: String): SearchKey = if(name.isEmpty) empty else new SearchKey(transliterated(tokenize(name)))
   def unsafeRestore(asciiRepresentation: String) = new SearchKey(asciiRepresentation)
   def unapply(k: SearchKey): Option[String] = Some(k.asciiRepresentation)
 
   def transliterated(s: String): String = Locales.transliteration.transliterate(s).trim
 
+  private def tokenize(s: String): String = s.replaceAll("[-|_]+", " ")
+
   //TODO for tests only - get libcore working in tests again
-  def simple(name: String): SearchKey = if (name.isEmpty) empty else new SearchKey(name)
+  def simple(name: String): SearchKey = if (name.isEmpty) empty else new SearchKey(tokenize(name))
 }

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -93,7 +93,7 @@ class UserSearchService(selfUserId:           UserId,
       sortUsers(included, filter, isHandle = false, filter)
     }
 
-  def mentionsSearchUsersInConversation(convId: ConvId, filter: Filter, includeSelf: Boolean = false): Signal[Seq[UserData]] =
+  def mentionsSearchUsersInConversation(convId: ConvId, filter: Filter, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =
     for {
       curr <- membersStorage.activeMembers(convId)
       currData <- usersStorage.listSignal(curr)
@@ -118,7 +118,7 @@ class UserSearchService(selfUserId:           UserId,
         cmpHandle(_, _.contains(filter))
       )
 
-      rules.foldLeft[(Set[UserId],Seq[UserData])]((Set.empty, Seq())){ case ((found, results), rule) =>
+      rules.foldLeft[(Set[UserId],IndexedSeq[UserData])]((Set.empty, IndexedSeq())){ case ((found, results), rule) =>
         val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.getDisplayName)
         (found ++ matches.map(_.id).toSet, results ++: matches)
       }._2

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -119,7 +119,7 @@ class UserSearchService(selfUserId:           UserId,
       )
 
       rules.foldLeft[(Set[UserId],IndexedSeq[UserData])]((Set.empty, IndexedSeq())){ case ((found, results), rule) =>
-        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.getDisplayName)
+        val matches = included.filter(rule).filter(u => !found.contains(u.id)).sortBy(_.getDisplayName.toLowerCase)
         (found ++ matches.map(_.id).toSet, results ++: matches)
       }._2
     }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -170,15 +170,15 @@ class ConversationsUiServiceImpl(selfUserId:      UserId,
   }
 
   override def updateMessage(convId: ConvId, id: MessageId, text: String, mentions: Seq[Mention] = Nil): Future[Option[MessageData]] = {
-    verbose(s"updateMessage($convId, $id, $text")
+    verbose(s"updateMessage($convId, $id, $text, $mentions")
     messagesContent.updateMessage(id) {
       case m if m.convId == convId && m.userId == selfUserId =>
-        val (tpe, ct) = MessageData.messageContent(text, mentions, isSendingMessage = true, weblinkEnabled = true)
+        val (tpe, ct) = MessageData.messageContent(text, mentions, weblinkEnabled = true)
         verbose(s"updated content: ${(tpe, ct)}")
         m.copy(
           msgType = tpe,
           content = ct,
-          protos = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(text, mentions, Nil)))),
+          protos = Seq(GenericMessage(Uid(), MsgEdit(id, GenericContent.Text(text, ct.flatMap(_.mentions), Nil)))),
           state = Message.Status.PENDING,
           editTime = (m.time max m.editTime) + 1.millis max LocalInstant.Now.toRemote(currentBeDrift)
         )

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
@@ -172,15 +172,12 @@ object RichMediaContentParser {
 class MessageContentBuilder {
   val res = Seq.newBuilder[MessageContent]
 
-  def +=(part: String) = {
-    val trimmed = part.trim
-    if (trimmed.nonEmpty) res += RichMediaContentParser.textMessageContent(trimmed)
-  }
+  def +=(part: String) =
+    if (part.trim.nonEmpty) res += RichMediaContentParser.textMessageContent(part)
 
-  def +=(tpe: Part.Type, part: String) = {
-    val trimmed = part.trim
-    if (trimmed.nonEmpty) res += MessageContent(tpe, trimmed)
-  }
+
+  def +=(tpe: Part.Type, part: String) =
+    if (part.trim.nonEmpty) res += MessageContent(tpe, part)
 
   def +=(content: MessageContent) = res += content
 

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -165,8 +165,9 @@ class MessageEventProcessor(selfUserId:          UserId,
     //v3 assets go here
     def content(id: MessageId, msgContent: Any, from: UserId, time: RemoteInstant, proto: GenericMessage): MessageData = msgContent match {
       case Text(text, mentions, links) =>
-        val (tpe, content) = MessageData.messageContent(text, mentions, isSendingMessage = false, links)
-        MessageData(id, conv.id, tpe, from, content, time = time, localTime = event.localTime, protos = Seq(TextMessage.updateMentions(proto, content.flatMap(_.mentions))))
+        val (tpe, content) = MessageData.messageContent(text, mentions, links)
+        verbose(s"MessageData content: $content")
+        MessageData(id, conv.id, tpe, from, content, time = time, localTime = event.localTime, protos = Seq(proto)).adjustMentions(false)
       case Knock() =>
         MessageData(id, conv.id, Message.Type.KNOCK, from, time = time, localTime = event.localTime, protos = Seq(proto))
       case Reaction(_, _) => MessageData.Empty

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -167,7 +167,8 @@ class MessageEventProcessor(selfUserId:          UserId,
       case Text(text, mentions, links) =>
         val (tpe, content) = MessageData.messageContent(text, mentions, links)
         verbose(s"MessageData content: $content")
-        MessageData(id, conv.id, tpe, from, content, time = time, localTime = event.localTime, protos = Seq(proto)).adjustMentions(false)
+        val messageData = MessageData(id, conv.id, tpe, from, content, time = time, localTime = event.localTime, protos = Seq(proto))
+        messageData.adjustMentions(false).getOrElse(messageData)
       case Knock() =>
         MessageData(id, conv.id, Message.Type.KNOCK, from, time = time, localTime = event.localTime, protos = Seq(proto))
       case Reaction(_, _) => MessageData.Empty

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -172,7 +172,7 @@ class MessagesServiceImpl(selfUserId:   UserId,
     val (tpe, ct) = MessageData.messageContent(content, weblinkEnabled = true)
     verbose(s"parsed content: $ct")
     val id = MessageId()
-    updater.addLocalMessage(MessageData(id, convId, tpe, selfUserId, ct, protos = Seq(GenericMessage(id.uid, Text(content, Map.empty, Nil)))), exp = exp) // FIXME: links
+    updater.addLocalMessage(MessageData(id, convId, tpe, selfUserId, ct, protos = Seq(GenericMessage(id.uid, Text(content, Nil, Nil)))), exp = exp) // FIXME: links
   }
 
   override def addLocationMessage(convId: ConvId, content: Location) = {

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesService.scala
@@ -131,7 +131,7 @@ class MessagesServiceImpl(selfUserId:   UserId,
             _ <- edits.insert(EditHistory(msg.id, MessageId(id.str), time))
             (tpe, ct) = MessageData.messageContent(text, mentions, links, weblinkEnabled = true)
             edited = MessageData(MessageId(id.str), convId, tpe, userId, ct, Seq(gm), time = msg.time, localTime = msg.localTime, editTime = time)
-            res <- updater.addMessage(edited.adjustMentions(false))
+            res <- updater.addMessage(edited.adjustMentions(false).getOrElse(edited))
             _ <- updater.deleteOnUserRequest(Seq(msg.id))
         } yield res
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/OtrServiceImpl.scala
@@ -116,7 +116,7 @@ class OtrServiceImpl(selfUserId:     UserId,
               Some(GenericMessageEvent(conv, time, from, msg).withLocalTime(localTime))
           }
         case GenericMessage(mId, SessionReset) if metadata.internalBuild => // display session reset notifications in internal build
-          Some(GenericMessageEvent(conv, time, from, GenericMessage(mId, Text("System msg: session reset", Map.empty, Nil))))
+          Some(GenericMessageEvent(conv, time, from, GenericMessage(mId, Text("System msg: session reset", Nil, Nil))))
         case GenericMessage(_, SessionReset) => None // ignore session reset notifications
         case GenericMessage(_, Calling(content)) =>
           Some(CallMessageEvent(conv, time, from, sender, content)) //call messages need sender client id

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -359,7 +359,14 @@ object NotificationService {
 
   def notification(msg: MessageData, drift: bp.Duration = Duration.Zero): Option[NotificationData] = {
     mapMessageType(msg.msgType, msg.protos, msg.members, msg.userId).map { tp =>
-      NotificationData(NotId(msg.id), if (msg.isEphemeral) "" else msg.contentString, msg.convId, msg.userId, tp, if (msg.time == RemoteInstant.Epoch) msg.localTime.toRemote(drift) else msg.time, ephemeral = msg.isEphemeral, mentions = msg.mentions.keys.toSeq)
+      NotificationData(
+        NotId(msg.id),
+        if (msg.isEphemeral) "" else msg.contentString, msg.convId,
+        msg.userId, tp,
+        if (msg.time == RemoteInstant.Epoch) msg.localTime.toRemote(drift) else msg.time,
+        ephemeral = msg.isEphemeral,
+        mentions = msg.mentions.flatMap(_.userId)
+      )
     }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -157,7 +157,7 @@ class MessagesSyncHandler(selfUserId: UserId,
   private def postMessage(conv: ConversationData, msg: MessageData, reqEditTime: RemoteInstant)(implicit convLock: ConvLock): Future[SyncResult] = {
 
     def postTextMessage() = {
-      val adjustedMsg = msg.adjustMentions(true)
+      val adjustedMsg = msg.adjustMentions(true).getOrElse(msg)
 
       val (gm, isEdit) =
         adjustedMsg.protos.lastOption match {


### PR DESCRIPTION
We already had `mentions` in the protobuf and handled it in `MessageContent`, but they were not used in the app. Now we want to introduce them properly, and that means changes both to how they are encoded in the protobuf, and new code which actually uses them.

New `Mention`s can be now sent from `ConversationsUiService.addTextMessage`.
They are added to `MessageContent`s of `MessageData` and adjusted for the specified charset.
We differentiate between two charsets: UTF-16 and default. When we want to send a message,
we specify that the mentions in that message should be adjusted for UTF-16. When we receive
one, we need to re-adjust the mentions for our default charset (UTF-8 on Android). Sending
and receiving messages use common fuctionality in MessageData: `messageContent`. Before this
method was used the same way no matter the direction. Now we have to specify which way
the message will go after adjusting. This creates a special case for editing messages.
An edited message is both re-displayed on the our side, as if we received it, and it is sent
to other devices. In this commit we handle only the sending side. The re-displaying of
an edited message needs additional work.