### PR TITLE
fix: Improvements for slowdown

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -227,7 +227,7 @@ class MessagesStorageImpl(context:     Context,
     find(m => m.convId == conv && !m.time.isBefore(time), MessageDataDao.findMessagesFrom(conv, time)(_), identity)
 
   def findMessagesBetween(conv: ConvId, from: RemoteInstant, to: RemoteInstant): Future[IndexedSeq[MessageData]] =
-    find(m => !m.isLocal, MessageDataDao.findMessagesBetween(conv, from, to)(_), identity)
+    find(m => !m.isLocal && m.time.isAfter(from) && (m.time.isBefore(to) || m.time == to), MessageDataDao.findMessagesBetween(conv, from, to)(_), identity)
 
   override def delete(msg: MessageData) =
     for {

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -100,8 +100,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     case Some(convId) => convsStorage.get(convId).flatMap {
       case Some(conv) if conv.accessRole.isEmpty =>
         for {
-          syncId        <- sync.syncConversations(Set(conv.id))
-          _             <- syncReqService.await(syncId)
+          syncIds        <- sync.syncConversations(Set(conv.id))
+          _             <- syncReqService.await(syncIds)
           Some(updated) <- content.convById(conv.id)
         } yield if (updated.access.contains(Access.CODE)) sync.syncConvLink(conv.id)
 
@@ -173,8 +173,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
           sync.syncConversations(Set(conv.id)).map(Option(_))
         else
           Future.successful(None)
-        syncId <- users.syncIfNeeded(userIds.toSet)
-        _ <- syncId.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))
+        syncIds <- users.syncIfNeeded(userIds.toSet)
+        _ <- syncReqService.await(syncIds).map(_ => ())
         _ <- membersStorage.add(conv.id, userIds)
         _ <- if (userIds.contains(selfUserId)) content.setConvActive(conv.id, active = true) else successful(None)
         _ <- convSync.fold(Future.successful(()))(sId => syncReqService.await(sId).map(_ => ()))

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -416,7 +416,7 @@ class ConversationsUiServiceImpl(selfUserId:      UserId,
           }
           RichFuture.traverseSequential(msgs.groupBy(_.userId).toSeq)( { case (u, ms) if ms.nonEmpty =>
             sync.postReceipt(convId, ms.map(_.id), u, ReceiptType.Read)
-          })
+          }).map(_.flatten)
         }
       }
     }

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -151,7 +151,7 @@ class AndroidSyncServiceHandle(account: UserId, service: SyncRequestService, tim
   = addRequest(PostConv(id, users, name, team, access, accessRole, receiptMode))
   def postReceiptMode(id: ConvId, receiptMode: Int): Future[SyncId] = addRequest(PostConvReceiptMode(id, receiptMode))
   def postLiking(id: ConvId, liking: Liking): Future[SyncId] = addRequest(PostLiking(id, liking))
-  def postLastRead(id: ConvId, time: RemoteInstant) = addRequest(PostLastRead(id, time), priority = Priority.Low, delay = timeouts.messages.lastReadPostDelay)
+  def postLastRead(id: ConvId, time: RemoteInstant) = addRequest(PostLastRead(id, time), priority = Priority.Normal)
   def postCleared(id: ConvId, time: RemoteInstant) = addRequest(PostCleared(id, time))
   def postOpenGraphData(conv: ConvId, msg: MessageId, time: RemoteInstant) = addRequest(PostOpenGraphMeta(conv, msg, time), priority = Priority.Low)
   def postReceipt(conv: ConvId, messages: Seq[MessageId], user: UserId, tpe: ReceiptType): Future[SyncId] = addRequest(PostReceipt(conv, messages, user, tpe), priority = Priority.Optional)

--- a/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/ExpiredUsersServiceSpec.scala
@@ -69,7 +69,7 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
       println(s"us: $us")
       if (!us.contains(wirelessId)) fail("Called sync for wrong user")
       finished ! {}
-      Future.successful(SyncId())
+      Future.successful(Set(SyncId()))
     }
 
     result(finished.next)
@@ -139,7 +139,7 @@ class ExpiredUsersServiceSpec extends AndroidFreeSpec {
     (sync.syncUsers _).expects(*).once().onCall { (us: Set[UserId]) =>
       if (!us.contains(wirelessUser.id)) fail("Called sync for wrong user")
       finished ! {}
-      Future.successful(SyncId())
+      Future.successful(Set(SyncId()))
     }
 
     result(finished.next)

--- a/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserServiceSpec.scala
@@ -58,7 +58,7 @@ class UserServiceSpec extends AndroidFreeSpec {
   (usersStorage.optSignal _).expects(*).anyNumberOfTimes().onCall((id: UserId) => Signal.const(users.find(_.id == id)))
   (accountsService.accountsWithManagers _).expects().anyNumberOfTimes().returning(Signal.empty)
   (pushService.onHistoryLost _).expects().anyNumberOfTimes().returning(new SourceSignal(Some(Instant.now())) with BgEventSource)
-  (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(SyncId()))
+  (sync.syncUsers _).expects(*).anyNumberOfTimes().returning(Future.successful(Set(SyncId())))
   (assetService.updateAssets _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
   (usersStorage.updateOrCreateAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Set.empty))
   (selectedConv.selectedConversationId _).expects().anyNumberOfTimes().returning(Signal.const(None))

--- a/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/connections/ConnectionServiceSpec.scala
@@ -153,7 +153,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
         }.toSet)
       }
 
-      (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(SyncId()))
+      (sync.syncUsers _).expects(Set(otherUser.id)).returning(Future.successful(Set(SyncId())))
       (usersStorage.listAll _).expects(*).returning(Future.successful(Vector(otherUser)))
       (convsStorage.getByRemoteIds2 _).expects(Set(remoteId)).twice().returning(Future.successful(Map.empty))
       (convsStorage.updateLocalIds _).expects(Map.empty[ConvId, ConvId]).returning(Future.successful(Set.empty))
@@ -234,7 +234,7 @@ class ConnectionServiceSpec extends AndroidFreeSpec with Inside {
     (messagesService.addDeviceStartMessages _).expects(*, *).anyNumberOfTimes().onCall{ (convs: Seq[ConversationData], selfUserId: UserId) =>
       Future.successful(convs.map(conv => MessageData(MessageId(), conv.id, Message.Type.STARTED_USING_DEVICE, selfUserId)).toSet)
     }
-    (sync.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(SyncId()))
+    (sync.syncUsers _).expects(*).anyNumberOfTimes().returns(Future.successful(Set(SyncId())))
     new ConnectionServiceImpl(selfUserId, teamId, push, convs, convsStorage, members, messagesService, messagesStorage, users, usersStorage, sync)
   }
 }


### PR DESCRIPTION
The introduction of the work manager brought some shortcomings that we didn't expect, like no throttling or order guarantee of commands (which led to no proper way of merging them as well). 
This PR only removes the delay of the last read command and a predicate fix for read receipt messages. It is possible that other issues we haven't noticed yet will arise.