### PR TITLE
fix: Use correct predicate for the findMessagesBetween

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -227,7 +227,7 @@ class MessagesStorageImpl(context:     Context,
     find(m => m.convId == conv && !m.time.isBefore(time), MessageDataDao.findMessagesFrom(conv, time)(_), identity)
 
   def findMessagesBetween(conv: ConvId, from: RemoteInstant, to: RemoteInstant): Future[IndexedSeq[MessageData]] =
-    find(m => !m.isLocal, MessageDataDao.findMessagesBetween(conv, from, to)(_), identity)
+    find(m => !m.isLocal && m.time.isAfter(from) && (m.time.isBefore(to) || m.time == to), MessageDataDao.findMessagesBetween(conv, from, to)(_), identity)
 
   override def delete(msg: MessageData) =
     for {


### PR DESCRIPTION
The SQL query isn't enough to filter out the messages in between the provided timestamps