### PR TITLE
Fix `expires_at` not being preserved when updating `UserData`

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -83,7 +83,7 @@ case class UserData(override val id:       UserId,
     },
     providerId = user.service.map(_.provider),
     integrationId = user.service.map(_.id),
-    expiresAt = user.expiresAt,
+    expiresAt = user.expiresAt.orElse(expiresAt),
     teamId = user.teamId.orElse(teamId),
     managedBy = user.managedBy.orElse(managedBy)
   )
@@ -168,10 +168,7 @@ object UserData {
 
   def apply(user: UserInfo): UserData = apply(user, withSearchKey = true)
 
-  def apply(user: UserInfo, withSearchKey: Boolean): UserData =
-    UserData(user.id, None, user.name.getOrElse(Name.Empty), user.email, user.phone, user.trackingId, user.mediumPicture.map(_.id),
-      user.accentId.getOrElse(AccentColor.defaultColor.id), SearchKey(if (withSearchKey) user.name.getOrElse(Name.Empty).str else ""), deleted = user.deleted,
-      handle = user.handle, providerId = user.service.map(_.provider), integrationId = user.service.map(_.id))
+  def apply(user: UserInfo, withSearchKey: Boolean): UserData = UserData(user.id, user.name.getOrElse(Name.Empty)).updated(user, withSearchKey)
 
   implicit lazy val Decoder: JsonDecoder[UserData] = new JsonDecoder[UserData] {
     import JsonDecoder._

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -81,8 +81,8 @@ case class UserData(override val id:       UserId,
       case Some(h) if !h.toString.isEmpty => Some(h)
       case _ => handle
     },
-    providerId = user.service.map(_.provider),
-    integrationId = user.service.map(_.id),
+    providerId = user.service.map(_.provider).orElse(providerId),
+    integrationId = user.service.map(_.id).orElse(integrationId),
     expiresAt = user.expiresAt.orElse(expiresAt),
     teamId = user.teamId.orElse(teamId),
     managedBy = user.managedBy.orElse(managedBy)

--- a/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+
+class UserDataSpec extends AndroidFreeSpec {
+
+  val referenceInfo = UserInfo(
+    UserId(),
+    Some(Name("Atticus")),
+    Some(4),
+    Some(EmailAddress("atticus@wire.com")),
+    Some(PhoneNumber("+0099223344556677")),
+    None, // ignoring pictures for now
+    Some(TrackingId("123454fsdf")),
+    false,
+    Some(Handle("atticus")),
+    Some(false),
+    None, // ignoring services for now
+    Some(TeamId("7d49b132-03b2-4124-bb18-9388577a6bb2")),
+    Some(RemoteInstant.ofEpochSec(10000)),
+    Some(SSOId("foo", "bar")),
+    Some(ManagedBy("wire"))
+  )
+
+  feature("Update from user info") {
+
+    scenario("Creation transfers all data") {
+
+      // WHEN
+      val data = UserData(referenceInfo, false)
+
+      // THEN
+      data.id.shouldEqual(referenceInfo.id)
+      data.name.shouldEqual(referenceInfo.name.get)
+      data.accent.shouldEqual(referenceInfo.accentId.get)
+      data.email.shouldEqual(referenceInfo.email)
+      data.phone.shouldEqual(referenceInfo.phone)
+      data.handle.shouldEqual(referenceInfo.handle)
+      data.deleted.shouldEqual(referenceInfo.deleted)
+      data.teamId.shouldEqual(referenceInfo.teamId)
+      data.expiresAt.shouldEqual(referenceInfo.expiresAt)
+      data.managedBy.shouldEqual(referenceInfo.managedBy)
+    }
+
+    scenario("Updating with empty UserInfo preserves data") {
+
+      // GIVEN
+      val oldData = UserData(referenceInfo, false)
+      val info = UserInfo(referenceInfo.id, referenceInfo.name)
+
+      // WHEN
+      val data = oldData.updated(info)
+
+      // THEN
+      data.id.shouldEqual(referenceInfo.id)
+      data.name.shouldEqual(referenceInfo.name.get)
+      data.accent.shouldEqual(referenceInfo.accentId.get)
+      data.email.shouldEqual(referenceInfo.email)
+      data.phone.shouldEqual(referenceInfo.phone)
+      data.handle.shouldEqual(referenceInfo.handle)
+      data.deleted.shouldEqual(referenceInfo.deleted)
+      data.teamId.shouldEqual(referenceInfo.teamId)
+      data.expiresAt.shouldEqual(referenceInfo.expiresAt)
+      data.managedBy.shouldEqual(referenceInfo.managedBy)
+    }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserDataSpec.scala
@@ -17,6 +17,7 @@
  */
 package com.waz.model
 
+import com.waz.model.UserInfo.Service
 import com.waz.specs.AndroidFreeSpec
 
 class UserDataSpec extends AndroidFreeSpec {
@@ -32,7 +33,10 @@ class UserDataSpec extends AndroidFreeSpec {
     false,
     Some(Handle("atticus")),
     Some(false),
-    None, // ignoring services for now
+    Some(Service(
+      IntegrationId("f0f83af0-c7d3-42b7-ab8b-7fc137ee7173"),
+      ProviderId("148668b1-e393-419d-b4ab-bf021e300262"))
+    ),
     Some(TeamId("7d49b132-03b2-4124-bb18-9388577a6bb2")),
     Some(RemoteInstant.ofEpochSec(10000)),
     Some(SSOId("foo", "bar")),
@@ -52,6 +56,9 @@ class UserDataSpec extends AndroidFreeSpec {
       data.accent.shouldEqual(referenceInfo.accentId.get)
       data.email.shouldEqual(referenceInfo.email)
       data.phone.shouldEqual(referenceInfo.phone)
+      data.trackingId.shouldEqual(referenceInfo.trackingId)
+      data.providerId.shouldEqual(referenceInfo.service.map(_.provider))
+      data.integrationId.shouldEqual(referenceInfo.service.map(_.id))
       data.handle.shouldEqual(referenceInfo.handle)
       data.deleted.shouldEqual(referenceInfo.deleted)
       data.teamId.shouldEqual(referenceInfo.teamId)
@@ -74,6 +81,9 @@ class UserDataSpec extends AndroidFreeSpec {
       data.accent.shouldEqual(referenceInfo.accentId.get)
       data.email.shouldEqual(referenceInfo.email)
       data.phone.shouldEqual(referenceInfo.phone)
+      data.trackingId.shouldEqual(referenceInfo.trackingId)
+      data.providerId.shouldEqual(referenceInfo.service.map(_.provider))
+      data.integrationId.shouldEqual(referenceInfo.service.map(_.id))
       data.handle.shouldEqual(referenceInfo.handle)
       data.deleted.shouldEqual(referenceInfo.deleted)
       data.teamId.shouldEqual(referenceInfo.teamId)

--- a/zmessaging/src/test/scala/com/waz/model/UserInfoSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/UserInfoSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+import com.waz.specs.AndroidFreeSpec
+import com.waz.utils.JsonDecoder
+import org.threeten.bp.Instant
+
+class UserInfoSpec extends AndroidFreeSpec {
+
+  feature("Deserialization from JSON") {
+
+    scenario("JSON with 'expires_at'") {
+
+      // GIVEN
+      val expectedTime = RemoteInstant(Instant.parse("2019-02-20T14:32:09.329Z"))
+      val document =
+        """
+          |{
+          |  "expires_at" : "2019-02-20T14:32:09.329Z",
+          |  "id" : "e902e865-7564-4bd9-9789-d2395a984922",
+          |  "picture" : [
+          |
+          |  ],
+          |  "assets" : [
+          |
+          |  ],
+          |  "name" : "Atticus",
+          |  "accent_id" : 6
+          |}
+        """.stripMargin
+
+      // WHEN
+      val info: UserInfo = JsonDecoder.decode[UserInfo](document)
+
+      // THEN
+      info.expiresAt.shouldEqual(Some(expectedTime))
+      info.id.shouldEqual(UserId("e902e865-7564-4bd9-9789-d2395a984922"))
+      info.name.shouldEqual(Some(Name("Atticus")))
+      info.accentId.shouldEqual(Some(6))
+
+    }
+  }
+}


### PR DESCRIPTION
# Reason for this pull request
Bug: wireless guests are not displayed as wireless. They have no expiration time and it's possible to connect to them.

The reason is that `expires_at`, which is used to distinguish if a user is a guest user, is overwritten with `None` when updating the `UserData`.

# Changes
- Fix `expires_at` field in `UserData` being overwritten with `None` when applying `UserInfo` to `UserData`
- Removed code duplication in the `apply` method of `UserData`
- Added tests to cover `UserData` update from UserInfo
- The new test showed that `teamId` was also not correctly initialized when creating `UserData` from `UserInfo`. This was fixed too by removing code duplication

# Testing
- Added new unit tests for `UserData` and `UserInfo`
- Manually tested on device before and after: now wireless users are displayed correctly

