### PR TITLE
fix: Don't add file extensions to filenames with file extensions

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Mime.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Mime.scala
@@ -34,6 +34,7 @@ case class Mime(str: String) {
 object Mime {
   val Unknown = Mime("")
   val Default = Mime("application/octet-stream")
+  val Text    = Mime("text/plain")
 
   def fromFileName(fileName: String) = extensionOf(fileName).fold2(Unknown, fromExtension)
   def fromExtension(ext: String) = Option(MimeTypeMap.getSingleton.getMimeTypeFromExtension(ext)).fold2(Unknown, Mime(_))
@@ -112,6 +113,7 @@ object Mime {
     Audio.Ogg    -> "ogg",
     Audio.FLAC   -> "flac",
     Audio.WAV    -> "wav",
-    Audio.PCM    -> "m4a"
+    Audio.PCM    -> "m4a",
+    Text         -> "txt"
   )
 }

--- a/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/AssetService.scala
@@ -239,8 +239,8 @@ class AssetServiceImpl(storage:         AssetsStorage,
             mime        = info.mime,
             sizeInBytes = info.size.getOrElse(0),
             name        = info.name.map {
-              case name if info.mime.extension.nonEmpty => name + "." + info.mime.extension
-              case name                                 => name
+              case name if info.mime.extension.nonEmpty && !name.contains(".") => name + "." + info.mime.extension
+              case name                                                        => name
             },
             source      = Some(uri),
             metaData = info.mime match {

--- a/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoader.scala
@@ -105,7 +105,7 @@ class AssetLoaderImpl(context:         Context,
   override val onDownloadFailed   = EventStream[(AssetId, ErrorResponse)]()
 
   override def loadAsset(asset: AssetData, callback: Callback, force: Boolean): CancellableFuture[CacheEntry] = {
-    verbose(s"loadAsset: ${asset.id}, isDownloadable?: ${asset.isDownloadable}, force?: $force, mime: ${asset.mime}")
+    verbose(s"loadAsset: ${asset.id}, isDownloadable?: ${asset.isDownloadable}, force?: $force, mime: ${asset.mime}, name: ${asset.name}")
     returning(asset match {
       case _ if asset.mime == Mime.Audio.PCM => transcodeAudio(asset, callback)
       case _ => CancellableFuture.lift(cache.getEntry(asset.cacheKey)).flatMap {

--- a/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoaderService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/downloads/AssetLoaderService.scala
@@ -200,7 +200,7 @@ object AssetLoaderService {
       promise.tryFailure(new CancelException("Cancelled by user"))
 
     def load() = {
-      verbose(s"performing load: ${asset.id}")
+      verbose(s"performing load: ${asset.id}, name: ${asset.name}")
       loader.loadAsset(asset, state ! _, force)
     }
 


### PR DESCRIPTION
I assume the filename has file extension simply if it contains a '.' sign. Also, I added a ".txt" file extension to the Mime map.

fixes https://github.com/wireapp/android-project/issues/259