### PR TITLE
fix: check for potentially out of sync push token

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -320,54 +320,54 @@ object SyncRequest {
 
       try {
         SyncCommand.fromName(cmd) match {
-          case Cmd.SyncUser              => SyncUser(users)
-          case Cmd.SyncConversation      => SyncConversation(decodeConvIdSeq('convs).toSet)
-          case Cmd.SyncConvLink          => SyncConvLink('conv)
-          case Cmd.SyncSearchQuery       => SyncSearchQuery(SearchQuery.fromCacheKey(decodeString('queryCacheKey)))
-          case Cmd.ExactMatchHandle      => ExactMatchHandle(Handle(decodeString('handle)))
-          case Cmd.PostConv              => PostConv(convId, decodeStringSeq('users).map(UserId(_)).toSet, 'name, 'team, 'access, 'access_role)
-          case Cmd.PostConvName          => PostConvName(convId, 'name)
-          case Cmd.PostConvState         => PostConvState(convId, JsonDecoder[ConversationState]('state))
-          case Cmd.PostLastRead          => PostLastRead(convId, 'time)
-          case Cmd.PostCleared           => PostCleared(convId, 'time)
-          case Cmd.PostTypingState       => PostTypingState(convId, 'typing)
-          case Cmd.PostConnectionStatus  => PostConnectionStatus(userId, opt('status, js => ConnectionStatus(js.getString("status"))))
-          case Cmd.PostSelfPicture       => PostSelfPicture(decodeOptAssetId('asset))
-          case Cmd.PostSelfName          => PostSelfName(decodeString('name))
-          case Cmd.PostSelfAccentColor   => PostSelfAccentColor(AccentColor(decodeInt('color)))
-          case Cmd.PostAvailability      => PostAvailability(Availability(decodeInt('availability)))
-          case Cmd.PostMessage           => PostMessage(convId, messageId, 'time)
-          case Cmd.PostDeleted           => PostDeleted(convId, messageId)
-          case Cmd.PostRecalled          => PostRecalled(convId, messageId, decodeId[MessageId]('recalled))
-          case Cmd.PostAssetStatus       => PostAssetStatus(convId, messageId, decodeOptLong('ephemeral).map(_.millis), JsonDecoder[AssetStatus.Syncable]('status))
-          case Cmd.PostConvJoin          => PostConvJoin(convId, users)
-          case Cmd.PostConvLeave         => PostConvLeave(convId, userId)
-          case Cmd.PostConnection        => PostConnection(userId, 'name, 'message)
-          case Cmd.DeletePushToken       => DeletePushToken(decodeId[PushToken]('token))
-          case Cmd.SyncRichMedia         => SyncRichMedia(messageId)
-          case Cmd.SyncSelf              => SyncSelf
-          case Cmd.DeleteAccount         => DeleteAccount
-          case Cmd.SyncConversations     => SyncConversations
-          case Cmd.SyncTeam              => SyncTeam
-          case Cmd.SyncTeamMember        => SyncTeamMember(userId)
-          case Cmd.SyncConnectedUsers    => SyncConnectedUsers
-          case Cmd.SyncConnections       => SyncConnections
-          case Cmd.RegisterPushToken     => RegisterPushToken(decodeId[PushToken]('token))
-          case Cmd.PostSelf              => PostSelf(JsonDecoder[UserInfo]('user))
-          case Cmd.PostAddressBook       => PostAddressBook(JsonDecoder.opt[AddressBook]('addressBook).getOrElse(AddressBook.Empty))
-          case Cmd.SyncSelfClients       => SyncSelfClients
-          case Cmd.SyncSelfPermissions   => SyncSelfPermissions
-          case Cmd.SyncClients           => SyncClients(userId)
-          case Cmd.SyncClientLocation    => SyncClientsLocation
-          case Cmd.SyncPreKeys           => SyncPreKeys(userId, decodeClientIdSeq('clients).toSet)
-          case Cmd.PostClientLabel       => PostClientLabel(decodeId[ClientId]('client), 'label)
-          case Cmd.PostLiking            => PostLiking(convId, JsonDecoder[Liking]('liking))
-          case Cmd.PostAddBot            => PostAddBot(decodeId[ConvId]('convId), decodeId[ProviderId]('providerId), decodeId[IntegrationId]('integrationId))
-          case Cmd.PostRemoveBot         => PostRemoveBot(decodeId[ConvId]('convId), decodeId[UserId]('botId))
-          case Cmd.PostSessionReset      => PostSessionReset(convId, userId, decodeId[ClientId]('client))
-          case Cmd.PostOpenGraphMeta     => PostOpenGraphMeta(convId, messageId, 'time)
-          case Cmd.PostReceipt           => PostReceipt(convId, messageId, userId, ReceiptType.fromName('type))
-          case Cmd.Unknown               => Unknown
+          case Cmd.SyncUser                  => SyncUser(users)
+          case Cmd.SyncConversation          => SyncConversation(decodeConvIdSeq('convs).toSet)
+          case Cmd.SyncConvLink              => SyncConvLink('conv)
+          case Cmd.SyncSearchQuery           => SyncSearchQuery(SearchQuery.fromCacheKey(decodeString('queryCacheKey)))
+          case Cmd.ExactMatchHandle          => ExactMatchHandle(Handle(decodeString('handle)))
+          case Cmd.PostConv                  => PostConv(convId, decodeStringSeq('users).map(UserId(_)).toSet, 'name, 'team, 'access, 'access_role)
+          case Cmd.PostConvName              => PostConvName(convId, 'name)
+          case Cmd.PostConvState             => PostConvState(convId, JsonDecoder[ConversationState]('state))
+          case Cmd.PostLastRead              => PostLastRead(convId, 'time)
+          case Cmd.PostCleared               => PostCleared(convId, 'time)
+          case Cmd.PostTypingState           => PostTypingState(convId, 'typing)
+          case Cmd.PostConnectionStatus      => PostConnectionStatus(userId, opt('status, js => ConnectionStatus(js.getString("status"))))
+          case Cmd.PostSelfPicture           => PostSelfPicture(decodeOptAssetId('asset))
+          case Cmd.PostSelfName              => PostSelfName(decodeString('name))
+          case Cmd.PostSelfAccentColor       => PostSelfAccentColor(AccentColor(decodeInt('color)))
+          case Cmd.PostAvailability          => PostAvailability(Availability(decodeInt('availability)))
+          case Cmd.PostMessage               => PostMessage(convId, messageId, 'time)
+          case Cmd.PostDeleted               => PostDeleted(convId, messageId)
+          case Cmd.PostRecalled              => PostRecalled(convId, messageId, decodeId[MessageId]('recalled))
+          case Cmd.PostAssetStatus           => PostAssetStatus(convId, messageId, decodeOptLong('ephemeral).map(_.millis), JsonDecoder[AssetStatus.Syncable]('status))
+          case Cmd.PostConvJoin              => PostConvJoin(convId, users)
+          case Cmd.PostConvLeave             => PostConvLeave(convId, userId)
+          case Cmd.PostConnection            => PostConnection(userId, 'name, 'message)
+          case Cmd.DeletePushToken           => DeletePushToken(decodeId[PushToken]('token))
+          case Cmd.SyncRichMedia             => SyncRichMedia(messageId)
+          case Cmd.SyncSelf                  => SyncSelf
+          case Cmd.DeleteAccount             => DeleteAccount
+          case Cmd.SyncConversations         => SyncConversations
+          case Cmd.SyncTeam                  => SyncTeam
+          case Cmd.SyncTeamMember            => SyncTeamMember(userId)
+          case Cmd.SyncConnectedUsers        => SyncConnectedUsers
+          case Cmd.SyncConnections           => SyncConnections
+          case Cmd.RegisterPushToken         => RegisterPushToken(decodeId[PushToken]('token))
+          case Cmd.PostSelf                  => PostSelf(JsonDecoder[UserInfo]('user))
+          case Cmd.PostAddressBook           => PostAddressBook(JsonDecoder.opt[AddressBook]('addressBook).getOrElse(AddressBook.Empty))
+          case Cmd.SyncSelfClients           => SyncSelfClients
+          case Cmd.SyncSelfPermissions       => SyncSelfPermissions
+          case Cmd.SyncClients               => SyncClients(userId)
+          case Cmd.SyncClientLocation        => SyncClientsLocation
+          case Cmd.SyncPreKeys               => SyncPreKeys(userId, decodeClientIdSeq('clients).toSet)
+          case Cmd.PostClientLabel           => PostClientLabel(decodeId[ClientId]('client), 'label)
+          case Cmd.PostLiking                => PostLiking(convId, JsonDecoder[Liking]('liking))
+          case Cmd.PostAddBot                => PostAddBot(decodeId[ConvId]('convId), decodeId[ProviderId]('providerId), decodeId[IntegrationId]('integrationId))
+          case Cmd.PostRemoveBot             => PostRemoveBot(decodeId[ConvId]('convId), decodeId[UserId]('botId))
+          case Cmd.PostSessionReset          => PostSessionReset(convId, userId, decodeId[ClientId]('client))
+          case Cmd.PostOpenGraphMeta         => PostOpenGraphMeta(convId, messageId, 'time)
+          case Cmd.PostReceipt               => PostReceipt(convId, messageId, userId, ReceiptType.fromName('type))
+          case Cmd.Unknown                   => Unknown
         }
       } catch {
         case NonFatal(e) =>
@@ -472,7 +472,8 @@ object SyncRequest {
         case SyncPreKeys(user, clients) =>
           o.put("user", user.str)
           o.put("clients", arrString(clients.toSeq map (_.str)))
-        case SyncSelf | SyncTeam | DeleteAccount | SyncConversations | SyncConnections | SyncConnectedUsers | SyncSelfClients | SyncSelfPermissions | SyncClientsLocation | Unknown => () // nothing to do
+        case SyncSelf | SyncTeam | DeleteAccount | SyncConversations | SyncConnections | SyncConnectedUsers |
+             SyncSelfClients | SyncSelfPermissions | SyncClientsLocation | Unknown => () // nothing to do
       }
     }
   }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -154,7 +154,7 @@ class AndroidSyncServiceHandle(service: SyncRequestService, timeouts: Timeouts, 
   def postAddBot(cId: ConvId, pId: ProviderId, iId: IntegrationId) = addRequest(PostAddBot(cId, pId, iId))
   def postRemoveBot(cId: ConvId, botId: UserId) = addRequest(PostRemoveBot(cId, botId))
 
-  def registerPush(token: PushToken) = addRequest(RegisterPushToken(token), priority = Priority.High, forceRetry = true)
+  def registerPush(token: PushToken)    = addRequest(RegisterPushToken(token), priority = Priority.High, forceRetry = true)
   def deletePushToken(token: PushToken) = addRequest(DeletePushToken(token), priority = Priority.Low)
 
   def syncSelfClients() = addRequest(SyncSelfClients, priority = Priority.Critical)

--- a/zmessaging/src/test/scala/com/waz/sync/client/PushTokenClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/PushTokenClientSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.sync.client
+
+import com.waz.ZIntegrationSpec
+
+class PushTokenClientSpec extends ZIntegrationSpec {
+
+  import com.waz.AuthenticationConfig._
+
+  //TODO reintroduce test when AuthRequestInterceptor2 is used
+//  lazy val client = new PushTokenClientImpl()
+
+//  scenario("get push tokens for user") {
+//    for {
+//      res <- client.getPushTokens()
+//    } yield {
+//      println(res)
+//      assert(true)
+//    }
+//  }
+
+}


### PR DESCRIPTION
Due to a race where we might accidentally unregister our own push
token from the BE without noticing, it can be that some users in the
wild have no push token.

This commit implements functionality to fetch all registered push tokens
on the BE for a given user, upon which the PushTokenService will compare
these tokens with the one it thinks is registered. If there is no match,
then it will re-register the current device token with the backend.

This commit only provides the above described functionality, but does
not schedule the check. This will be determined in the Android (UI)
project - the best time to do it would be on app start and app upgrade.

partly fixes: https://github.com/wireapp/android-project/issues/263