### PR TITLE
fix: use fileUri for broadcast to media scanner

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/images/ImageLoader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/images/ImageLoader.scala
@@ -156,8 +156,9 @@ class ImageLoaderImpl(context:                  Context,
           Future {
             val newFile = AssetService.saveImageFile(mime)
             IoUtils.copy(data.inputStream, new FileOutputStream(newFile))
+            val scanUri = URI.fromFile(newFile)
+            context.sendBroadcast(Intent.scanFileIntent(scanUri))
             val uri = new AndroidURI(FileProvider.getUriForFile(context, context.getApplicationContext.getPackageName + ".fileprovider", newFile))
-            context.sendBroadcast(Intent.scanFileIntent(uri))
             Some(uri)
           }(Threading.IO)
         case _ =>


### PR DESCRIPTION
In upgrading to android 8, we moved all file uris (`file:///`) to
content uris (`content:///`) to be complient with changes introduced in
android 7, however these uris don't seem to work with the media scanner
and so our saved images stopped appearing in the system as images.

This creates 2 uris, one file type, to be used by the scanner, and
another content type, to be returned to other parts of the app that will
then share this URI with other applications via other types of intents.

Testing
  - Save an image on Android version >= 7, open the image from the
    generated notification and make sure it doesn't crash
  - Save an image on any android version, and make sure that image
    appears in the gallery (or any other application)