### PR TITLE
fix: Users removed from the team are marked as deleted instead of being deleted

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -90,8 +90,6 @@ case class UserData(id:                    UserId,
     handle = Some(user.handle)
   )
 
-  def updated(teamId: Option[TeamId]): UserData = copy(teamId = teamId)
-
   def updateConnectionStatus(status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): UserData = {
     if (time.exists(_.isBefore(this.connectionLastUpdated))) this
     else if (this.connection == status) time.fold(this) { time => this.copy(connectionLastUpdated = time) }

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -137,6 +137,7 @@ class UserSearchService(selfUserId:           UserId,
         !excluded.contains(user.id) &&
           selfUserId != user.id &&
           !user.isWireBot &&
+          !user.deleted &&
           user.expiresAt.isEmpty &&
           user.matchesFilter(filter) &&
           (showBlockedUsers || (user.connection != ConnectionStatus.Blocked))


### PR DESCRIPTION
Until now when a user was removed from our team, we removed that user's data completely from the database. That was inconsistent with what happened when the user actually deleted their account: in that case we just marked the user as deleted, but we were still able to retrieve the data if needed.
This fix makes users removed from the team also just marked as deleted.

The most important purpose of that is for the other users to be able to read old conversations. Even if some of the participants are not longer in the team, we should be able to display information about them in these conversations.

It also means that if a user is removed from a team, and then restored, we don't lose the history of the one-to-one conversation with them.