### PR TITLE
fix: onIncomingCall should replace finished calls from the profile

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallInfo.scala
@@ -158,8 +158,10 @@ object CallInfo {
 
     val ActiveCallStates   = Set[CallState](SelfCalling, SelfJoining, SelfConnected, Terminating)
     val JoinableCallStates = Set[CallState](SelfCalling, OtherCalling, SelfJoining, SelfConnected, Ongoing)
+    val FinishedStates = Set[CallState](Terminating, Ended)
 
     def isActive(st: CallState, shouldRing: Boolean): Boolean = ActiveCallStates(st) || (st == OtherCalling && shouldRing)
     def isJoinable(st: CallState): Boolean = JoinableCallStates(st)
+    def isFinished(st: CallState): Boolean = FinishedStates(st)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -236,7 +236,8 @@ class CallingServiceImpl(val accountId:       UserId,
 
       callProfile.mutate { p =>
         // If we have a call in the profile with the same id, this incoming call should be just a GROUPCHECK
-        p.copy(calls = p.calls + (newCall.convId -> p.calls.getOrElse(newCall.convId, newCall)))
+        val call = p.calls.get(newCall.convId).filter(c => !isFinished(c.state)).getOrElse(newCall)
+        p.copy(calls = p.calls + (call.convId -> call))
       }
     }
 


### PR DESCRIPTION
onIncomingCall should update the call profile unless it's for a group check, which occurs on an ongoing call. Terminating or Ended calls should be discarded.