### PR TITLE
[WIP] refactor: Make remote time in MessageData an Option of RemoteInstant

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -218,14 +218,12 @@ class NotificationService(context:         Context,
 
       msgs.flatMap(msg =>
         mapMessageType(msg.msgType, msg.protos, msg.members, msg.userId).map { tp =>
-          val drift: bp.Duration = pushService.beDrift.currentValue.getOrElse(Duration.Zero)
-
           NotificationData(
             NotId(msg.id),
             if (msg.isEphemeral) "" else msg.contentString, msg.convId,
             msg.userId,
             tp,
-            if (msg.time == RemoteInstant.Epoch) msg.localTime.toRemote(drift) else msg.time,
+            msg.time,
             ephemeral = msg.isEphemeral,
             mentions = msg.mentions.flatMap(_.userId),
             isQuote = msg.quote.exists(quoteIds)


### PR DESCRIPTION
The old val `time` is changed to a private val `remoteTime`. `time` becomes a method, so in most places in the code, where we only read the time, no changes are necessary. The `time` method checks `remoteTime` and if it's `None`, it returns `localTime` modified by the current BackEnd drift.