### PR TITLE
Refactor: json user search client

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -25,7 +25,7 @@ import com.waz.model.ManagedBy.ManagedBy
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.UserPermissions._
 import com.waz.service.SearchKey
-import com.waz.sync.client.UserSearchClient.UserSearchEntry
+import com.waz.service.UserSearchService.UserSearchEntry
 import com.waz.utils._
 import com.waz.utils.wrappers.{DB, DBCursor}
 

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -18,19 +18,19 @@
 package com.waz.service
 
 import com.waz.log.LogSE._
-import com.waz.content._
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import com.waz.content._
 import com.waz.model.AccountData.Password
 import com.waz.model.UserData.ConnectionStatus
 import com.waz.model.{AccentColor, _}
 import com.waz.service.EventScheduler.Stage
+import com.waz.service.UserSearchService.UserSearchEntry
 import com.waz.service.UserService._
 import com.waz.service.assets.AssetService
 import com.waz.service.assets.AssetService.RawAssetInput
 import com.waz.service.conversation.SelectedConversationService
 import com.waz.service.push.PushService
 import com.waz.sync.SyncServiceHandle
-import com.waz.sync.client.UserSearchClient.UserSearchEntry
 import com.waz.sync.client.{CredentialsUpdateClient, ErrorOr, UsersClient}
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue, Threading}
 import com.waz.utils._


### PR DESCRIPTION
# What's In This PR?
We want to remove our own custom JSON (de)serialization and instead rely on **Circe**. This is a small step toward that goal.

The deserialization code in `UserSearchClient` has been replaced with auto derived circe json objects.  We define a response object for each backend response that we expect. In this case `UserSearchResponse` and `ExtractHandleResponse`. These objects reflect the structure of the response payload (but we only include keys that we're interested in). Simply by defining these objects, deserialization handled for us.

The model objects extracted from these responses are defined in the domain layer, to maintain separation. In this case, `UserSearchEntry` has been moved from `UserSearchClient` to `UserSearchService`.