### PR TITLE
fix: Send a typing indicator event

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncRequestService.scala
@@ -79,8 +79,10 @@ class SyncRequestServiceImpl(accountId: UserId,
                           forceRetry: Boolean        = false,
                           delay:      FiniteDuration = Duration.Zero) = {
     val timestamp = SyncJob.timestamp
-    val startTime = if (delay == Duration.Zero) 0 else timestamp + delay.toMillis
-    content.addSyncJob(SyncJob(SyncId(), req, dependsOn.toSet, priority = priority, timestamp = timestamp, startTime = startTime), forceRetry).map(_.id)
+    content.addSyncJob(
+      SyncJob(SyncId(), req, dependsOn.toSet, priority = priority, timestamp = timestamp, startTime = SyncJob.timestamp + delay.toMillis),
+      forceRetry
+    ).map(_.id)
   }
 
   override def await(ids: Set[SyncId]): Future[Set[SyncResult]] =

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TypingSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TypingSyncHandler.scala
@@ -29,18 +29,16 @@ import com.waz.threading.Threading
 import com.waz.utils._
 
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class TypingSyncHandler(client:        TypingClient,
                         convs:         ConversationsContentUpdaterImpl,
                         typingService: TypingService,
                         timeouts:      Timeouts) {
 
-  import TypingSyncHandler._
   import Threading.Implicits.Background
 
   def postTypingState(convId: ConvId, typing: Boolean)(implicit info: RequestInfo): Future[SyncResult] =
-    if (TypingIndicatorTimeout.elapsedSince(info.requestStart))
+    if (timeouts.typing.refreshDelay.elapsedSince(info.requestStart))
       Future.successful(SyncResult.Failure(expired("Typing indicator request no longer valid")))
     else convs.convById(convId).flatMap {
       case Some(conv) =>
@@ -52,8 +50,4 @@ class TypingSyncHandler(client:        TypingClient,
       case None =>
         Future.successful(Failure(s"conversation not found: $convId"))
     }
-}
-
-object TypingSyncHandler {
-  val TypingIndicatorTimeout = 45.seconds
 }


### PR DESCRIPTION
Recent introduction of `RequestInfo` broke the typing indicator.

In `TypingSyncHandler` we check if the request is not too much delayed, by checking the job's `startTime`. But due to other requirements, if there is no delay at all, we have the `startTime` set to 0, not to `now()`, which meant that the request was always delayed too much. I added a check for that.