### PR TITLE
fix: messages which were deleted still showing up

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -269,6 +269,7 @@ class MessagesStorageImpl(context:     Context,
       _ <- Future(msgsFilteredIndex(conv).foreach(_.delete(upTo)))
       _ <- msgsIndex(conv).flatMap(_.delete(upTo))
       _ <- storage.flushWALToDatabase()
+      _ =  onMessagesDeletedInConversation ! Set(conv)
     } yield ()
   }
 


### PR DESCRIPTION
 - When opening a cleared conversation from the searchUI
   messages from before the clearing would still show.
 - This commit adds a missing notification of changes which resulted in the cached `MessagesListView` displaying deleted content
 - Fixes wireapp/android-project#391