### PR TITLE
feat: Replace id extractors of classes held in DB  with compile-time information

### DIFF
--- a/zmessaging/src/main/scala/com/waz/cache/CacheEntryData.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheEntryData.scala
@@ -26,7 +26,7 @@ import com.waz.db.Dao
 import com.waz.db.DbTranslator.FileTranslator
 import com.waz.log.ZLog2.LogShow
 import com.waz.model._
-import com.waz.utils.returning
+import com.waz.utils.{Identifiable, returning}
 import com.waz.utils.wrappers.{DB, DBCursor}
 
 case class CacheEntryData(key:      CacheKey,
@@ -38,7 +38,9 @@ case class CacheEntryData(key:      CacheKey,
                           fileName: Option[String]      = None,
                           mimeType: Mime                = Mime.Unknown,
                           fileId:   Uid                 = Uid(),
-                          length:   Option[Long]        = None)
+                          length:   Option[Long]        = None) extends Identifiable[CacheKey] {
+  override val id: CacheKey = key
+}
 
 object CacheEntryData {
 

--- a/zmessaging/src/main/scala/com/waz/content/AccountsStorageOld.scala
+++ b/zmessaging/src/main/scala/com/waz/content/AccountsStorageOld.scala
@@ -31,8 +31,8 @@ import scala.concurrent.ExecutionContext
 trait AccountStorage2 extends Storage2[UserId, AccountData]
 class AccountStorageImpl2(context: Context, db: DB, ec: ExecutionContext)
   extends CachedStorage2[UserId, AccountData](
-    new DbStorage2(AccountDataDao, AccountDataDao.idExtractor)(ec, db),
-    new InMemoryStorage2[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)), AccountDataDao.idExtractor)(ec)
+    new DbStorage2(AccountDataDao)(ec, db),
+    new InMemoryStorage2[UserId, AccountData](new TrimmingLruCache(context, Fixed(8)))(ec)
   )(ec) with AccountStorage2
 
 trait AccountStorage extends CachedStorage[UserId, AccountData]

--- a/zmessaging/src/main/scala/com/waz/content/PropertiesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/PropertiesStorage.scala
@@ -22,18 +22,20 @@ import com.waz.service.PropertyKey
 import com.waz.service.assets2.StorageCodecs
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.wrappers.{DB, DBCursor}
-import com.waz.utils.{CachedStorage2, DbStorage2, InMemoryStorage2, ReactiveStorage2, ReactiveStorageImpl2, TrimmingLruCache}
+import com.waz.utils.{CachedStorage2, DbStorage2, Identifiable, InMemoryStorage2, ReactiveStorage2, ReactiveStorageImpl2, TrimmingLruCache}
 
 import scala.concurrent.ExecutionContext
 
-case class PropertyValue(key: PropertyKey, value: String)
+case class PropertyValue(key: PropertyKey, value: String) extends Identifiable[PropertyKey] {
+  override val id: PropertyKey = key
+}
 
 trait PropertiesStorage extends ReactiveStorage2[PropertyKey, PropertyValue]
 
 class PropertiesStorageImpl(implicit context: Context, db: DB, ec: ExecutionContext) extends ReactiveStorageImpl2[PropertyKey, PropertyValue](
     new CachedStorage2(
-      new DbStorage2(PropertiesDao, PropertiesDao.idExtractor),
-      new InMemoryStorage2(new TrimmingLruCache(context, Fixed(8)), PropertiesDao.idExtractor)))
+      new DbStorage2(PropertiesDao),
+      new InMemoryStorage2(new TrimmingLruCache(context, Fixed(8)))))
   with PropertiesStorage
 
 

--- a/zmessaging/src/main/scala/com/waz/db/Dao.scala
+++ b/zmessaging/src/main/scala/com/waz/db/Dao.scala
@@ -39,7 +39,6 @@ abstract class Dao[T, A] extends DaoIdOps[T] {
 
   protected def idColumns(id: IdCols): IndexedSeq[Column[_]] = Vector(id)
   protected def idValueSplitter(v: IdVals): Array[String] = Array(idCol(v))
-  def idExtractor(item: T): IdVals = idCol.extractor(item)
 
   override def getAll(ids: Set[A])(implicit db: DB): Vector[T] =
     if (ids.isEmpty) Vector.empty
@@ -52,7 +51,6 @@ abstract class Dao2[T, A, B] extends DaoIdOps[T] {
 
   protected def idColumns(id: IdCols): IndexedSeq[Column[_]] = Vector(id._1, id._2)
   protected def idValueSplitter(v: IdVals): Array[String] = Array(idCol._1.col.sqlLiteral(v._1), idCol._2.col.sqlLiteral(v._2))
-  def idExtractor(item: T): IdVals = (idCol._1.extractor(item), idCol._2.extractor(item))
 }
 
 abstract class Dao3[T, A, B, C] extends DaoIdOps[T] {
@@ -61,7 +59,6 @@ abstract class Dao3[T, A, B, C] extends DaoIdOps[T] {
 
   protected def idColumns(id: IdCols): IndexedSeq[Column[_]] = Vector(id._1, id._2, id._3)
   protected def idValueSplitter(v: IdVals): Array[String] = Array(idCol._1.col.sqlLiteral(v._1), idCol._2.col.sqlLiteral(v._2), idCol._3.col.sqlLiteral(v._3))
-  def idExtractor(item: T): IdVals = (idCol._1.extractor(item), idCol._2.extractor(item), idCol._3.extractor(item))
 }
 
 abstract class DaoIdOps[T] extends BaseDao[T] {
@@ -70,7 +67,6 @@ abstract class DaoIdOps[T] extends BaseDao[T] {
 
   protected def idColumns(id: IdCols): IndexedSeq[Column[_]]
   protected def idValueSplitter(v: IdVals): Array[String]
-  def idExtractor(item: T): IdVals
 
   val idCol: IdCols
 
@@ -99,8 +95,6 @@ abstract class DaoIdOps[T] extends BaseDao[T] {
       }
     }
   }
-
-  def update(item: T)(f: T => T)(implicit db: DB): Option[T] = updateById(idExtractor(item))(f)
 
   def updateById(id: IdVals)(f: T => T)(implicit db: DB): Option[T] = getById(id).map(it => insertOrReplace(f(it)))
 

--- a/zmessaging/src/main/scala/com/waz/model/AccountDataOld.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AccountDataOld.scala
@@ -28,7 +28,7 @@ import com.waz.sync.client.AuthenticationManager
 import com.waz.utils.Locales.currentLocaleOrdering
 import com.waz.utils.scrypt.SCrypt
 import com.waz.utils.wrappers.{DB, DBContentValues, DBCursor, DBProgram}
-import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder}
 import com.waz.sync.client.AuthenticationManager.{AccessToken, Cookie}
 import com.waz.utils.crypto.AESUtils
 import org.json.JSONObject
@@ -41,12 +41,13 @@ import scala.collection.mutable
   *
   * Any information that needs to be deregistered can be kept here (e.g., de-registered cookies, tokens, clients etc)
   */
-case class AccountData(id:           UserId              = UserId(),
-                       teamId:       Option[TeamId]      = None,
-                       cookie:       Cookie              = Cookie(""), //defaults for tests
-                       accessToken:  Option[AccessToken] = None,
-                       pushToken:    Option[PushToken]   = None,
-                       password:     Option[Password]    = None) { //password never saved to database
+case class AccountData(override val id: UserId              = UserId(),
+                       teamId:          Option[TeamId]      = None,
+                       cookie:          Cookie              = Cookie(""), //defaults for tests
+                       accessToken:     Option[AccessToken] = None,
+                       pushToken:       Option[PushToken]   = None,
+                       password:        Option[Password]    = None        //password never saved to database
+                      ) extends Identifiable[UserId] {
 
   override def toString: String =
     s"""AccountData:
@@ -98,7 +99,7 @@ object AccountData {
 /**
  * This account data needs to be maintained for migration purposes - it can be deleted after a while (1 year?)
  */
-case class AccountDataOld(id:              AccountId                       = AccountId(),
+case class AccountDataOld(override val id: AccountId                       = AccountId(),
                           teamId:          TriTeamId                       = Left({}),
                           pendingTeamName: Option[String]                  = None,
                           email:           Option[EmailAddress]            = None,
@@ -120,7 +121,7 @@ case class AccountDataOld(id:              AccountId                       = Acc
                           firstLogin:      Boolean                         = true,
                           private val _selfPermissions: Long      = 0,
                           private val _copyPermissions: Long      = 0
-                      ) {
+                      ) extends Identifiable[AccountId] {
 
   override def toString: String =
     s"""AccountData:

--- a/zmessaging/src/main/scala/com/waz/model/AssetData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AssetData.scala
@@ -35,28 +35,28 @@ import org.threeten.bp.Duration
 
 import scala.util.Try
 
-case class AssetData(id:          AssetId               = AssetId(),
-                     mime:        Mime                  = Mime.Unknown,
-                     sizeInBytes: Long                  = 0L,
-                     status:      AssetStatus           = AssetStatus.UploadNotStarted,
-                     remoteId:    Option[RAssetId]      = None,
-                     token:       Option[AssetToken]    = None,
-                     otrKey:      Option[AESKey]        = None,
-                     sha:         Option[Sha256]        = None,
-                     encryption:  Option[EncryptionAlgorithm] = None,
-                     name:        Option[String]        = None,
-                     previewId:   Option[AssetId]       = None,
-                     metaData:    Option[AssetMetaData] = None,
-                     source:      Option[URI]           = None,
-                     proxyPath:   Option[String]        = None,
+case class AssetData(override val id: AssetId               = AssetId(),
+                     mime:            Mime                  = Mime.Unknown,
+                     sizeInBytes:     Long                  = 0L,
+                     status:          AssetStatus           = AssetStatus.UploadNotStarted,
+                     remoteId:        Option[RAssetId]      = None,
+                     token:           Option[AssetToken]    = None,
+                     otrKey:          Option[AESKey]        = None,
+                     sha:             Option[Sha256]        = None,
+                     encryption:      Option[EncryptionAlgorithm] = None,
+                     name:            Option[String]        = None,
+                     previewId:       Option[AssetId]       = None,
+                     metaData:        Option[AssetMetaData] = None,
+                     source:          Option[URI]           = None,
+                     proxyPath:       Option[String]        = None,
                      //TODO remove v2 attributes when transition period is over
-                     convId:      Option[RConvId]       = None,
+                     convId:          Option[RConvId]       = None,
                      //data only used for temporary caching and legacy reasons - shouldn't be stored in AssetsStorage where possible
-                     data:        Option[Array[Byte]]   = None,
-                     v2ProfileId: Option[RAssetId]      = None,
+                     data:            Option[Array[Byte]]   = None,
+                     v2ProfileId:     Option[RAssetId]      = None,
                      //TODO remove after v2 transtion period (eases database migration)
-                     assetType:   Option[AssetType]     = None
-                    ) {
+                     assetType:       Option[AssetType]     = None
+                    ) extends Identifiable[AssetId] {
 
   import AssetData._
 

--- a/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ConversationData.scala
@@ -33,7 +33,7 @@ import org.json.JSONArray
 
 import scala.concurrent.duration._
 
-case class ConversationData(id:                   ConvId                 = ConvId(),
+case class ConversationData(override val id:      ConvId                 = ConvId(),
                             remoteId:             RConvId                = RConvId(),
                             name:                 Option[Name]           = None,
                             creator:              UserId                 = UserId(),
@@ -61,7 +61,7 @@ case class ConversationData(id:                   ConvId                 = ConvI
                             accessRole:           Option[AccessRole]     = None, //option for migration purposes only - at some point we do a fetch and from that point it will always be defined
                             link:                 Option[Link]           = None,
                             receiptMode:          Option[Int]            = None
-                           ) {
+                           ) extends Identifiable[ConvId] {
 
   def displayName = if (convType == ConversationType.Group) name.getOrElse(generatedName) else generatedName
 
@@ -113,7 +113,9 @@ case class ConversationData(id:                   ConvId                 = ConvI
 /**
  * Conversation user binding.
  */
-case class ConversationMemberData(userId: UserId, convId: ConvId)
+case class ConversationMemberData(userId: UserId, convId: ConvId) extends Identifiable[(UserId, ConvId)] {
+  override val id: (UserId, ConvId) = (userId, convId)
+}
 
 object ConversationData {
 

--- a/zmessaging/src/main/scala/com/waz/model/EditHistory.scala
+++ b/zmessaging/src/main/scala/com/waz/model/EditHistory.scala
@@ -19,11 +19,13 @@ package com.waz.model
 
 import com.waz.db.Col._
 import com.waz.db.Dao
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.{DB, DBCursor}
 import org.threeten.bp.Instant
 
-
-case class EditHistory(originalId: MessageId, updatedId: MessageId, time: RemoteInstant)
+case class EditHistory(originalId: MessageId, updatedId: MessageId, time: RemoteInstant) extends Identifiable[MessageId] {
+  override val id: MessageId = originalId
+}
 
 object EditHistory {
 

--- a/zmessaging/src/main/scala/com/waz/model/ErrorData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ErrorData.scala
@@ -23,18 +23,18 @@ import com.waz.api.ErrorType
 import com.waz.api.impl.ErrorResponse
 import com.waz.db.Col._
 import com.waz.db.Dao
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.{DB, DBCursor}
 
-case class ErrorData(id: Uid,
-                     errType: ErrorType,
-                     users: Seq[UserId] = Nil,
-                     messages: Seq[MessageId] = Nil,
-                     convId: Option[ConvId] = None,
-                     responseCode: Int = 0,
+case class ErrorData(override val id: Uid,
+                     errType:         ErrorType,
+                     users:           Seq[UserId] = Nil,
+                     messages:        Seq[MessageId] = Nil,
+                     convId:          Option[ConvId] = None,
+                     responseCode:    Int = 0,
                      responseMessage: String = "",
-                     responseLabel: String = "",
-                     time: Date = new Date) {
-}
+                     responseLabel:   String = "",
+                     time: Date = new Date) extends Identifiable[Uid]
 
 object ErrorData {
 

--- a/zmessaging/src/main/scala/com/waz/model/KeyValueData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/KeyValueData.scala
@@ -19,9 +19,12 @@ package com.waz.model
 
 import com.waz.db.Col._
 import com.waz.db.Dao
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.DBCursor
 
-case class KeyValueData(key: String, value: String)
+case class KeyValueData(key: String, value: String) extends Identifiable[String] {
+  override val id: String = key
+}
 
 object KeyValueData {
 

--- a/zmessaging/src/main/scala/com/waz/model/Liking.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Liking.scala
@@ -22,12 +22,11 @@ import com.waz.db.Col._
 import com.waz.db.{Dao2, Reader, iteratingWithReader}
 import com.waz.utils.JsonEncoder.encodeInstant
 import com.waz.utils.wrappers.{DB, DBCursor}
-import com.waz.utils.{JsonDecoder, JsonEncoder}
-import com.waz.utils.RichWireInstant
+import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder, RichWireInstant}
 import org.json.JSONObject
 
-case class Liking(message: MessageId, user: UserId, timestamp: RemoteInstant, action: Liking.Action) {
-  lazy val id: Liking.Id = (message, user)
+case class Liking(message: MessageId, user: UserId, timestamp: RemoteInstant, action: Liking.Action) extends Identifiable[Liking.Id] {
+  override val id: Liking.Id = (message, user)
 
   def max(other: Liking) =
     if (other.message == message && other.user == user && other.timestamp.isAfter(timestamp)) other else this

--- a/zmessaging/src/main/scala/com/waz/model/MessageContentIndexDao.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageContentIndexDao.scala
@@ -21,9 +21,12 @@ import com.waz.ZLog._
 import com.waz.api.{ContentSearchQuery, Message}
 import com.waz.db.Col._
 import com.waz.db.Dao
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.{DB, DBCursor}
 
-case class MessageContentIndexEntry(messageId: MessageId, convId: ConvId, content: String, time: RemoteInstant)
+case class MessageContentIndexEntry(messageId: MessageId, convId: ConvId, content: String, time: RemoteInstant) extends Identifiable[MessageId] {
+  override val id: MessageId = messageId
+}
 
 object MessageContentIndexDao extends Dao[MessageContentIndexEntry, MessageId] {
   import MessageContentIndex._

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -37,14 +37,14 @@ import com.waz.service.ZMessaging.clock
 import com.waz.service.media.{MessageContentBuilder, RichMediaContentParser}
 import com.waz.sync.client.OpenGraphClient.OpenGraphData
 import com.waz.utils.wrappers.{DB, DBCursor, URI}
-import com.waz.utils.{EnumCodec, JsonDecoder, JsonEncoder, returning}
+import com.waz.utils.{EnumCodec, Identifiable, JsonDecoder, JsonEncoder, returning}
 import org.json.{JSONArray, JSONObject}
 import org.threeten.bp.Instant.now
 
 import scala.collection.breakOut
 import scala.concurrent.duration._
 
-case class MessageData(id:                MessageId              = MessageId(),
+case class MessageData(override val id:   MessageId              = MessageId(),
                        convId:            ConvId                 = ConvId(),
                        msgType:           Message.Type           = Message.Type.TEXT,
                        userId:            UserId                 = UserId(),
@@ -65,7 +65,7 @@ case class MessageData(id:                MessageId              = MessageId(),
                        duration:          Option[FiniteDuration] = None, //for successful calls and message_timer changes
                        quote:             Option[QuoteContent]   = None,
                        forceReadReceipts: Option[Int]    = None
-                      ) {
+                      ) extends Identifiable[MessageId] {
   def getContent(index: Int) = {
     if (index == 0) content.headOption.getOrElse(MessageContent.Empty)
     else content.drop(index).headOption.getOrElse(MessageContent.Empty)

--- a/zmessaging/src/main/scala/com/waz/model/MsgDeletion.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MsgDeletion.scala
@@ -19,10 +19,13 @@ package com.waz.model
 
 import com.waz.db.Col._
 import com.waz.db.Dao
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.{DB, DBCursor}
 import org.threeten.bp.Instant
 
-case class MsgDeletion(msg: MessageId, time: Instant)
+case class MsgDeletion(msg: MessageId, time: Instant) extends Identifiable[MessageId] {
+  override val id: MessageId = msg
+}
 
 object MsgDeletion {
 

--- a/zmessaging/src/main/scala/com/waz/model/NotificationData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/NotificationData.scala
@@ -22,10 +22,10 @@ import com.waz.api.NotificationsHandler.NotificationType.LikedContent
 import com.waz.db.Col._
 import com.waz.db.Dao
 import com.waz.utils.wrappers.DBCursor
-import com.waz.utils.{EnumCodec, JsonDecoder, JsonEncoder}
+import com.waz.utils.{EnumCodec, Identifiable, JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 
-case class NotificationData(id:                NotId                = NotId(),
+case class NotificationData(override val id:   NotId                = NotId(),
                             msg:               String               = "",
                             conv:              ConvId               = ConvId(),
                             user:              UserId               = UserId(),
@@ -35,8 +35,7 @@ case class NotificationData(id:                NotId                = NotId(),
                             isSelfMentioned:   Boolean              = false,
                             likedContent:      Option[LikedContent] = None,
                             isReply:           Boolean              = false,
-                            hasBeenDisplayed:  Boolean              = false) {
-}
+                            hasBeenDisplayed:  Boolean              = false) extends Identifiable[NotId]
 
 object NotificationData {
 

--- a/zmessaging/src/main/scala/com/waz/model/PushNotificationEvents.scala
+++ b/zmessaging/src/main/scala/com/waz/model/PushNotificationEvents.scala
@@ -19,6 +19,7 @@ package com.waz.model
 
 import com.waz.db.Dao
 import com.waz.db.Col._
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.{DB, DBCursor}
 import org.json
 import org.json.JSONObject
@@ -53,4 +54,6 @@ case class PushNotificationEvent(pushId:    Uid,
                                  decrypted: Boolean = false,
                                  event:     JSONObject,
                                  plain:     Option[Array[Byte]] = None,
-                                 transient: Boolean)
+                                 transient: Boolean) extends Identifiable[Int] {
+  override val id: Int = index
+}

--- a/zmessaging/src/main/scala/com/waz/model/ReadReceipt.scala
+++ b/zmessaging/src/main/scala/com/waz/model/ReadReceipt.scala
@@ -18,11 +18,11 @@
 package com.waz.model
 import com.waz.db.Col.{id, remoteTimestamp}
 import com.waz.db.{Dao2, Table}
-import com.waz.utils.Managed
+import com.waz.utils.{Identifiable, Managed}
 import com.waz.utils.wrappers.{DB, DBCursor}
 
-case class ReadReceipt(message: MessageId, user: UserId, timestamp: RemoteInstant) {
-  lazy val id: ReadReceipt.Id = (message, user)
+case class ReadReceipt(message: MessageId, user: UserId, timestamp: RemoteInstant) extends Identifiable[ReadReceipt.Id] {
+  override val id: ReadReceipt.Id = (message, user)
 }
 
 object ReadReceipt {

--- a/zmessaging/src/main/scala/com/waz/model/SearchQueryCache.scala
+++ b/zmessaging/src/main/scala/com/waz/model/SearchQueryCache.scala
@@ -20,11 +20,14 @@ package com.waz.model
 import com.waz.db.Col._
 import com.waz.db.Dao
 import com.waz.utils.wrappers.{DB, DBCursor}
-import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder}
 import org.json.JSONArray
 import org.threeten.bp.Instant
 
 case class SearchQueryCache(query: SearchQuery, timestamp: Instant, entries: Option[Vector[UserId]])
+extends Identifiable[SearchQuery] {
+  override val id: SearchQuery = query
+}
 
 object SearchQueryCache {
   implicit object SearchQueryCacheDao extends Dao[SearchQueryCache, SearchQuery] {

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -19,15 +19,15 @@ package com.waz.model
 
 import com.waz.db.Dao
 import com.waz.model
-import com.waz.utils.JsonDecoder
+import com.waz.utils.{Identifiable, JsonDecoder}
 import com.waz.utils.wrappers.DBCursor
 import org.json.JSONObject
 
-case class TeamData(id:      TeamId,
-                    name:    Name,
-                    creator: UserId,
-                    icon:    Option[RAssetId] = None,
-                    iconKey: Option[AESKey]  = None)
+case class TeamData(override val id: TeamId,
+                    name:            Name,
+                    creator:         UserId,
+                    icon:            Option[RAssetId] = None,
+                    iconKey:         Option[AESKey]  = None) extends Identifiable[TeamId]
 
 object TeamData {
 

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -30,7 +30,7 @@ import org.json.JSONObject
 
 import scala.concurrent.duration._
 
-case class UserData(id:                    UserId,
+case class UserData(override val id:       UserId,
                     teamId:                Option[TeamId]        = None,
                     name:                  Name,
                     email:                 Option[EmailAddress]  = None,
@@ -52,7 +52,7 @@ case class UserData(id:                    UserId,
                     handle:                Option[Handle]        = None,
                     providerId:            Option[ProviderId]    = None,
                     integrationId:         Option[IntegrationId] = None,
-                    expiresAt:             Option[RemoteInstant] = None) {
+                    expiresAt:             Option[RemoteInstant] = None) extends Identifiable[UserId] {
 
   def isConnected = ConnectionStatus.isConnected(connection)
   def hasEmailOrPhone = email.isDefined || phone.isDefined

--- a/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
+++ b/zmessaging/src/main/scala/com/waz/model/otr/Client.scala
@@ -25,7 +25,7 @@ import com.waz.db.Dao
 import com.waz.model.{Id, UserId}
 import com.waz.utils.crypto.ZSecureRandom
 import com.waz.utils.wrappers.{DB, DBCursor}
-import com.waz.utils.{JsonDecoder, JsonEncoder}
+import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder}
 import org.json.JSONObject
 import org.threeten.bp.Instant
 
@@ -138,7 +138,8 @@ object Client {
   }
 }
 
-case class UserClients(user: UserId, clients: Map[ClientId, Client]) {
+case class UserClients(user: UserId, clients: Map[ClientId, Client]) extends Identifiable[UserId] {
+  override val id: UserId = user
   def -(clientId: ClientId) = UserClients(user, clients - clientId)
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/assets2/AssetStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets2/AssetStorage.scala
@@ -38,8 +38,8 @@ trait AssetStorage extends ReactiveStorage2[AssetId, Asset[General]]
 
 class AssetStorageImpl(context: Context, db: DB, ec: ExecutionContext) extends ReactiveStorageImpl2(
   new CachedStorage2[AssetId, Asset[General]](
-    new DbStorage2(AssetDao, AssetDao.idExtractor)(ec, db),
-    new InMemoryStorage2[AssetId, Asset[General]](new TrimmingLruCache(context, Fixed(8)), AssetDao.idExtractor)(ec)
+    new DbStorage2(AssetDao)(ec, db),
+    new InMemoryStorage2[AssetId, Asset[General]](new TrimmingLruCache(context, Fixed(8)))(ec)
   )(ec)
 ) with AssetStorage
 

--- a/zmessaging/src/main/scala/com/waz/service/assets2/models.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets2/models.scala
@@ -22,11 +22,12 @@ import java.net.URI
 import com.waz.cache2.CacheService.Encryption
 import com.waz.model._
 import com.waz.sync.client.AssetClient2.Retention
+import com.waz.utils.Identifiable
 import org.threeten.bp.Duration
 
 //TODO Maybe we can remove encryption here
 case class RawAsset[+T <: AssetDetails](
-    id: AssetId,
+    override val id: AssetId,
     uri: URI,
     sha: Sha256,
     mime: Mime,
@@ -36,10 +37,10 @@ case class RawAsset[+T <: AssetDetails](
     encryption: Encryption,
     details: T,
     @deprecated convId: Option[RConvId]
-)
+) extends Identifiable[AssetId]
 
 case class Asset[+T <: AssetDetails](
-    id: AssetId,
+    override val id: AssetId,
     token: Option[AssetToken], //all not public assets should have an AssetToken
     sha: Sha256,
     encryption: Encryption,
@@ -47,7 +48,7 @@ case class Asset[+T <: AssetDetails](
     preview: Option[AssetId],
     details: T,
     @deprecated convId: Option[RConvId]
-)
+) extends Identifiable[AssetId]
 
 object Asset {
   type General = AssetDetails

--- a/zmessaging/src/main/scala/com/waz/service/push/ReceivedPushData.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/ReceivedPushData.scala
@@ -26,7 +26,7 @@ import com.waz.model.Uid
 import com.waz.service.push.ReceivedPushData.ReceivedPushDataDao
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.wrappers.DBCursor
-import com.waz.utils.{CachedStorage, CachedStorageImpl, JsonDecoder, JsonEncoder, TrimmingLruCache, returning}
+import com.waz.utils.{CachedStorage, CachedStorageImpl, Identifiable, JsonDecoder, JsonEncoder, TrimmingLruCache, returning}
 import org.json.JSONObject
 import org.threeten.bp.{Duration, Instant}
 
@@ -41,13 +41,13 @@ class ReceivedPushStorageImpl(context: Context, storage: Database)
   * @param receivedAt instant the push notification was received
   * @param toFetch time elapsed until we successfully fetched the notification
   */
-case class ReceivedPushData(id:              Uid, //for notifications where we don't get the id, we will generate a random one for storage's sake
+case class ReceivedPushData(override val id: Uid, //for notifications where we don't get the id, we will generate a random one for storage's sake
                             sinceSent:       Duration,
                             receivedAt:      Instant,
                             networkMode:     NetworkMode,
                             networkOperator: String,
                             isDeviceIdle:    Boolean,
-                            toFetch:         Option[Duration] = None)
+                            toFetch:         Option[Duration] = None) extends Identifiable[Uid]
 
 object ReceivedPushData {
 

--- a/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
+++ b/zmessaging/src/test/scala/com/waz/AuthenticationConfig.scala
@@ -61,7 +61,7 @@ object AuthenticationConfig {
       accessToken = Some(loginResult.accessToken)
     )
 
-    val accountStorage = new UnlimitedInMemoryStorage[UserId, AccountData](_.id) with AccountStorage2
+    val accountStorage = new UnlimitedInMemoryStorage[UserId, AccountData] with AccountStorage2
     Await.ready(accountStorage.save(testAccountData), 1.minute)
 
     new AuthenticationManager2(userInfo.id, accountStorage, LoginClient, DisabledTrackingService)

--- a/zmessaging/src/test/scala/com/waz/testutils/package.scala
+++ b/zmessaging/src/test/scala/com/waz/testutils/package.scala
@@ -191,10 +191,8 @@ package object testutils {
   }
 
 
-  implicit class RichStorage[K, V](storage: CachedStorageImpl[K, V]) {
-    def deleteAll() = storage.list() flatMap { vs =>
-      storage.removeAll(vs.map(storage.dao.idExtractor))
-    }
+  implicit class RichStorage[K, V <: com.waz.utils.Identifiable[K]](storage: CachedStorageImpl[K, V]) {
+    def deleteAll() = storage.list().flatMap { vs => storage.removeAll(vs.map(_.id)) }
   }
 
   def randomPhoneNumber = PhoneNumber("+0" + (Random.nextInt(9) + 1).toString + Array.fill(13)(Random.nextInt(10)).mkString)

--- a/zmessaging/src/test/scala/com/waz/utils/CachedStorageSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/CachedStorageSpec.scala
@@ -31,10 +31,7 @@ class CachedStorageSpec extends ZIntegrationMockSpec {
   feature("CachedStorage specific features") {
 
     scenario("Load, when values exist in cache, return that values and do not touch main storage") {
-      val keys = values.map(keyExtractor)
-
-      (cache.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
-      (main.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
+      val keys = values.map(_.id)
 
       (cache.loadAll _)
         .expects(where { keys: Set[Int] => keys.size == values.size })
@@ -46,15 +43,12 @@ class CachedStorageSpec extends ZIntegrationMockSpec {
       for {
         loaded <- cachedStorage.loadAll(keys)
       } yield {
-        loaded.map(keyExtractor).toSet shouldBe keys
+        loaded.map(_.id).toSet shouldBe keys
       }
     }
 
     scenario("Load, when values do not exist in cache, return that values from the main storage and put them in cache") {
-      val keys = values.map(keyExtractor)
-
-      (cache.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
-      (main.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
+      val keys = values.map(_.id)
 
       (cache.loadAll _)
         .expects(where { keys: Set[Int] => keys.size == values.size })
@@ -74,15 +68,12 @@ class CachedStorageSpec extends ZIntegrationMockSpec {
       for {
         loaded <- cachedStorage.loadAll(keys)
       } yield {
-        loaded.map(keyExtractor).toSet shouldBe keys
+        loaded.map(_.id).toSet shouldBe keys
       }
     }
 
     scenario("Should remove all values from cache and from main on delete") {
-      val keys = values.map(keyExtractor)
-
-      (cache.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
-      (main.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
+      val keys = values.map(_.id)
 
       (cache.deleteAllByKey _)
         .expects(where { keys: Set[Int] => keys.size == values.size })
@@ -100,9 +91,6 @@ class CachedStorageSpec extends ZIntegrationMockSpec {
     }
 
     scenario("Should save all values in cache and in main on save") {
-      (cache.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
-      (main.keyExtractor _).expects().anyNumberOfTimes().returns(keyExtractor)
-
       (cache.saveAll _)
         .expects(where { xs: Iterable[TestObject] => xs.size == values.size })
         .once()

--- a/zmessaging/src/test/scala/com/waz/utils/StorageTestData.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/StorageTestData.scala
@@ -18,7 +18,6 @@
 package com.waz.utils
 
 object StorageTestData {
-  case class TestObject(id: Int, title: String)
+  case class TestObject(override val id: Int, title: String) extends Identifiable[Int]
   val values: Set[TestObject] = (1 to 50).map(i => TestObject(id = i, title = s"test object $i")).toSet
-  val keyExtractor: TestObject => Int = _.id
 }

--- a/zmessaging/src/test/scala/com/waz/utils/UnlimitedInMemoryStorage.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/UnlimitedInMemoryStorage.scala
@@ -22,13 +22,11 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class UnlimitedInMemoryStorage[K,V](override val keyExtractor: V => K)
-                                   (implicit
-                                    override val ec: ExecutionContext) extends Storage2[K, V] {
+class UnlimitedInMemoryStorage[K, V <: Identifiable[K]](implicit override val ec: ExecutionContext) extends Storage2[K, V] {
 
   private val map: ConcurrentHashMap[K,V] = new concurrent.ConcurrentHashMap[K, V]()
 
   override def loadAll(keys: Set[K]): Future[Seq[V]] = Future(keys.toSeq.flatMap(k => Option(map.get(k))))
-  override def saveAll(values: Iterable[V]): Future[Unit] = Future(values.map(v => map.put(keyExtractor(v), v)))
+  override def saveAll(values: Iterable[V]): Future[Unit] = Future(values.map(v => map.put(v.id, v)))
   override def deleteAllByKey(keys: Set[K]): Future[Unit] = Future(keys.map(map.remove))
 }


### PR DESCRIPTION
When accessing storage we often use "id extractors" (or "key extractors") to get the id of an object we're manipulating. The id extractor accesses the db and retrieves the id from there. This is necessary because until now at this point in code we knew nothing about the type of the object. It was a generic type `V`, associated with a `Dao` class and only from there we were able to get any information about it, at run-time.
But if we change the signature of case classes of objects we held in the db, we can easily access their ids at compile-time, rendering id extractors unnecessary. It should lower the number of times we access storage.
