### PR TITLE
Simplified build configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,14 @@ import scala.util.Random
 val MajorVersion = "141"
 val MinorVersion = "0" // hotfix release
 
-lazy val buildType = sys.props.getOrElse("build_type", "dev")
+lazy val buildType =
+  sys.props.getOrElse("build_type", "dev").toLowerCase match {
+    case "dev" => "dev"
+    case "release" => "release"
+    case "pr" => "pr"
+    case t => throw new MessageOnlyException(s"Invalid build type: '$t', " +
+      s"set the sbt flag -Dbuild_type to either 'dev', 'release' or 'pr'. ")
+  }
 lazy val buildNumber = sys.props.getOrElse("build_number", "0")
 lazy val isRelease = buildType == "release"
 lazy val isPR = buildType == "pr"


### PR DESCRIPTION
## What's new in this PR?

### Issues

There are several types of builds done in slightly different configurations and it could simplified to be more consistent. In addition the version numbers are set to different strings depending on Jenkins environment variables which makes it specific to the CI setup we have.

### Solutions

The table summarises the current situation. The proposed changes for version numbers are outlined

Branch | Version (current) | Version (proposed) | Debug | Bintray repo |
-- |	-- | -- | -- | -- | 
master | `141.0.512` | `141.0.512` | ❌ | Release
develop | `141.2237` | `141.0.512-DEV` | ✅ | Snapshot
PR | `141.768-PR` | `141.0.512-PR` | ✅ | Snapshot
Local | `141-SNAPSHOT` | `141.0.0-DEV` | ✅ | N/A

Also the way we build the project is changed slightly to make it less coupled to Jenkins:
* Passing the type of build as `Dbuild_type=dev` parameter. The value can be `dev`, `pr` or `release`. 
* Passing build number explicitly with `-Dbuild_number=123`. When it's not there (e.g. building locally) it will be set to `0`.

### Testing

Tried running tests with these parameters:
* `sbt -Dbuild_type=dev -Dbuild_number=123 test`
* `sbt -Dbuild_type=pr -Dbuild_number=123 test`
* `sbt -Dbuild_type=release -Dbuild_number=123 test`

## Questions

- [x] What would be a good way to fail build if `build_type` is not one of known values? It will default to `dev` build but this could be a user error.