### PR TITLE
fix: removes duplicated entries in the conversations table

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -441,4 +441,7 @@ object UserPreferences {
   lazy val ShouldSyncConversations          = PrefKey[Boolean]("should_sync_conversations_1", customDefault = true)
   lazy val ShouldSyncInitial                = PrefKey[Boolean]("should_sync_initial_1", customDefault = true)
   lazy val ShouldSyncUsers                  = PrefKey[Boolean]("should_sync_users", customDefault = true)
+
+  // fix for duplicated entries in the database, left there by a bug from an old version of the app
+  lazy val FixDuplicatedConversations       = PrefKey[Boolean]("fix_duplicated_conversations", customDefault = true)
 }


### PR DESCRIPTION
A bug introduced in a previous release broke the way new conversations were created. Instead of adding one entry to the conversations table and then updating it, the bug was creating a new entry, with a new local id, and the same remote id. The app wasn't then able to display the new conversation on the conversations list, and display messages in this conversation.
The bug was fixed, but the duplicate entries already created were left in the database. This commit removes them and corrects the original one. It should run only once, just after the update to the release with the fix.

We can suspect that in at most a few months all clients with the duplicated entries in the database will be fixed and we will be able to remove the code.

for more info about this please look at https://github.com/wireapp/wire-android-sync-engine/pull/421