### PR TITLE
fix: Message sending should fail when on offline instead of retrying

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -111,7 +111,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val syncRequests:      SyncRequestService      = wire[SyncRequestServiceImpl]
   lazy val syncContent:       SyncContentUpdater      = wire[SyncContentUpdaterImpl]
 
-  lazy val otrClientsService: OtrClientsService       = wire[OtrClientsService]
+  lazy val otrClientsService: OtrClientsService       = wire[OtrClientsServiceImpl]
   lazy val otrClientsSync:    OtrClientsSyncHandler   = wire[OtrClientsSyncHandlerImpl]
   lazy val otrClient:         OtrClientImpl           = account.otrClient
   lazy val credentialsClient: CredentialsUpdateClientImpl = account.credentialsClient

--- a/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/MessagesSyncHandler.scala
@@ -130,7 +130,13 @@ class MessagesSyncHandler(selfUserId: UserId,
                 case _ =>
                   Future.successful({})
               }
-              result <- SyncResult(error) match {
+              syncResult = error match {
+                case ErrorResponse(ErrorResponse.ConnectionErrorCode, _, _) =>
+                  Failure.apply(error)
+                case _ =>
+                  SyncResult(error)
+              }
+              result <- syncResult match {
                 case r: SyncResult.Failure =>
                   service
                     .messageDeliveryFailed(convId, msg, error)

--- a/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/otr/OtrSyncHandler.scala
@@ -95,7 +95,7 @@ class OtrSyncHandlerImpl(teamId:             Option[TeamId],
             clientsSyncHandler.syncSessions(missing).flatMap { err =>
               if (err.isDefined)
                 error(s"syncSessions for missing clients failed: $err")
-              encryptAndSend(msg, external, retries, content)
+              encryptAndSend(msg, external, retries + 1, content)
             }
           case _: MessageResponse.Failure =>
             successful(Left(internalError(s"postEncryptedMessage/broadcastMessage failed with missing clients after several retries")))

--- a/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/MessagesSyncHandlerSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.sync.handler
+import com.waz.api.{Message, NetworkMode}
+import com.waz.api.impl.ErrorResponse
+import com.waz.content.MessagesStorage
+import com.waz.model._
+import com.waz.service.ErrorsService
+import com.waz.service.assets.AssetService
+import com.waz.service.conversation.ConversationsContentUpdater
+import com.waz.service.messages.{MessagesContentUpdater, MessagesService}
+import com.waz.service.otr.OtrClientsService
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.SyncHandler.RequestInfo
+import com.waz.sync.SyncResult.Failure
+import com.waz.sync.SyncServiceHandle
+import com.waz.sync.otr.OtrSyncHandler
+
+import scala.concurrent.Future
+
+class MessagesSyncHandlerSpec extends AndroidFreeSpec {
+
+  val service    = mock[MessagesService]
+  val msgContent = mock[MessagesContentUpdater]
+  val clients    = mock[OtrClientsService]
+  val otrSync    = mock[OtrSyncHandler]
+  val convs      = mock[ConversationsContentUpdater]
+  val storage    = mock[MessagesStorage]
+  val assetSync  = mock[AssetSyncHandler]
+  val sync       = mock[SyncServiceHandle]
+  val assets     = mock[AssetService]
+  val errors     = mock[ErrorsService]
+
+  def getHandler: MessagesSyncHandler = {
+    new MessagesSyncHandler(account1Id, service, msgContent, clients, otrSync, convs, storage, assetSync, sync, assets, errors)
+  }
+
+  scenario("post invalid message should fail immediately") {
+
+    val convId = ConvId()
+    val messageId = MessageId()
+    implicit val requestInfo: RequestInfo = RequestInfo(0, clock.instant(), Option(NetworkMode.WIFI))
+
+    (storage.getMessage _).expects(messageId).returning(Future.successful(None))
+
+    result(getHandler.postMessage(convId, messageId, RemoteInstant.Epoch)).isInstanceOf[Failure] should be(true)
+  }
+
+  scenario("post message with no internet should fail immediately") {
+
+    val convId = ConvId()
+    val messageId = MessageId()
+    val message = MessageData(messageId, convId = convId)
+    val connectionError = ErrorResponse(ErrorResponse.ConnectionErrorCode, "", "")
+    implicit val requestInfo: RequestInfo = RequestInfo(0, clock.instant(), Option(NetworkMode.OFFLINE))
+
+    (storage.getMessage _).expects(messageId).returning(Future.successful(Option(message)))
+    (convs.convById _).expects(convId).returning(Future.successful(Option(ConversationData(convId))))
+
+    (otrSync.postOtrMessage _).expects(convId, *, * ,*).returning(Future.successful(Left(connectionError)))
+
+    (service.messageDeliveryFailed _).expects(convId, message, connectionError).returning(Future.successful(Some(message.copy(state = Message.Status.FAILED))))
+
+    result(getHandler.postMessage(convId, messageId, RemoteInstant.Epoch)).isInstanceOf[Failure] should be(true)
+  }
+}


### PR DESCRIPTION
When sending a message offline, it should fail and ask the user to resend.