### PR TITLE
fix: subscribe to global event context on signal head

### DIFF
--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -286,11 +286,7 @@ object ZLog2 {
     implicit val ConvDataLogShow: LogShow[ConversationData] =
       LogShow.createFrom { c =>
         import c._
-        l"""
-           |ConversationData(id: $id | remoteId: $remoteId | name: $name | convType: $convType | team: $team | muted: $muted | muteTime: $muteTime |
-           |  archived: $archived archivedTime: $archiveTime | lastRead: $lastRead | cleared: $cleared | unreadCount: $unreadCount)
-        """.stripMargin
-
+        l"ConversationData(id: $id | remoteId: $remoteId | name: $name | convType: $convType | team: $team | lastEventTime: $lastEventTime | muted: $muted | muteTime: $muteTime | archived: $archived | archivedTime: $archiveTime | lastRead: $lastRead | cleared: $cleared | unreadCount: $unreadCount)"
       }
 
     implicit val MentionShow: LogShow[Mention] =

--- a/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/events/SignalSpec.scala
@@ -149,6 +149,13 @@ class SignalSpec extends AndroidFreeSpec {
 
       result(future) shouldEqual 1
     }
+
+    scenario("Race condition between mutate and head") {
+      val s = Signal(0)
+      result(s.head) shouldEqual 0
+      await(Future(s.mutate(_ + 1))(Threading.Background)) //mutate signal on another thread
+      result(s.head) shouldEqual 1
+    }
   }
 
   feature("Concurrency") {


### PR DESCRIPTION
For cases where the underlying signal has no reference held elsewhere in
the app, the signal my have been garbage collected before the first value
is ever published to the listener that completes the promise. This would
mean the listener is never called, and the future would never complete.

In this PR, we instead create a regular subscription and subscribe to the
global event context, which will then keep a reference to the signal until
the promise is completed. We now also do not check the current value before
subscribing, since if there is a value, we get called back immediately
anyway. This also has the added bonus that calling head won't call
disableAutoWiring on the Signal, meaning it won't be alive indefinitely
(as long as a reference to it is held).