### PR TITLE
test: Add test for sorting of likes

### DIFF
--- a/zmessaging/src/test/scala/com/waz/model/MessageAndLikesStorageSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/MessageAndLikesStorageSpec.scala
@@ -36,16 +36,19 @@ class MessageAndLikesStorageSpec extends AndroidFreeSpec {
     )
 
     val likes = Map(
-      MessageId("1") -> Likes(MessageId("1"), Map(self -> RemoteInstant.Epoch)),
-      MessageId("2") -> Likes(MessageId("2"), Map(UserId("2") -> RemoteInstant.Epoch))
+      MessageId("1") -> Likes(MessageId("1"), Map(self -> RemoteInstant.ofEpochSec(100))),
+      MessageId("2") -> Likes(MessageId("2"), Map(
+        UserId("2") -> RemoteInstant.ofEpochSec(500),
+        UserId("3") -> RemoteInstant.ofEpochSec(100),
+        UserId("last") -> RemoteInstant.ofEpochSec(10000),
+        UserId("first") -> RemoteInstant.ofEpochSec(epochSecond = 0)
+      ))
     )
 
     scenario("Get messages and relevant info from ids") {
 
       val messagesStorage = mock[MessagesStorage]
       val reactionsStorage = mock[ReactionsStorage]
-
-      val ids = Seq(MessageId("1"), MessageId("2"), MessageId("3"))
 
       (messagesStorage.onDeleted _).expects().anyNumberOfTimes().returning(EventStream[Seq[MessageId]]())
       (messagesStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream[Seq[MessageData]]())
@@ -69,6 +72,42 @@ class MessageAndLikesStorageSpec extends AndroidFreeSpec {
       result.exists(_.quote.exists(_.id == MessageId("2"))) shouldBe true
       result.count(_.likedBySelf == true) shouldBe 1
       result.count(_.likes.nonEmpty) shouldBe 2
+    }
+
+    scenario("Message likes are sorted by timestamp") {
+
+      // GIVEN
+      val messagesStorage = mock[MessagesStorage]
+      val reactionsStorage = mock[ReactionsStorage]
+
+      (messagesStorage.onDeleted _).expects().anyNumberOfTimes().returning(EventStream[Seq[MessageId]]())
+      (messagesStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream[Seq[MessageData]]())
+      (reactionsStorage.onChanged _).expects().anyNumberOfTimes().returning(EventStream[Seq[Liking]]())
+      (reactionsStorage.getLikes _).expects(*).anyNumberOfTimes().onCall { id: MessageId =>
+        Future.successful(likes.get(id).get)
+      }
+
+      (messagesStorage.getMessages _).expects(*).anyNumberOfTimes().onCall { ids: Seq[MessageId] =>
+        Future.successful(ids.map(messages.get))
+      }
+      (reactionsStorage.loadAll _).expects(*).anyNumberOfTimes().onCall { ids: Seq[MessageId] =>
+        Future.successful(ids.flatMap(likes.get).toVector)
+      }
+      (messagesStorage.getMessage _).expects(*).anyNumberOfTimes().onCall { id: MessageId =>
+        Future.successful(messages.get(id))
+      }
+
+      val messageAndLikesStorage = new MessageAndLikesStorageImpl(self, messagesStorage, reactionsStorage)
+
+      // WHEN
+      val result = Await.result(messageAndLikesStorage.getMessageAndLikes(MessageId("2")), 10.seconds)
+
+      // THEN
+      result match {
+        case Some(messageAndLike) =>
+          messageAndLike.likes shouldBe IndexedSeq(UserId("first"), UserId("3"), UserId("2"), UserId("last"))
+        case _ => fail()
+      }
     }
   }
 }


### PR DESCRIPTION
# Reason for this pull request

During my investigation for https://github.com/wireapp/wire-android/pull/1988 I could not find any test about the sorting of likes so I created one

# Known issues

There are a few methods to get likes, I only tested `getMessageAndLikes` which is the one used on the UI.