### PR TITLE
Log migration

### DIFF
--- a/zmessaging/src/main/scala/com/waz/bitmap/ExifOrientation.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/ExifOrientation.scala
@@ -19,8 +19,8 @@ package com.waz.bitmap
 
 import java.io.InputStream
 import android.media.ExifInterface
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 
 import scala.util.control.NonFatal
 
@@ -57,7 +57,7 @@ object ExifOrientation {
         case Seq(0x4d, 0x4d, 0, 0x2a) => true
         case Seq(0x49, 0x49, 0x2a, 0) => false
         case mark =>
-          verbose(s"tag mark: ${mark.map(_.toHexString)}")
+          verbose(l"tag mark: ${mark.map(n => showString(n.toHexString))}")
           return 0
       }
 
@@ -95,7 +95,7 @@ object ExifOrientation {
     0
   } catch {
     case NonFatal(e) =>
-      warn(s"Extracting exif orientation failed", e)
+      warn(l"Extracting exif orientation failed", e)
       ExifInterface.ORIENTATION_UNDEFINED
   }
 }

--- a/zmessaging/src/main/scala/com/waz/bitmap/gif/AnimGifDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/gif/AnimGifDecoder.scala
@@ -18,8 +18,8 @@
 package com.waz.bitmap.gif
 
 import android.graphics.Bitmap
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 
 import scala.concurrent.duration.Duration
 
@@ -64,7 +64,7 @@ class AnimGifDecoder(gif: Gif) {
    * Will decode next frame pixels, but not modify current frame image yet.
    */
   def advanceNextFrame(): Unit = {
-    if (frameDirty) warn(s"should call getCurrentFrame before advancing to next frame")
+    if (frameDirty) warn(l"should call getCurrentFrame before advancing to next frame")
     if (!frameDirty && advance()) {
       val frame = gif.frames(frameIndex)
       if (frameIndex == 0) decoder.clear()

--- a/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder.scala
@@ -81,7 +81,7 @@ object VideoTranscoder {
 
   type MediaCodecIterator = Iterator[CodecResponse]
 
-  sealed trait CodecResponse
+  sealed trait CodecResponse extends SafeToLog
   object CodecResponse {
     case object TryAgain extends CodecResponse
     case class FormatChanged(format: MediaFormat) extends CodecResponse

--- a/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder18.scala
+++ b/zmessaging/src/main/scala/com/waz/bitmap/video/VideoTranscoder18.scala
@@ -22,10 +22,10 @@ import java.io.File
 import android.annotation.TargetApi
 import android.content.Context
 import android.media.{MediaCodec, MediaExtractor, MediaFormat, MediaMuxer}
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.bitmap.video.VideoTranscoder.CodecResponse.{CodecBuffer, FormatChanged, TryAgain}
 import com.waz.bitmap.video.VideoTranscoder.{MediaCodecIterator, OutputWriter}
+import com.waz.log.ZLog2._
 import com.waz.utils.{Cleanup, Managed, returning}
 
 
@@ -102,14 +102,14 @@ class MuxerWriter(muxer: MediaMuxer, sources: MediaCodecIterator*) extends Outpu
                 s.positionMs = info.presentationTimeUs / 1000
               }
               frame.release()
-            case st => error(s"unexpected state: $st")
+            case st => error(l"unexpected state: $st")
           }
         case s @ SourceWithTrack(source, None, _) if source.hasNext && !started =>
           source.next() match {
             case TryAgain =>
             case FormatChanged(format) =>
               s.track = Some(muxer.addTrack(format))
-            case st => error(s"unexpected state: $st")
+            case st => error(l"unexpected state: $st")
           }
         case _ => // ignore
       }

--- a/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/cache/CacheStorage.scala
@@ -20,7 +20,7 @@ package com.waz.cache
 import java.io.File
 
 import android.content.Context
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.cache.CacheEntryData.CacheEntryDao
 import com.waz.cache.CacheStorage.EntryCache
@@ -49,7 +49,7 @@ class CacheStorageImpl(storage: Database, context: Context) extends CachedStorag
 
   val fileCleanupQueue = new SerialProcessingQueue[(File, Uid)]({ entries =>
     Future {
-      verbose(s"deleting cache files: $entries")
+      verbose(l"deleting cache files: $entries")
       entries foreach { case (path, uid) => entryFile(path, uid).delete() }
     } (Threading.IO)
   }, "CacheFileCleanupQueue")

--- a/zmessaging/src/main/scala/com/waz/content/OtrClientsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/OtrClientsStorage.scala
@@ -18,7 +18,7 @@
 package com.waz.content
 
 import android.content.Context
-import com.waz.ZLog.verbose
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Verification
 import com.waz.model.UserId
@@ -69,7 +69,7 @@ class OtrClientsStorageImpl(userId: UserId, context: Context, storage: Database)
         UserClients(user, clients.map(c => c.id -> c)(breakOut))
     }
 
-    verbose(s"updateClients: $ucs, replace = $replace")
+    verbose(l"updateClients: $ucs, replace = $replace")
 
     updateOrCreateAll(ucs.map { case (u, cs) => u -> updateOrCreate(u, cs) } (breakOut))
   }

--- a/zmessaging/src/main/scala/com/waz/content/SyncStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/SyncStorage.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.content
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.SyncId
 import com.waz.model.sync.SyncJob
 import com.waz.model.sync.SyncJob.SyncJobDao
@@ -64,7 +64,7 @@ class SyncStorage(db: Database, jobs: Seq[SyncJob]) {
   jobsMap ++= jobs map { job => job.id -> job }
 
   def add(job: SyncJob): SyncJob = {
-    verbose(s"add($job)")
+    verbose(l"add($job)")
     jobsMap.get(job.id) match {
       case Some(prev) => update(prev, job)
       case None =>
@@ -77,7 +77,7 @@ class SyncStorage(db: Database, jobs: Seq[SyncJob]) {
   def get(id: SyncId): Option[SyncJob] = jobsMap.get(id)
 
   def remove(id: SyncId) = {
-    verbose(s"remove($id)")
+    verbose(l"remove($id)")
     jobsMap.remove(id) foreach { onRemoved ! _ }
     saveQueue ! id
   }
@@ -103,7 +103,7 @@ class SyncStorage(db: Database, jobs: Seq[SyncJob]) {
   }
 
   private def save(job: SyncJob) = {
-    verbose(s"save($job)")
+    verbose(l"save($job)")
     jobsMap.put(job.id, job)
     saveQueue ! job.id
   }

--- a/zmessaging/src/main/scala/com/waz/db/Dao.scala
+++ b/zmessaging/src/main/scala/com/waz/db/Dao.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.db
 
-import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.utils.wrappers.{DB, DBContentValues, DBCursor}
 import com.waz.utils.{Managed, returning}
 
@@ -163,7 +163,7 @@ abstract class BaseDao[T] extends Reader[T] {
   final implicit def columnToValue[A](col: Column[A])(implicit cursor: DBCursor): A = {
     val index = cursor.getColumnIndex(col.name)
     if (index < 0) {
-      ZLog.error(s"getColumnIndex returned $index for column: ${col.name}, cursor columns: ${cursor.getColumnNames.mkString(",")}")
+      error(l"getColumnIndex returned $index for column: ${showString(col.name)}, cursor columns: ${showString(cursor.getColumnNames.mkString(","))}")
     }
     col.load(cursor, index)
   }

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -341,8 +341,8 @@ object ZLog2 {
       LogShow.createFrom { c =>
         import c._
         l"""
-           |AssetData: id: $id | mime: $mime | sizeInBytes: $sizeInBytes | status: $status | source: $source
-           |  rId: $remoteId| token: $token | otrKey: $otrKey | preview: $previewId
+           |AssetData(id: $id | mime: $mime | sizeInBytes: $sizeInBytes | status: $status | source: $source
+           |  rId: $remoteId | token: $token | otrKey: $otrKey | preview: $previewId)
         """.stripMargin
       }
 

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -31,6 +31,7 @@ import com.waz.log.InternalLog.LogLevel.{Debug, Error, Info, Verbose, Warn}
 import com.waz.model.AccountData.Password
 import com.waz.model.GenericContent.Location
 import com.waz.model.ManagedBy.ManagedBy
+import com.waz.model.messages.media.{ArtistData, TrackData}
 import com.waz.model.{SSOId, _}
 import com.waz.model.otr.{Client, ClientId, UserClients}
 import com.waz.model.sync.{ReceiptType, SyncCommand, SyncJob, SyncRequest}
@@ -346,6 +347,30 @@ object ZLog2 {
            |AssetData(id: $id | mime: $mime | sizeInBytes: $sizeInBytes | status: $status | source: $source
            |  rId: $remoteId | token: $token | otrKey: $otrKey | preview: $previewId)
         """.stripMargin
+      }
+
+    implicit val TrackDataLogShow: LogShow[TrackData] =
+      LogShow.createFrom { d =>
+        import d._
+        l"""
+            |TrackData(
+            | provider: $provider,
+            | title: ${redactedString(title)},
+            | artist: $artist,
+            | linkUrl: ${new URI(linkUrl)},
+            | artwork: $artwork,
+            | duration: $duration,
+            | streamable: $streamable,
+            | streamUrl: ${streamUrl.map(new URI(_))},
+            | previewUrl: ${previewUrl.map(new URI(_))},
+            | expires: $expires)
+          """.stripMargin
+
+      }
+
+    implicit val ArtistDataLogShow: LogShow[ArtistData] =
+      LogShow.createFrom { d =>
+        l"ArtistData(name: ${redactedString(d.name)}, avatar: ${d.avatar})"
       }
 
     implicit val NotificationDataLogShow: LogShow[NotificationData] =

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -213,6 +213,7 @@ object ZLog2 {
     implicit val PlaybackRouteLogShow:      LogShow[PlaybackRoute]                         = LogShow.create(_.name())
     implicit val VerificationLogShow:       LogShow[Verification]                          = LogShow.create(_.name())
     implicit val NotificationTypeLogShow:   LogShow[NotificationsHandler.NotificationType] = LogShow.create(_.name())
+    implicit val MediaProviderLogShow:      LogShow[MediaProvider]                         = LogShow.create(_.name())
 
     //wire types
     implicit val UidShow:        LogShow[Uid]        = logShowWithHash

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -35,6 +35,7 @@ import com.waz.model.sync.ReceiptType
 import com.waz.service.{PlaybackRoute, PropertyKey}
 import com.waz.service.assets.AssetService.RawAssetInput
 import com.waz.service.assets.AssetService.RawAssetInput.{BitmapInput, ByteInput, UriInput, WireAssetInput}
+import com.waz.service.assets.GlobalRecordAndPlayService.PCMContent
 import com.waz.service.assets2.{Asset, AssetDetails}
 import com.waz.service.call.Avs.AvsClosedReason.reasonString
 import com.waz.service.call.Avs.VideoState
@@ -303,7 +304,6 @@ object ZLog2 {
         l"MessageData(id: $id | convId: $convId | msgType: $msgType | userId: $userId | state: $state | time: $time | localTime: $localTime)"
       }
 
-
     implicit val MessageContentLogShow: LogShow[MessageContent] =
       LogShow.createFrom { m =>
         import m._
@@ -341,6 +341,11 @@ object ZLog2 {
            |AssetData: id: $id | mime: $mime | sizeInBytes: $sizeInBytes | status: $status | source: $source
            |  rId: $remoteId| token: $token | otrKey: $otrKey | preview: $previewId
         """.stripMargin
+      }
+
+    implicit val PCMContentShow: LogShow[PCMContent] =
+      LogShow.createFrom { p =>
+        l"PCMContent(file: ${p.file})"
       }
 
     implicit val NotificationDataLogShow: LogShow[NotificationData] =
@@ -381,6 +386,12 @@ object ZLog2 {
            | pushToken: $pushToken
            | password: $password
            | ssoId: $ssoId)"""
+      }
+
+    implicit val ThreadShow: LogShow[Thread] =
+      LogShow.create { t =>
+        import t._
+        s"Thread(id: $getId, name: $getName, priority: $getPriority, state: $getState)"
       }
 
     //Events

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -32,7 +32,7 @@ import com.waz.model.GenericContent.Location
 import com.waz.model.ManagedBy.ManagedBy
 import com.waz.model.{SSOId, _}
 import com.waz.model.otr.{Client, ClientId, UserClients}
-import com.waz.model.sync.ReceiptType
+import com.waz.model.sync.{ReceiptType, SyncCommand, SyncJob, SyncRequest}
 import com.waz.service.{PlaybackRoute, PropertyKey}
 import com.waz.service.assets.AssetService.RawAssetInput
 import com.waz.service.assets.AssetService.RawAssetInput.{BitmapInput, ByteInput, UriInput, WireAssetInput}
@@ -426,6 +426,32 @@ object ZLog2 {
         case UnauthenticatedContent(uri) => l"UnauthenticatedContent(uri: $uri)"
         case PCMContent(file) => l"PCMContent(file: $file)"
       }
+
+    // Sync Job
+
+    implicit val SyncJobLogShow: LogShow[SyncJob] =
+      LogShow.createFrom { j =>
+        import j._
+        l"""SyncJob(
+            | id: $id
+            | request: $request
+            | dependsOn: $dependsOn
+            | priority: $priority
+            | timestamp: $timestamp
+            | startTime: $startTime
+            | attempts: $attempts
+            | offline: $offline
+            | state: $state
+            | error: ${j.error})"""
+      }
+
+    implicit val SyncRequestLogShow: LogShow[SyncRequest] =
+      LogShow.createFrom { r =>
+        l"SyncRequest(cmd: ${r.cmd})"
+      }
+
+    implicit val SyncCommandLogShow: LogShow[SyncCommand] = LogShow.create(_.name())
+    implicit val SyncStateLogShow: LogShow[SyncState] = LogShow.create(_.name())
 
     //Events
     implicit val EventLogShow: LogShow[Event] = logShowWithHash

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -22,6 +22,7 @@ import java.net.URI
 
 import android.net.Uri
 import com.waz.ZLog.LogTag
+import com.waz.api.impl.ErrorResponse
 import com.waz.api.{MessageContent => _, _}
 import com.waz.cache2.CacheService.{AES_CBC_Encryption, Encryption, NoEncryption}
 import com.waz.content.Preferences.PrefKey
@@ -389,6 +390,8 @@ object ZLog2 {
         import t._
         s"Thread(id: $getId, name: $getName, priority: $getPriority, state: $getState)"
       }
+
+    implicit val ErrorResponseLogShow: LogShow[ErrorResponse] = LogShow.create(_.toString)
 
     // Global Record and Play Service
 

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -322,6 +322,12 @@ object ZLog2 {
         l"UserData(id: $id | teamId: $teamId | name: $name | displayName: $displayName | email: $email | phone: $phone | handle: $handle | deleted: $deleted)"
       }
 
+    implicit val UserInfoLogShow: LogShow[UserInfo] =
+      LogShow.createFrom { u =>
+        import u._
+        l"UserInfo: id: $id | email: $email: | phone: $phone: | picture: $picture: | deleted: $deleted: | handle: $handle: | expiresAt: $expiresAt: | ssoId: $ssoId | managedBy: $managedBy"
+      }
+
     implicit val ConvDataLogShow: LogShow[ConversationData] =
       LogShow.createFrom { c =>
         import c._

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -43,6 +43,7 @@ import com.waz.service.call.Avs.AvsClosedReason.reasonString
 import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo
 import com.waz.service.otr.OtrService.SessionId
+import com.waz.sync.SyncResult
 import com.waz.sync.client.AuthenticationManager.{AccessToken, Cookie}
 import com.waz.utils.{sha2, wrappers}
 import org.json.JSONObject
@@ -448,6 +449,13 @@ object ZLog2 {
     implicit val SyncRequestLogShow: LogShow[SyncRequest] =
       LogShow.createFrom { r =>
         l"SyncRequest(cmd: ${r.cmd})"
+      }
+
+    implicit val SyncResultLogShow: LogShow[SyncResult] =
+      LogShow.createFrom {
+        case SyncResult.Success => l"Success"
+        case SyncResult.Failure(error) => l"Failure(error: $error)"
+        case SyncResult.Retry(error) => l"Retry(error: $error)"
       }
 
     implicit val SyncCommandLogShow: LogShow[SyncCommand] = LogShow.create(_.name())

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -151,6 +151,8 @@ object ZLog2 {
     implicit val ThrowableShow:      LogShow[Throwable]      = logShowWithToString
     implicit val ShowStringLogShow:  LogShow[ShowString]     = logShowWithToString
 
+    implicit val RedactedStringShow: LogShow[RedactedString] = create(_ => "<redacted>", _.value)
+
     implicit val Sha256LogShow: LogShow[Sha256] = create(_.hexString, _.str)
 
     implicit val enumShow: LogShow[Enum[_]] = LogShow.create((enumValue: Enum[_]) => enumValue.name())
@@ -198,7 +200,7 @@ object ZLog2 {
         t => (showA.showSafe(t._1), showB.showSafe(t._2), showC.showSafe(t._3)).toString(),
         t => (showA.showUnsafe(t._1), showB.showUnsafe(t._2), showC.showUnsafe(t._3)).toString()
       )
-    
+
     //wire types
     implicit val UidShow:        LogShow[Uid]        = logShowWithHash
     implicit val UserIdShow:     LogShow[UserId]     = logShowWithHash
@@ -214,7 +216,6 @@ object ZLog2 {
     implicit val CacheKeyShow:   LogShow[CacheKey]   = logShowWithHash
     implicit val AssetTokenShow: LogShow[AssetToken] = logShowWithHash
 
-    implicit val RedactedStringShow: LogShow[RedactedString] = create(_ => "<redacted>", _.value)
     implicit val PasswordShow: LogShow[Password] = create(_ => "********") //Also don't show in debug mode (e.g. Internal)
 
     implicit val NameShow:              LogShow[Name]             = logShowWithHash
@@ -347,7 +348,6 @@ object ZLog2 {
             | previewUrl: ${previewUrl.map(new URI(_))},
             | expires: $expires)
           """.stripMargin
-
       }
 
     implicit val ArtistDataLogShow: LogShow[ArtistData] =
@@ -370,6 +370,7 @@ object ZLog2 {
       }
 
     implicit val VideoStateLogShow: LogShow[VideoState] = logShowWithToString
+
     implicit val CallInfoLogShow: LogShow[CallInfo] =
       LogShow.createFrom { n =>
         import n._
@@ -446,7 +447,7 @@ object ZLog2 {
             | attempts: $attempts
             | offline: $offline
             | state: $state
-            | error: ${j.error})"""
+            | error: ${j.error})""".stripMargin
       }
 
     implicit val SyncRequestLogShow: LogShow[SyncRequest] =
@@ -465,7 +466,9 @@ object ZLog2 {
     implicit val SyncStateLogShow: LogShow[SyncState] = LogShow.create(_.name())
 
     //Events
+
     implicit val EventLogShow: LogShow[Event] = logShowWithHash
+
     implicit val OtrErrorLogShow: LogShow[OtrError] =
       LogShow.createFrom {
         case Duplicate => l"Duplicate"
@@ -473,6 +476,7 @@ object ZLog2 {
         case IdentityChangedError(from, sender) => l"IdentityChangedError(from: $from | sender: $sender)"
         case UnknownOtrErrorEvent(json) => l"UnknownOtrErrorEvent(json: $json)"
       }
+
     implicit val OtrErrorEventLogShow: LogShow[OtrErrorEvent] =
       LogShow.createFrom { e =>
         import e._
@@ -480,6 +484,7 @@ object ZLog2 {
       }
 
     //Protos
+
     implicit val GenericMessageLogShow: LogShow[GenericMessage] = LogShow.create { m =>
       m.getContentCase
       s"GenericMessage(messageId: ${sha2(m.messageId)} | contentCase: ${m.getContentCase})"
@@ -558,5 +563,4 @@ object ZLog2 {
 //  @deprecated("Only for legacy support. Will be removed after migration", " ")
   def showString(str: String): ShowString = new ShowString(str)
   def redactedString(str: String): RedactedString = new RedactedString(str)
-
 }

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -23,6 +23,7 @@ import java.net.URI
 import android.net.Uri
 import com.waz.ZLog.LogTag
 import com.waz.api.{MessageContent => _, _}
+import com.waz.cache2.CacheService.{AES_CBC_Encryption, Encryption, NoEncryption}
 import com.waz.content.Preferences.PrefKey
 import com.waz.log.InternalLog.LogLevel.{Debug, Error, Info, Verbose, Warn}
 import com.waz.model.AccountData.Password
@@ -34,6 +35,7 @@ import com.waz.model.sync.ReceiptType
 import com.waz.service.{PlaybackRoute, PropertyKey}
 import com.waz.service.assets.AssetService.RawAssetInput
 import com.waz.service.assets.AssetService.RawAssetInput.{BitmapInput, ByteInput, UriInput, WireAssetInput}
+import com.waz.service.assets2.{Asset, AssetDetails}
 import com.waz.service.call.Avs.AvsClosedReason.reasonString
 import com.waz.service.call.Avs.VideoState
 import com.waz.service.call.CallInfo
@@ -264,6 +266,12 @@ object ZLog2 {
         case HandleCredentials(handle, password)     => l"HandleCredentials($handle, $password)"
       }
 
+    implicit val EncryptionShow: LogShow[Encryption] =
+      LogShow.createFrom {
+        case NoEncryption => l"NoEncryption"
+        case AES_CBC_Encryption(key) => l"AES_CBC_Encryption($key)"
+      }
+
     implicit val CookieShow: LogShow[Cookie] = create(
       c => s"Cookie(${c.str.take(10)}, exp: ${c.expiry}, isValid: ${c.isValid})",
       c => s"Cookie(${c.str}, exp: ${c.expiry}, isValid: ${c.isValid})"
@@ -318,6 +326,12 @@ object ZLog2 {
       createFrom { m =>
         import m._
         l"Mention(userId: $userId, start: $start, length: $length)"
+      }
+
+    implicit val AssetLogShow: LogShow[Asset[AssetDetails]] =
+      LogShow.createFrom { a =>
+        import a._
+        l"Asset(id: $id | token: $token | sha: $sha | encryption: $encryption | localSource: $localSource | preview: $preview | details: $details | convId: $convId)"
       }
 
     implicit val AssetDataLogShow: LogShow[AssetData] =

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -19,6 +19,7 @@ package com.waz.log
 
 import java.io.File
 import java.net.URI
+import java.util.Locale
 
 import android.net.Uri
 import com.waz.ZLog.LogTag
@@ -386,12 +387,6 @@ object ZLog2 {
            | ssoId: $ssoId)"""
       }
 
-    implicit val ThreadShow: LogShow[Thread] =
-      LogShow.create { t =>
-        import t._
-        s"Thread(id: $getId, name: $getName, priority: $getPriority, state: $getState)"
-      }
-
     implicit val ErrorResponseLogShow: LogShow[ErrorResponse] = LogShow.create(_.toString)
 
     // Global Record and Play Service
@@ -490,7 +485,18 @@ object ZLog2 {
     }
 
     implicit val ReceiptType: LogShow[ReceiptType] = logShowWithToString
+
+    // System Types
+
+    implicit val ThreadLogShow: LogShow[Thread] =
+      LogShow.create { t =>
+        import t._
+        s"Thread(id: $getId, name: $getName, priority: $getPriority, state: $getState)"
+      }
+
+    implicit val LocaleLogShow: LogShow[Locale] = logShowWithHash
   }
+
 
   trait CanBeShown {
     def showSafe: String

--- a/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
+++ b/zmessaging/src/main/scala/com/waz/log/ZLog2.scala
@@ -237,6 +237,7 @@ object ZLog2 {
     implicit val CacheKeyShow:   LogShow[CacheKey]   = logShowWithHash
     implicit val AssetTokenShow: LogShow[AssetToken] = logShowWithHash
 
+    implicit val RedactedStringShow: LogShow[RedactedString] = create(_ => "<redacted>", _.value)
     implicit val PasswordShow: LogShow[Password] = create(_ => "********") //Also don't show in debug mode (e.g. Internal)
 
     implicit val NameShow:              LogShow[Name]             = logShowWithHash
@@ -544,7 +545,11 @@ object ZLog2 {
     override def toString: LogTag = value
   }
 
+  // Use to hide string content only in public logs.
+  class RedactedString(val value: String)
+
 //  @deprecated("Only for legacy support. Will be removed after migration", " ")
   def showString(str: String): ShowString = new ShowString(str)
+  def redactedString(str: String): RedactedString = new RedactedString(str)
 
 }

--- a/zmessaging/src/main/scala/com/waz/model/Availability.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Availability.scala
@@ -17,7 +17,9 @@
  */
 package com.waz.model
 
-sealed trait Availability { val id: Int }
+import com.waz.log.ZLog2.SafeToLog
+
+sealed trait Availability extends SafeToLog { val id: Int }
 
 object Availability {
   case object None      extends Availability { override val id = 0 }

--- a/zmessaging/src/main/scala/com/waz/model/Liking.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Liking.scala
@@ -20,6 +20,7 @@ package com.waz.model
 import android.database.DatabaseUtils.{sqlEscapeString => escape}
 import com.waz.db.Col._
 import com.waz.db.{Dao2, Reader, iteratingWithReader}
+import com.waz.log.ZLog2.SafeToLog
 import com.waz.utils.JsonEncoder.encodeInstant
 import com.waz.utils.wrappers.{DB, DBCursor}
 import com.waz.utils.{Identifiable, JsonDecoder, JsonEncoder, RichWireInstant}
@@ -38,7 +39,7 @@ object Liking {
   def like: Action = Action.Like
   def unlike: Action = Action.Unlike
 
-  @SerialVersionUID(1L) sealed abstract class Action(val serial: Int) extends Serializable
+  @SerialVersionUID(1L) sealed abstract class Action(val serial: Int) extends Serializable with SafeToLog
 
   object Action {
     case object Unlike extends Action(0)

--- a/zmessaging/src/main/scala/com/waz/model/Uid.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Uid.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 
 import com.waz.api.NotificationsHandler.NotificationType
 import com.waz.api.NotificationsHandler.NotificationType._
+import com.waz.log.ZLog2.SafeToLog
 import com.waz.utils.crypto.ZSecureRandom
 import com.waz.utils.wrappers.URI
 import com.waz.utils.{JsonDecoder, JsonEncoder}
@@ -199,7 +200,7 @@ object RConvId {
   }
 }
 
-case class SyncId(str: String) {
+case class SyncId(str: String) extends SafeToLog {
   override def toString: String = str
 }
 

--- a/zmessaging/src/main/scala/com/waz/model/UserInfo.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserInfo.scala
@@ -160,9 +160,4 @@ object UserInfo {
     }
   }
 
-  implicit val UserInfoShow: LogShow[UserInfo] =
-    LogShow.createFrom { u =>
-      import u._
-      l" UserInfo: id: $id | email: $email: | phone: $phone: | picture: $picture: | deleted: $deleted: | handle: $handle: | expiresAt: $expiresAt: | ssoId: $ssoId | managedBy: $managedBy"
-    }
 }

--- a/zmessaging/src/main/scala/com/waz/model/VersionBlacklist.scala
+++ b/zmessaging/src/main/scala/com/waz/model/VersionBlacklist.scala
@@ -17,10 +17,13 @@
  */
 package com.waz.model
 
+import com.waz.log.ZLog2.SafeToLog
 import com.waz.utils.JsonDecoder
 import org.json.JSONObject
 
-case class VersionBlacklist(oldestAccepted: Int = 0, blacklisted: Seq[Int] = Seq.empty)
+case class VersionBlacklist(oldestAccepted: Int = 0, blacklisted: Seq[Int] = Seq.empty) extends SafeToLog {
+  override def toString: String = s"VersionBlacklist(oldestAccepted: $oldestAccepted, blacklisted: $blacklisted)"
+}
 
 object VersionBlacklist {
   import JsonDecoder._

--- a/zmessaging/src/main/scala/com/waz/service/BackupManager.scala
+++ b/zmessaging/src/main/scala/com/waz/service/BackupManager.scala
@@ -23,8 +23,8 @@ import java.util.Locale
 import java.util.zip.{ZipFile, ZipOutputStream}
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.verbose
 import com.waz.db.ZMessagingDB
+import com.waz.log.ZLog2._
 import com.waz.model.UserId
 import com.waz.model.otr.ClientId
 import com.waz.service.BackupManager.InvalidBackup.{DbEntryNotFound, MetadataEntryNotFound}
@@ -126,14 +126,14 @@ object BackupManager {
 
           val walFileName = getDbWalFileName(userId)
           val walFile = new File(databaseDir, walFileName)
-          verbose(s"WAL file: ${walFile.getAbsolutePath} exists: ${walFile.exists}, length: ${if (walFile.exists) walFile.length else 0}")
+          verbose(l"WAL file: $walFile exists: ${walFile.exists}, length: ${if (walFile.exists) walFile.length else 0}")
 
           if (walFile.exists) withResource(new BufferedInputStream(new FileInputStream(walFile))) {
             IoUtils.writeZipEntry(_, zip, walFileName)
           }
         }
 
-        verbose(s"database export finished: ${zipFile.getAbsolutePath} . Data contains: ${zipFile.length} bytes")
+        verbose(l"database export finished: $zipFile . Data contains: ${zipFile.length} bytes")
       }
     }.mapFailureIfNot[BackupError](UnknownBackupError.apply)
 

--- a/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/CacheCleaningService.scala
@@ -20,10 +20,10 @@ package com.waz.service
 import java.lang.System._
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.cache.CacheService
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences.LastCacheCleanup
+import com.waz.log.ZLog2._
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.EventContext
 
@@ -40,7 +40,7 @@ class CacheCleaningService(cache: CacheService, prefs: GlobalPreferences) {
   def requestDeletionOfExpiredCacheEntries(): Future[Unit] = {
     prefs.preference(LastCacheCleanup).mutate { lastSync =>
       if ((currentTimeMillis() - lastSync).millis > CleanupInterval) {
-        debug("at least one week expired since last cache cleaning, cleaning now...")
+        debug(l"at least one week expired since last cache cleaning, cleaning now...")
         cache.deleteExpired()
         currentTimeMillis()
       } else {

--- a/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/PhoneNumberService.scala
@@ -23,7 +23,7 @@ import com.github.ghik.silencer.silent
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.google.i18n.phonenumbers.Phonenumber.{PhoneNumber => GooglePhoneNumber}
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.model.PhoneNumber
 import com.waz.threading.SerialDispatchQueue
 
@@ -69,7 +69,7 @@ class PhoneNumberServiceImpl(context: Context) extends PhoneNumberService{
         Some(PhoneNumber(util.format(number, PhoneNumberUtil.PhoneNumberFormat.E164)))
       } catch {
         case ex: Throwable =>
-          debug(s"phone number normalization failed for $phone ($defaultRegion): ${ex.getMessage}")
+          debug(l"phone number normalization failed for $phone (${redactedString(defaultRegion)}): ${showString(ex.getMessage)}")
           None
       }
   }

--- a/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/VersionBlacklistService.scala
@@ -17,10 +17,10 @@
  */
 package com.waz.service
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.GlobalPreferences
 import com.waz.content.GlobalPreferences._
+import com.waz.log.ZLog2._
 import com.waz.model.VersionBlacklist
 import com.waz.sync.client.VersionBlacklistClient
 import com.waz.threading.Threading
@@ -58,12 +58,15 @@ class VersionBlacklistService(metadata: MetaDataService, prefs: GlobalPreference
   }
 
   def syncVersionBlackList() = client.loadVersionBlacklist().future flatMap { blacklist =>
-    debug(s"Retrieved version blacklist: $blacklist")
-    updateBlacklist(blacklist.right.getOrElse(VersionBlacklist()))
+    updateBlacklist({
+      val list = blacklist.right.getOrElse(VersionBlacklist())
+      debug(l"Retrieved version blacklist: $list")
+      list
+    })
   }
 
   def updateBlacklist(blacklist: VersionBlacklist): Future[Unit] = {
-    verbose(s"app Version: $appVersion, blacklist: $blacklist")
+    verbose(l"app Version: $appVersion, blacklist: $blacklist")
     for {
       _ <- upToDatePref := (appVersion >= blacklist.oldestAccepted && !blacklist.blacklisted.contains(appVersion))
       _ <- lastUpToDateSync := System.currentTimeMillis

--- a/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets/PCMPlayer.scala
@@ -25,8 +25,8 @@ import java.nio.ByteOrder.LITTLE_ENDIAN
 import android.media.AudioManager.STREAM_MUSIC
 import android.media.AudioTrack
 import android.media.AudioTrack.{MODE_STREAM, OnPlaybackPositionUpdateListener, getMinBufferSize}
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.service.assets.GlobalRecordAndPlayService.{MediaPointer, PCMContent}
 import com.waz.threading.{SerialDispatchQueue, Threading}
 import libcore.io.SizeOf
@@ -119,11 +119,11 @@ class PCMPlayer private (content: PCMContent, track: AudioTrack, totalSamples: L
     @volatile private var playing = false
 
     setUncaughtExceptionHandler(new UncaughtExceptionHandler {
-      override def uncaughtException(thread: Thread, cause: Throwable): Unit = error(s"scooping [$thread] stopped due to exception", cause)
+      override def uncaughtException(thread: Thread, cause: Throwable): Unit = error(l"scooping [$thread] stopped due to exception", cause)
     })
 
     override def run: Unit = {
-      verbose("scooping started")
+      verbose(l"scooping started")
       playing = true
       scoop()
     }
@@ -151,14 +151,14 @@ class PCMPlayer private (content: PCMContent, track: AudioTrack, totalSamples: L
         }
         scoop()
       }
-    } else verbose("scooping stopped")
+    } else verbose(l"scooping stopped")
   }
 }
 
 object PCMPlayer {
   def apply(content: PCMContent, observer: Player.Observer): Future[PCMPlayer] = Threading.BackgroundHandler.map { handler =>
     val track = new AudioTrack(STREAM_MUSIC, PCM.sampleRate, PCM.outputChannelConfig, PCM.sampleFormat, playerBufferSize, MODE_STREAM)
-    verbose(s"created audio track; buffer size: $playerBufferSize")
+    verbose(l"created audio track; buffer size: $playerBufferSize")
     val totalSamples = content.file.length / SizeOf.SHORT
 
     track.setNotificationMarkerPosition(totalSamples.toInt)
@@ -166,7 +166,7 @@ object PCMPlayer {
     track.setPlaybackPositionUpdateListener(new OnPlaybackPositionUpdateListener {
       override def onPeriodicNotification(t: AudioTrack): Unit = ()
       override def onMarkerReached(t: AudioTrack): Unit = {
-        verbose(s"EOF reached: $content")
+        verbose(l"EOF reached: $content")
         observer.onCompletion()
       }
     }, handler)

--- a/zmessaging/src/main/scala/com/waz/service/assets2/models.scala
+++ b/zmessaging/src/main/scala/com/waz/service/assets2/models.scala
@@ -20,6 +20,7 @@ package com.waz.service.assets2
 import java.net.URI
 
 import com.waz.cache2.CacheService.Encryption
+import com.waz.log.ZLog2.SafeToLog
 import com.waz.model._
 import com.waz.sync.client.AssetClient2.Retention
 import com.waz.utils.Identifiable
@@ -71,15 +72,15 @@ object Asset {
 
 }
 
-sealed trait AssetDetails
-case object BlobDetails                                                                 extends AssetDetails
-case class ImageDetails(dimensions: Dim2, tag: ImageTag)                                extends AssetDetails
-case class AudioDetails(duration: Duration, loudness: Loudness)                         extends AssetDetails
-case class VideoDetails(dimensions: Dim2, duration: Duration) extends AssetDetails
+sealed trait AssetDetails                                       extends SafeToLog
+case object BlobDetails                                         extends AssetDetails
+case class ImageDetails(dimensions: Dim2, tag: ImageTag)        extends AssetDetails
+case class AudioDetails(duration: Duration, loudness: Loudness) extends AssetDetails
+case class VideoDetails(dimensions: Dim2, duration: Duration)   extends AssetDetails
 
-sealed trait ImageTag
-case object Preview extends ImageTag
-case object Medium  extends ImageTag
-case object Empty   extends ImageTag
+sealed trait ImageTag extends SafeToLog
+case object Preview   extends ImageTag
+case object Medium    extends ImageTag
+case object Empty     extends ImageTag
 
 case class Loudness(levels: Vector[Float])

--- a/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallLoggingService.scala
@@ -18,7 +18,7 @@
 package com.waz.service.call
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.{verbose, warn}
+import com.waz.log.ZLog2._
 import com.waz.model.{ConvId, LocalInstant, UserId}
 import com.waz.service.call.Avs.AvsClosedReason._
 import com.waz.service.call.CallInfo.CallState._
@@ -44,7 +44,7 @@ class CallLoggingService(selfUserId:  UserId,
     */
   calling.calls.onPartialUpdate(_.keySet) { calls =>
     val ids = calls.keySet
-    verbose(s"Listening to calls: $ids")
+    verbose(l"Listening to calls: $ids")
 
     val prevIds = subscribedConvs
     val toCreate = ids -- prevIds
@@ -78,14 +78,14 @@ class CallLoggingService(selfUserId:  UserId,
     if (!call.endReason.contains(AnsweredElsewhere))
       (call.prevState, call.estabTime) match {
         case (_, None) =>
-          verbose("Call was never successfully established - mark as missed call")
+          verbose(l"Call was never successfully established - mark as missed call")
           messages.addMissedCallMessage(call.convId, call.caller, nowTime)
         case (_, Some(est)) =>
           val duration = est.remainingUntil(endTime)
-          verbose(s"Had a call of duration: ${duration.toSeconds} seconds, save duration as a message")
+          verbose(l"Had a call of duration: ${duration.toSeconds} seconds, save duration as a message")
           messages.addSuccessfulCallMessage(call.convId, call.caller, est.toRemote(drift), duration)
         case _ =>
-          warn(s"unexpected call state: ${call.state}")
+          warn(l"unexpected call state: ${call.state}")
       }
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/TypingService.scala
@@ -18,9 +18,9 @@
 package com.waz.service.conversation
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.content.GlobalPreferences.BackendDrift
 import com.waz.content.{ConversationStorage, GlobalPreferences}
+import com.waz.log.ZLog2._
 import com.waz.model._
 import com.waz.service.AccountsService.InForeground
 import com.waz.service.ZMessaging.clock
@@ -68,7 +68,7 @@ class TypingService(userId:        UserId,
     if (isRecent(e, beDrift)) {
       conversations.getByRemoteId(e.convId) map {
         case Some(conv) => setUserTyping(conv.id, e.from, e.time.toLocal(beDrift), e.isTyping)
-        case None => warn(s"Conversation ${e.convId} not found, ignoring.")
+        case None => warn(l"Conversation ${e.convId} not found, ignoring.")
       }
     } else {
       Future.successful(())

--- a/zmessaging/src/main/scala/com/waz/service/images/BitmapSignal.scala
+++ b/zmessaging/src/main/scala/com/waz/service/images/BitmapSignal.scala
@@ -19,13 +19,13 @@ package com.waz.service.images
 
 import android.graphics.{Bitmap => ABitmap}
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.warn
 import com.waz.api.NetworkMode
 import com.waz.bitmap
 import com.waz.bitmap.BitmapUtils
 import com.waz.bitmap.gif.{Gif, GifAnimator}
 import com.waz.cache.LocalData
 import com.waz.content.UserPreferences
+import com.waz.log.ZLog2._
 import com.waz.model.{AssetData, AssetId, Mime}
 import com.waz.service.{DefaultNetworkModeService, NetworkModeService, ZMessaging}
 import com.waz.service.assets.AssetService.BitmapResult
@@ -71,14 +71,14 @@ abstract class BitmapSignal(req: BitmapRequest, network: NetworkModeService, dow
         signal publish LoadingFailed(ex)
         waitForWifi
       case ex =>
-        warn("bitmap loading failed", ex)
+        warn(l"bitmap loading failed", ex)
         signal publish LoadingFailed(ex)
     }
   }
 
   private def restart() =
     if (req.width > 0) load(loader(req))
-    else warn(s"invalid bitmap request, width <= 0: $req") // ignore requests with invalid size
+    else warn(l"invalid bitmap request, width <= 0: $req") // ignore requests with invalid size
 
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/images/ImageLoader.scala
+++ b/zmessaging/src/main/scala/com/waz/service/images/ImageLoader.scala
@@ -29,6 +29,7 @@ import com.waz.ZLog._
 import com.waz.bitmap.gif.{Gif, GifReader}
 import com.waz.bitmap.{BitmapDecoder, BitmapUtils}
 import com.waz.cache.{CacheEntry, CacheService, LocalData}
+import com.waz.log.ZLog2.SafeToLog
 import com.waz.model.AssetData.IsImage
 import com.waz.model.{Mime, _}
 import com.waz.permissions.PermissionsService
@@ -271,7 +272,7 @@ class ImageLoaderImpl(context:                  Context,
 object ImageLoader {
 
   //TODO if orientation could be useful ever to other clients, we might want to merge with AssetMetaData.Image
-  case class Metadata(width: Int, height: Int, mimeType: String, orientation: Int = ExifInterface.ORIENTATION_UNDEFINED) {
+  case class Metadata(width: Int, height: Int, mimeType: String, orientation: Int = ExifInterface.ORIENTATION_UNDEFINED) extends SafeToLog {
     def isRotated: Boolean = orientation != ExifInterface.ORIENTATION_NORMAL && orientation != ExifInterface.ORIENTATION_UNDEFINED
 
     def withOrientation(orientation: Int) = {

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaContentParser.scala
@@ -21,8 +21,8 @@ import java.net.URLDecoder
 
 import android.util.Patterns
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.api.Message.Part
+import com.waz.log.ZLog2._
 import com.waz.model.{Mention, MessageContent}
 import com.waz.sync.client.{SoundCloudClient, YouTubeClient}
 import com.waz.utils.wrappers.URI
@@ -103,7 +103,7 @@ object RichMediaContentParser {
       res.result()
     } catch {
       case e: Throwable =>
-        error("got error while parsing message content", e)
+        error(l"got error while parsing message content", e)
         Seq(MessageContent(TEXT, content))
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/RichMediaService.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.service.media
 
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.{MediaProvider, Message}
@@ -61,13 +61,13 @@ class RichMediaService(assets:      AssetService,
   msgsStorage.onUpdated { _ foreach {
     case (prev, updated) =>
       if (isSyncableMsg(updated) && syncableContentChanged(prev, updated)) {
-        verbose(s"Updated rich media message: $updated, scheduling sync")
+        verbose(l"Updated rich media message: $updated, scheduling sync")
         sync.syncRichMedia(updated.id)
       }
   } }
 
   private def scheduleSyncFor(ms: Seq[MessageData]) = if (ms.nonEmpty) {
-    verbose(s"Scheduling sync for added rich media messages: $ms")
+    verbose(l"Scheduling sync for added rich media messages: $ms")
 
     msgsStorage.updateAll2(ms.map(_.id), m => m.copy(content = m.content map (c => c.copy(syncNeeded = isSyncable(c))))) map { _ =>
       Future.traverse(ms) { m => sync.syncRichMedia(m.id) }
@@ -88,7 +88,7 @@ class RichMediaService(assets:      AssetService,
           results.collect { case Left(error) => error }
         }
       case None =>
-        error(s"No message data found with id: $id")
+        error(l"No message data found with id: $id")
         Future.successful(Seq(ErrorResponse.InternalError))
     }
   }
@@ -103,7 +103,7 @@ class RichMediaService(assets:      AssetService,
     case MediaProvider.YOUTUBE    => youTube.prepareStreaming(media)
     case MediaProvider.SOUNDCLOUD => soundCloud.prepareStreaming(media)
     case other =>
-      warn(s"Unable to prepare streaming for rich media from $other.")
+      warn(l"Unable to prepare streaming for rich media from $other.")
       Future.successful(Right(Vector.empty))
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/media/YouTubeMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/YouTubeMediaService.scala
@@ -17,9 +17,9 @@
  */
 package com.waz.service.media
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api.Message
+import com.waz.log.ZLog2._
 import com.waz.model._
 import com.waz.model.messages.media.MediaAssetData
 import com.waz.model.messages.media.MediaAssetData.MediaWithImages
@@ -39,21 +39,21 @@ class YouTubeMediaService(client: YouTubeClient, assets: AssetService) {
       case Some(vId) =>
         client.loadVideo(vId) flatMap {
           case Right(MediaWithImages(media, images)) =>
-            verbose(s"got youtube track: $media, images: $images")
+            verbose(l"got youtube track: $media, images: $images")
             assets.updateAssets(images.to[Vector]) map { _ =>
               Right(content.copy(tpe = Message.Part.Type.YOUTUBE, richMedia = Some(media)))
             }
 
           case Left(error) if error.isFatal =>
-            warn(s"snippet loading for ${content.content} failed fatally: $error, switching back to text")
+            warn(l"snippet loading for ${redactedString(content.content)} failed fatally: $error, switching back to text")
             Future successful Right(content.copy(tpe = Message.Part.Type.TEXT, richMedia = None))
 
           case Left(error) =>
-            warn(s"snippet loading failed: $error")
+            warn(l"snippet loading failed: $error")
             Future successful Left(error)
         }
       case None =>
-        warn(s"no video id found in message: $content")
+        warn(l"no video id found in message: $content")
         Future.successful(Right(content.copy(tpe = Message.Part.Type.TEXT, richMedia = None)))
     }
   }

--- a/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/EphemeralMessagesService.scala
@@ -18,7 +18,7 @@
 package com.waz.service.messages
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.api.Message
 import com.waz.content.{MessagesStorage, ZmsDatabase}
 import com.waz.model.AssetStatus.{UploadDone, UploadFailed}
@@ -75,7 +75,7 @@ class EphemeralMessagesService(selfUserId: UserId,
   }
 
   private def removeExpired() = Serialized.future(this, "removeExpired") {
-    verbose(s"removeExpired")
+    verbose(l"removeExpired")
     nextExpiryTime ! LocalInstant.Max
     db.read { implicit db =>
       val time = LocalInstant.Now
@@ -99,7 +99,7 @@ class EphemeralMessagesService(selfUserId: UserId,
 
   private def obfuscate(msg: MessageData): MessageData = {
     import Message.Type._
-    verbose(s"obfuscate($msg)")
+    verbose(l"obfuscate($msg)")
 
     def obfuscate(text: String) = text.map { c =>
       if (c.isWhitespace) c else randomChars.next

--- a/zmessaging/src/main/scala/com/waz/service/messages/ReactionsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/ReactionsService.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.service.messages
 
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.{Likes, ReactionsStorage, ReactionsStorageImpl}
 import com.waz.model._
@@ -36,7 +36,7 @@ class ReactionsService(storage: ReactionsStorage, messages: MessagesContentUpdat
   def unlike(conv: ConvId, msg: MessageId): Future[Likes] = addReaction(conv, msg, Liking.Action.Unlike)
 
   private def addReaction(conv: ConvId, msg: MessageId, action: Liking.Action): Future[Likes] = {
-    verbose(s"addLiking: $conv $msg, $action")
+    verbose(l"addLiking: $conv $msg, $action")
     val reaction = Liking(msg, selfUserId, RemoteInstant.Epoch, action) // EPOCH is used to signal "local" in-band
     for {
       likes  <- storage.addOrUpdate(reaction)

--- a/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/PushNotificationEventsStorage.scala
@@ -18,9 +18,9 @@
 package com.waz.service.push
 
 import android.content.Context
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.Database
+import com.waz.log.ZLog2._
 import com.waz.model.PushNotificationEvents.PushNotificationEventsDao
 import com.waz.model._
 import com.waz.model.otr.ClientId
@@ -79,7 +79,7 @@ class PushNotificationEventsStorageImpl(context: Context, storage: Database, cli
     def isOtrEventForUs(obj: JSONObject): Boolean = {
       returning(!obj.getString("type").startsWith("conversation.otr") || obj.getJSONObject("data").getString("recipient").equals(clientId.str)) { ret =>
         if (!ret) {
-          verbose(s"Skipping otr event not intended for us: $obj")
+          verbose(l"Skipping otr event not intended for us: $obj")
         }
       }
     }

--- a/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/tracking/TrackingService.scala
@@ -18,7 +18,8 @@
 package com.waz.service.tracking
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.ZLog.LogTag
+import com.waz.log.ZLog2._
 import com.waz.model._
 import com.waz.service.call.CallInfo
 import com.waz.service.call.CallInfo.CallState._
@@ -151,7 +152,7 @@ class TrackingServiceImpl(curAccount: => Signal[Option[UserId]], zmsProvider: Zm
       case (Some(_), SelfConnected)    => Some("established")
       case (Some(_), Ended)            => Some("ended")
       case _ =>
-        warn(s"Unexpected call state change: ${info.prevState} => ${info.state}, not tracking")
+        warn(l"Unexpected call state change: ${info.prevState} => ${info.state}, not tracking")
         None
     }).fold(Future.successful({})) { eventName =>
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/OtrClient.scala
@@ -17,9 +17,10 @@
  */
 package com.waz.sync.client
 
-import com.waz.ZLog._
+import com.waz.ZLog.{LogTag, logTagFor}
 import com.waz.api.impl.ErrorResponse
 import com.waz.api.{OtrClientType, Verification}
+import com.waz.log.ZLog2._
 import com.waz.model.AccountData.Password
 import com.waz.model.otr._
 import com.waz.model.{RemoteInstant, UserId}
@@ -97,7 +98,7 @@ class OtrClientImpl(implicit
         o.put(u.str, JsonEncoder.arrString(cs.map(_.str)))
       }
     }
-    verbose(s"loadPreKeys: $users")
+    verbose(l"loadPreKeys: $users")
     Request.Post(relativePath = prekeysPath, body = data)
       .withResultType[PreKeysResponse]
       .withErrorType[ErrorResponse]

--- a/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UserSearchClient.scala
@@ -18,8 +18,8 @@
 package com.waz.sync.client
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.api.impl.ErrorResponse
+import com.waz.log.ZLog2._
 import com.waz.model.SearchQuery.{Recommended, RecommendedHandle, TopPeople}
 import com.waz.model._
 import com.waz.sync.client.UserSearchClient.{DefaultLimit, UserSearchEntry}
@@ -51,11 +51,11 @@ class UserSearchClientImpl(implicit
     RawBodyDeserializer[JSONObject].map(json => UserSearchResponse.unapply(JsonObjectResponse(json)).get)
 
   override def getContacts(query: SearchQuery, limit: Int = DefaultLimit): ErrorOrResponse[Seq[UserSearchEntry]] = {
-    debug(s"graphSearch('$query', $limit)")
+    debug(l"graphSearch('$query', $limit)")
 
     //TODO Get rid of this
     if (query.isInstanceOf[TopPeople.type]) {
-      warn("A request to /search/top was made - this is now only handled locally")
+      warn(l"A request to /search/top was made - this is now only handled locally")
       CancellableFuture.successful(Right(Seq.empty))
     }
 
@@ -117,7 +117,7 @@ object UserSearchClient {
         try {
           Some(JsonDecoder.array[Option[UserSearchEntry]](js.getJSONArray("documents")).flatten)
         } catch {
-          case NonFatal(ex) => warn(s"parsing failed", ex)
+          case NonFatal(ex) => warn(l"parsing failed", ex)
             None
         }
       case _ => None

--- a/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/UsersClient.scala
@@ -18,8 +18,8 @@
 package com.waz.sync.client
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.api.impl.ErrorResponse
+import com.waz.log.ZLog2._
 import com.waz.model._
 import com.waz.service.tracking.TrackingService.NoReporting
 import com.waz.threading.{CancellableFuture, Threading}
@@ -75,7 +75,7 @@ class UsersClientImpl(implicit
   }
 
   override def updateSelf(info: UserInfo): ErrorOrResponse[Unit] = {
-    debug(s"updateSelf: $info, picture: ${info.picture}")
+    debug(l"updateSelf: $info, picture: ${info.picture}")
     Request.Put(relativePath = SelfPath, body = info)
       .withResultType[Unit]
       .withErrorType[ErrorResponse]

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConnectionsSyncHandler.scala
@@ -18,7 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.content.UsersStorage
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{Name, UserId}
@@ -52,7 +52,7 @@ class ConnectionsSyncHandler(usersStorage:      UsersStorage,
   def postConnection(userId: UserId, name: Name, message: String): Future[SyncResult] =
     connectionsClient.createConnection(userId, name, message).future flatMap {
       case Right(event) =>
-        verbose(s"postConnection($userId) success: $event")
+        verbose(l"postConnection($userId) success: $event")
         connectionService
           .handleUserConnectionEvents(Seq(event))
           .map(_ => Success)
@@ -66,7 +66,7 @@ class ConnectionsSyncHandler(usersStorage:      UsersStorage,
         connectionService.handleUserConnectionEvents(Seq(event)).map(_ => Success)
 
       case Right(None) =>
-        warn("postConnectionStatus was successful, but didn't return an event, no change")
+        warn(l"postConnectionStatus was successful, but didn't return an event, no change")
         Future.successful(Success)
 
       case Left(error) =>

--- a/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/LastReadSyncHandler.scala
@@ -18,7 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.content.ConversationStorage
 import com.waz.model.GenericContent.LastRead
 import com.waz.model._
@@ -34,7 +34,7 @@ class LastReadSyncHandler(selfUserId: UserId, convs: ConversationStorage, metada
   import com.waz.threading.Threading.Implicits.Background
 
   def postLastRead(convId: ConvId, time: RemoteInstant): Future[SyncResult] = {
-    verbose(s"postLastRead($convId, $time)")
+    verbose(l"postLastRead($convId, $time)")
 
     convs.get(convId).flatMap {
       case Some(conv) if conv.lastRead.isAfter(time) => // no need to send this msg as lastRead was already advanced

--- a/zmessaging/src/main/scala/com/waz/sync/handler/PushTokenSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/PushTokenSyncHandler.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.sync.handler
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.otr.ClientId
 import com.waz.model.PushToken
 import com.waz.service.BackendConfig
@@ -36,7 +36,7 @@ class PushTokenSyncHandler(pushTokenService: PushTokenService, backend: BackendC
   import Threading.Implicits.Background
 
   def registerPushToken(token: PushToken): Future[SyncResult] = {
-    debug(s"registerPushToken: $token")
+    debug(l"registerPushToken: $token")
     client.postPushToken(PushTokenRegistration(token, backend.pushSenderId, clientId)).future.flatMap {
       case Right(PushTokenRegistration(`token`, _, `clientId`, _)) =>
         pushTokenService
@@ -50,7 +50,7 @@ class PushTokenSyncHandler(pushTokenService: PushTokenService, backend: BackendC
   }
 
   def deleteGcmToken(token: PushToken): CancellableFuture[SyncResult] = {
-    debug(s"deleteGcmToken($token)")
+    debug(l"deleteGcmToken($token)")
     client.deletePushToken(token.str).map(SyncResult(_))
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UserSearchSyncHandler.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.sync.handler
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.{Handle, SearchQuery}
 import com.waz.service.UserSearchService
 import com.waz.sync.SyncResult
@@ -32,7 +32,7 @@ class UserSearchSyncHandler(userSearch: UserSearchService, client: UserSearchCli
   import Threading.Implicits.Background
 
   def syncSearchQuery(query: SearchQuery): Future[SyncResult] = {
-    debug(s"starting sync for: $query")
+    debug(l"starting sync for: $query")
     client.getContacts(query).future flatMap {
       case Right(results) =>
         userSearch.updateSearchResults(query, results)
@@ -44,7 +44,7 @@ class UserSearchSyncHandler(userSearch: UserSearchService, client: UserSearchCli
 
   def exactMatchHandle(handle: Handle): Future[SyncResult] = client.exactMatchHandle(handle).future.flatMap {
     case Right(Some(userId)) =>
-      debug(s"exactMatchHandle, got: $userId for the handle $handle")
+      debug(l"exactMatchHandle, got: $userId for the handle $handle")
       for {
         _ <- usersSyncHandler.syncUsers(userId)
         _ <- userSearch.updateExactMatch(handle, userId)

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.sync.handler
 
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.api.impl.ErrorResponse
 import com.waz.content.UsersStorage
@@ -89,7 +89,7 @@ class UsersSyncHandler(assetSync: AssetSyncHandler,
     }
 
   def postAvailability(availability: Availability): Future[SyncResult] = {
-    verbose(s"postAvailability($availability)")
+    verbose(l"postAvailability($availability)")
     otrSync.broadcastMessage(GenericMessage(Uid(), GenericContent.AvailabilityStatus(availability)))
       .map(SyncResult(_))
   }

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncContentUpdater.scala
@@ -18,9 +18,9 @@
 package com.waz.sync.queue
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
 import com.waz.api.SyncState
 import com.waz.content._
+import com.waz.log.ZLog2._
 import com.waz.model.SyncId
 import com.waz.model.sync.SyncJob.SyncJobDao
 import com.waz.model.sync._
@@ -62,7 +62,7 @@ class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater {
     // make sure no job is loaded with Syncing state, this could happen if app is killed while syncing
     jobs map { job =>
       if (job.state == SyncState.SYNCING) {
-        verbose(s"found job in state: SYNCING on initial load: $job")
+        verbose(l"found job in state: SYNCING on initial load: $job")
         job.copy(state = SyncState.WAITING)
       } else job
     }
@@ -123,18 +123,18 @@ class SyncContentUpdaterImpl(db: Database) extends SyncContentUpdater {
 
     def onAdded(added: SyncJob) = {
       assert(added.id == job.id)
-      verbose(s"addRequest: $job, added: $added")
+      verbose(l"addRequest: $job, added: $added")
       added
     }
 
     def onMerged(merged: SyncJob) = {
-      verbose(s"addRequest: $job, merged: $merged")
+      verbose(l"addRequest: $job, merged: $merged")
       if (forceRetry) merged.copy(attempts = 0, startTime = math.min(merged.startTime, job.startTime))
       else merged
     }
 
     val toSave = merge(job, syncStorage) match {
-      case Unchanged => error("Unexpected result from SyncJobMerger"); job
+      case Unchanged => error(l"Unexpected result from SyncJobMerger"); job
       case Updated(added) => onAdded(added)
       case Merged(merged) => onMerged(merged)
     }

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncSerializer.scala
@@ -19,8 +19,9 @@ package com.waz.sync.queue
 
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
-import com.waz.ZLog._
+import com.waz.ZLog.LogTag
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.ConvId
 import com.waz.model.sync.SyncJob.Priority
 import com.waz.threading.SerialDispatchQueue
@@ -62,7 +63,7 @@ class SyncSerializer {
   }
 
   def acquire(priority: Int): Future[Unit] = {
-    verbose(s"acquire($priority), running: $runningJobs")
+    verbose(l"acquire($priority), running: $runningJobs")
     val handle = new PriorityHandle(priority)
     Future {
       queue += handle
@@ -72,7 +73,7 @@ class SyncSerializer {
   }
 
   def release(): Unit = Future {
-    verbose(s"release, running: $runningJobs")
+    verbose(l"release, running: $runningJobs")
     runningJobs -= 1
     processQueue()
   }
@@ -85,7 +86,7 @@ class SyncSerializer {
   }
 
   def acquire(res: ConvId): Future[ConvLock] = {
-    verbose(s"acquire($res)")
+    verbose(l"acquire($res)")
     val handle = new ConvHandle(res)
     Future {
       convQueue :+= handle
@@ -95,7 +96,7 @@ class SyncSerializer {
   }
 
   def release(r: ConvId): Unit = Future {
-    verbose(s"release($r)")
+    verbose(l"release($r)")
     convs -= r
     processConvQueue()
   }

--- a/zmessaging/src/main/scala/com/waz/threading/DispatchQueue.scala
+++ b/zmessaging/src/main/scala/com/waz/threading/DispatchQueue.scala
@@ -21,7 +21,8 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 import android.os.{Handler, Looper}
-import com.waz.ZLog._
+import com.waz.ZLog.LogTag
+import com.waz.log.ZLog2._
 import com.waz.utils.crypto.ZSecureRandom
 
 import scala.annotation.tailrec
@@ -38,7 +39,7 @@ trait DispatchQueue extends ExecutionContext {
   def apply[A](task: => A)(implicit tag: LogTag = ""): CancellableFuture[A] = CancellableFuture(task)(this, tag)
 
   //TODO: this implements ExecutionContext.reportFailure, should we use different log here? or maybe do something else
-  override def reportFailure(t: Throwable): Unit = error("reportFailure called", t)(name)
+  override def reportFailure(t: Throwable): Unit = error(l"reportFailure called", t)(name)
 
   //used for waiting in tests
   def hasRemainingTasks: Boolean = false

--- a/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
+++ b/zmessaging/src/main/scala/com/waz/ui/MemoryImageCache.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.ui
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.AssetId
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.ui.MemoryImageCache.BitmapRequest
@@ -63,10 +63,10 @@ class MemoryImageCacheImpl(lru: Cache[MemoryImageCache.Key, MemoryImageCache.Ent
   override def apply(id: AssetId, req: BitmapRequest, imgWidth: Int, load: => CancellableFuture[Bitmap]): CancellableFuture[Bitmap] =
     get(id, req, imgWidth) match {
       case Some(bitmap) =>
-        verbose(s"found bitmap for req: $req")
+        verbose(l"found bitmap for req: $req")
         CancellableFuture.successful(bitmap)
       case None =>
-        verbose(s"no bitmap for req: $req, loading...")
+        verbose(l"no bitmap for req: $req, loading...")
         val future = load
         future.onSuccess {
           case EmptyBitmap => // ignore
@@ -100,7 +100,7 @@ object MemoryImageCache {
       override def sizeOf(id: Key, value: Entry): Int = value.size
     }
 
-  sealed trait BitmapRequest {
+  sealed trait BitmapRequest extends SafeToLog {
     val width: Int
     val mirror: Boolean = false
   }

--- a/zmessaging/src/main/scala/com/waz/utils/ContentURIs.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/ContentURIs.scala
@@ -20,7 +20,7 @@ package com.waz.utils
 import android.content.Context
 import android.provider.OpenableColumns._
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.model.Mime
 import com.waz.threading.Threading
 import com.waz.utils.wrappers.URI
@@ -35,7 +35,7 @@ object ContentURIs {
     def mimeFromExtension = Option(uri.getLastPathSegment).map(Mime.fromFileName).filterNot(_.isEmpty)
     def mime = mimeFromResolver orElse mimeFromExtension getOrElse Mime.Default
 
-    verbose(s"queryContentUriInfo($uri) - mimeFromResolver: $mimeFromResolver, mimeFromExtension: $mimeFromExtension")
+    verbose(l"queryContentUriInfo($uri) - mimeFromResolver: $mimeFromResolver, mimeFromExtension: $mimeFromExtension")
 
     def nameFromUri = Option(uri.getLastPathSegment).filterNot(_.isEmpty)
 

--- a/zmessaging/src/main/scala/com/waz/utils/Locales.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/Locales.scala
@@ -27,8 +27,9 @@ import android.content.res.Configuration
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.{JELLY_BEAN_MR2, LOLLIPOP}
 import com.github.ghik.silencer.silent
-import com.waz.ZLog._
+import com.waz.ZLog.LogTag
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.service.ZMessaging
 import com.waz.utils
 
@@ -83,7 +84,7 @@ trait LanguageTags {
 @TargetApi(LOLLIPOP)
 object AndroidLanguageTags {
   def create(implicit logTag: LogTag): LanguageTags = new LanguageTags {
-    debug("using built-in Android language tag support")(logTag)
+    debug(l"using built-in Android language tag support")(logTag)
     def languageTagOf(l: Locale): String = l.toLanguageTag
     def localeFor(t: String): Option[Locale] = Try(Locale.forLanguageTag(t)).toOption
   }
@@ -91,7 +92,7 @@ object AndroidLanguageTags {
 
 object FallbackLanguageTags {
   def create(implicit logTag: LogTag): LanguageTags = new LanguageTags {
-    debug("using fallback language tag support")(logTag)
+    debug(l"using fallback language tag support")(logTag)
     def languageTagOf(l: Locale): String = {
       val language = if (l.getLanguage.nonEmpty) l.getLanguage else "und"
       val country = l.getCountry
@@ -118,7 +119,7 @@ trait Transliteration {
 object Transliteration {
   private val id = "Any-Latin; Latin-ASCII; Lower; [^\\ 0-9a-z] Remove"
   def chooseImplementation(id: String = id): Transliteration = {
-    verbose(s"chooseImplementation: $id")
+    verbose(l"chooseImplementation: ${showString(id)}")
     if (!utils.isTest && Try(Class.forName("libcore.icu.Transliterator")).isSuccess) LibcoreTransliteration.create(id)
     else ICU4JTransliteration.create(id)
   }
@@ -127,7 +128,7 @@ object Transliteration {
 @TargetApi(JELLY_BEAN_MR2)
 object LibcoreTransliteration {
   def create(id: String)(implicit logTag: LogTag): Transliteration = new Transliteration {
-    debug("using libcore transliteration")(logTag)
+    debug(l"using libcore transliteration")(logTag)
     private val delegate = new libcore.icu.Transliterator(id)
     def transliterate(s: String): String = delegate.transliterate(s)
   }
@@ -135,7 +136,7 @@ object LibcoreTransliteration {
 
 object ICU4JTransliteration {
   def create(id: String)(implicit logTag: LogTag): Transliteration = new Transliteration {
-    debug("using ICU4J transliteration")(logTag)
+    debug(l"using ICU4J transliteration")(logTag)
     private val delegate = com.ibm.icu.text.Transliterator.getInstance(id)
     def transliterate(s: String): String = delegate.transliterate(s)
   }
@@ -151,7 +152,7 @@ object LibcoreIndexing {
 
     private val delegate = new libcore.icu.AlphabeticIndex(locale).getImmutableIndex
 
-    verbose(s"using libcore indexing for locale $locale; buckets: ${delegate.getBucketCount}")(logTag)
+    verbose(l"using libcore indexing for locale $locale; buckets: ${delegate.getBucketCount}")(logTag)
 
     override def labelFor(s: String): String = {
       val index = delegate.getBucketIndex(s)
@@ -185,7 +186,7 @@ object FallbackIndexing {
       if (block eq null) false else blocks(block)
     }
 
-    verbose(s"creating fallback indexing")
+    verbose(l"creating fallback indexing")
 
     @tailrec override def labelFor(s: String): String = {
       if (s.isEmpty) "#"

--- a/zmessaging/src/main/scala/com/waz/utils/TrimmingLruCache.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/TrimmingLruCache.scala
@@ -21,7 +21,7 @@ import android.app.ActivityManager
 import android.content.res.Configuration
 import android.content.{ComponentCallbacks2, Context}
 import android.support.v4.util.LruCache
-import com.waz.ZLog._
+import com.waz.log.ZLog2._
 import com.waz.ZLog.ImplicitTag._
 import com.waz.utils.TrimmingLruCache.CacheSize
 
@@ -76,7 +76,7 @@ trait AutoTrimming extends ComponentCallbacks2 { self: LruCache[_, _] =>
   override def onTrimMemory(level: Int): Unit =
     TrimFactors.collectFirst { case (l, factor) if l >= level =>
       val trimmedSize = (factor * maxSize()).toInt
-      verbose(s"onTrimMemory($level) - trimToSize: $trimmedSize")
+      verbose(l"onTrimMemory($level) - trimToSize: $trimmedSize")
       trimToSize(trimmedSize)
       System.gc()
     }

--- a/zmessaging/src/main/scala/com/waz/utils/crypto/RandomBytes.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/crypto/RandomBytes.scala
@@ -18,7 +18,7 @@
 package com.waz.utils.crypto
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.warn
+import com.waz.log.ZLog2._
 
 import scala.util.{Failure, Success, Try}
 
@@ -36,7 +36,7 @@ class RandomBytes {
     RandomBytes.loadLibrary match {
       case Success(_) => randomBytes(buffer, count)
       case _ =>
-        warn(s"Libsodium failed to generate $count random bytes. Falling back to SecureRandom")
+        warn(l"Libsodium failed to generate $count random bytes. Falling back to SecureRandom")
         ZSecureRandom.nextBytes(buffer)
     }
     buffer

--- a/zmessaging/src/main/scala/com/waz/utils/crypto/ReplyHashing.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/crypto/ReplyHashing.scala
@@ -21,8 +21,8 @@ import java.nio.ByteBuffer
 
 import com.waz.content.AssetsStorage
 import com.waz.model._
-import com.waz.ZLog.ImplicitTag.implicitLogTag
-import com.waz.ZLog.verbose
+import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.model.GenericMessage.TextMessage
 import com.waz.utils.returning
 
@@ -74,7 +74,7 @@ class ReplyHashingImpl(storage: AssetsStorage) extends ReplyHashing {
     val bytes =
       "\uFEFF".getBytes("UTF-16BE") ++ content.getBytes("UTF-16BE") ++ timestamp.toEpochSec.getBytes
     returning(Sha256.calculate(bytes)) { sha =>
-      verbose(s"hashTextReply($content, $timestamp): ${sha.hexString}")
+      verbose(l"hashTextReply(${redactedString(content)}, $timestamp): $sha")
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/utils/events/EventStream.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/events/EventStream.scala
@@ -19,8 +19,8 @@ package com.waz.utils.events
 
 import java.util.UUID.randomUUID
 
-import com.waz.ZLog._
 import com.waz.ZLog.ImplicitTag._
+import com.waz.log.ZLog2._
 import com.waz.threading.{CancellableFuture, Threading}
 import com.waz.utils.events.Events.Subscriber
 import com.waz.utils.{Serialized, returning}
@@ -136,7 +136,7 @@ class FutureEventStream[E, V](source: EventStream[E], f: E => Future[V]) extends
     Serialized.future(key)(f(event).andThen {
       case Success(v) => dispatch(v, sourceContext)
       case Failure(t: NoSuchElementException) => // do nothing to allow Future.filter/collect
-      case Failure(t) => error("async map failed", t)
+      case Failure(t) => error(l"async map failed", t)
     }(sourceContext.orElse(executionContext).getOrElse(Threading.Background)))
 }
 

--- a/zmessaging/src/main/scala/com/waz/utils/package.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/package.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.{TimeUnit, TimeoutException}
 
 import com.waz.ZLog.LogTag
 import com.waz.api.UpdateListener
+import com.waz.log.ZLog2._
 import com.waz.model.{LocalInstant, WireInstant}
 import com.waz.service.tracking.TrackingService
 import com.waz.threading.{CancellableFuture, Threading}
@@ -242,7 +243,7 @@ package object utils {
           p.success(())
         case Failure(t) =>
           p.success(())
-          ZLog.error("Future failed", t)
+          error(l"Future failed", t)
       }(Threading.Background)
       p.future
     }

--- a/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.znet2
 
-import com.waz.ZLog.{info, warn}
+import com.waz.log.ZLog2._
 import com.waz.sync.client.{JsonObjectResponse, ResponseContent, StringResponse, BinaryResponse}
 import com.waz.utils.events.EventStream
 import com.waz.znet2.WebSocketFactory.SocketEvent
@@ -67,34 +67,34 @@ object OkHttpWebSocketFactory extends WebSocketFactory {
         val socket = okHttpClient.newWebSocket(convertHttpRequest(request), new WebSocketListener {
 
           override def onOpen(webSocket: OkWebSocket, response: OkResponse): Unit = {
-            info("WebSocket connection has been opened")
+            info(l"WebSocket connection has been opened")
             publish(SocketEvent.Opened(new OkHttpWebSocket(webSocket)))
           }
 
           override def onMessage(webSocket: OkWebSocket, text: String): Unit = {
-            info("WebSocket received a text message.")
+            info(l"WebSocket received a text message.")
             val content = Try(JsonObjectResponse(new JSONObject(text))).getOrElse(StringResponse(text))
             publish(SocketEvent.Message(new OkHttpWebSocket(webSocket), content))
           }
 
           override def onMessage(webSocket: OkWebSocket, bytes: ByteString): Unit = {
-            info("WebSocket received a bytes message.")
+            info(l"WebSocket received a bytes message.")
             val content = Try(JsonObjectResponse(new JSONObject(bytes.utf8()))).getOrElse(BinaryResponse(bytes.toByteArray, ""))
             publish(SocketEvent.Message(new OkHttpWebSocket(webSocket), content))
           }
 
           override def onClosing(webSocket: OkWebSocket, code: Int, reason: String): Unit = {
-            info("WebSocket connection is going to be closed")
+            info(l"WebSocket connection is going to be closed")
             publish(SocketEvent.Closing(new OkHttpWebSocket(webSocket), code, reason))
           }
 
           override def onClosed(webSocket: OkWebSocket, code: Int, reason: String): Unit = {
-            info("WebSocket connection has been closed")
+            info(l"WebSocket connection has been closed")
             publish(SocketEvent.Closed(new OkHttpWebSocket(webSocket)))
           }
 
           override def onFailure(webSocket: OkWebSocket, ex: Throwable, response: okhttp3.Response): Unit = {
-            warn(s"WebSocket connection has been failed: ${ex.getMessage}")
+            warn(l"WebSocket connection has been failed.", ex)
             publish(SocketEvent.Closed(new OkHttpWebSocket(webSocket), Some(ex)))
           }
         })
@@ -103,7 +103,7 @@ object OkHttpWebSocketFactory extends WebSocketFactory {
       }
 
       override protected def onUnwire(): Unit = {
-        info("Cancelling websocket.")
+        info(l"Cancelling websocket.")
         socket.foreach(_.cancel())
       }
     }

--- a/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/http/HttpClient.scala
@@ -18,7 +18,7 @@
 package com.waz.znet2.http
 
 import com.waz.ZLog.ImplicitTag._
-import com.waz.ZLog.error
+import com.waz.log.ZLog2._
 import com.waz.threading.CancellableFuture
 import com.waz.znet2.http.HttpClient._
 import com.waz.znet2.http.Request.QueryParameter
@@ -186,7 +186,7 @@ trait HttpClient {
   )(implicit rs: RequestSerializer[T]): CancellableFuture[Request[Body]] =
     CancellableFuture(rs.serialize(request)).recoverWith {
       case err =>
-        error("Error while serializing request.", err)
+        error(l"Error while serializing request.", err)
         CancellableFuture.failed(EncodingError(err))
     }
 
@@ -195,7 +195,7 @@ trait HttpClient {
   )(implicit rd: ResponseDeserializer[T]): CancellableFuture[T] =
     CancellableFuture(rd.deserialize(response)).recoverWith {
       case err =>
-        error("Error while deserializing response.", err)
+        error(l"Error while deserializing response.", err)
         //we already have tried to deserialize response body, so it may be broken.
         CancellableFuture.failed(DecodingError(err, response.copy(body = EmptyBodyImpl)))
     }
@@ -215,7 +215,7 @@ trait HttpClient {
       .recoverWith {
         case err: HttpClientError => CancellableFuture.failed(err)
         case err =>
-          error("Unexpected error.", err)
+          error(l"Unexpected error.", err)
           CancellableFuture.failed(UnknownError(err))
       }
 
@@ -238,7 +238,7 @@ trait HttpClient {
       .recoverWith {
         case err: HttpClientError => CancellableFuture.failed(err)
         case err =>
-          error("Unexpected error.", err)
+          error(l"Unexpected error.", err)
           CancellableFuture.failed(UnknownError(err))
       }
 
@@ -259,7 +259,7 @@ trait HttpClient {
       .recover {
         case err: HttpClientError => Left(implicitly[CustomErrorConstructor[E]].constructFrom(err))
         case err =>
-          error("Unexpected error.", err)
+          error(l"Unexpected error.", err)
           Left(implicitly[CustomErrorConstructor[E]].constructFrom(UnknownError(err)))
       }
 


### PR DESCRIPTION
# What's In This PR?

This is the first phase of migration to the safe public logging system. The commit history should give a good overview of which types have been marked `SafeToLog` and which types have accompanying an `LogShow`.

I've done a best effort to avoid using the `showStr()` method, however in some cases it does occur. You can easily check the usages of this method to confirm that it's being used correctly.

## Note

Not all logs have been migrated yet. Many are in sources with are currently being refactored, and the others I was not sure about. These will be addressed at a later time.