### PR TITLE
feat: Users other than `self` should have the permission field in the user data

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -442,6 +442,7 @@ object UserPreferences {
   lazy val ShouldSyncConversations          = PrefKey[Boolean]("should_sync_conversations_1", customDefault = true)
   lazy val ShouldSyncInitial                = PrefKey[Boolean]("should_sync_initial_1", customDefault = true)
   lazy val ShouldSyncUsers                  = PrefKey[Boolean]("should_sync_users", customDefault = true)
+  lazy val ShouldSyncTeam                   = PrefKey[Boolean]("should_sync_team", customDefault = true)
 
   // fix for duplicated entries in the database, left there by a bug from an old version of the app
   lazy val FixDuplicatedConversations       = PrefKey[Boolean]("fix_duplicated_conversations", customDefault = true)

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -55,7 +55,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = 114
+  val DbVersion = 116
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao,
@@ -281,6 +281,12 @@ object ZMessagingDB {
     },
     Migration(114, 115) { db =>
       db.execSQL("ALTER TABLE Users ADD COLUMN fields TEXT DEFAULT null")
+    },
+    Migration(115, 116) { db =>
+      db.execSQL("ALTER TABLE Users ADD COLUMN self_permissions INTEGER DEFAULT 0")
+      db.execSQL("ALTER TABLE Users ADD COLUMN copy_permissions INTEGER DEFAULT 0")
+      db.execSQL("ALTER TABLE Users ADD COLUMN created_by TEXT DEFAULT null")
+      db.execSQL("UPDATE KeyValues SET value = 'true' WHERE key = 'should_sync_teams'")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/model/AccountDataOld.scala
+++ b/zmessaging/src/main/scala/com/waz/model/AccountDataOld.scala
@@ -22,7 +22,8 @@ import com.waz.ZLog._
 import com.waz.db.Col._
 import com.waz.db.{Col, Dao, DbTranslator}
 import com.waz.model.AccountData.Password
-import com.waz.model.AccountDataOld.{PermissionsMasks, TriTeamId}
+import com.waz.model.AccountDataOld.TriTeamId
+import com.waz.model.UserPermissions.PermissionsMasks
 import com.waz.model.otr.ClientId
 import com.waz.sync.client.AuthenticationManager
 import com.waz.utils.Locales.currentLocaleOrdering
@@ -152,8 +153,8 @@ case class AccountDataOld(override val id: AccountId                       = Acc
     """.stripMargin
 
 
-  lazy val selfPermissions = AccountDataOld.decodeBitmask(_selfPermissions)
-  lazy val copyPermissions = AccountDataOld.decodeBitmask(_copyPermissions)
+  lazy val selfPermissions = UserPermissions.decodeBitmask(_selfPermissions)
+  lazy val copyPermissions = UserPermissions.decodeBitmask(_copyPermissions)
 
   /**
     * A pending phone that matches the current phone signifies the user is trying to login. In this case, they're account
@@ -229,47 +230,9 @@ object AccountDataOld {
   //Left is undefined, Right(None) is no team, Right(Some()) is a team
   type TriTeamId = Either[Unit, Option[TeamId]]
 
-  type PermissionsMasks = (Long, Long) //self and copy permissions
-
   def apply(email: EmailAddress, password: String): AccountDataOld = {
     val id = AccountId()
     AccountDataOld(id, Left({}), email = Some(email), password = Some(password), phone = None, handle = None)
-  }
-
-  //TODO move to AccountData, and ensure they are copied across in migration...
-  type Permission = Permission.Value
-  object Permission extends Enumeration {
-    val
-    CreateConversation,         // 0x001
-    DeleteConversation,         // 0x002
-    AddTeamMember,              // 0x004
-    RemoveTeamMember,           // 0x008
-    AddConversationMember,      // 0x010
-    RemoveConversationMember,   // 0x020
-    GetBilling,                 // 0x040
-    SetBilling,                 // 0x080
-    SetTeamData,                // 0x100
-    GetMemberPermissions,       // 0x200
-    GetTeamConversations,       // 0x400
-    DeleteTeam,                 // 0x800
-    SetMemberPermissions        // 0x1000
-    = Value
-  }
-
-  def decodeBitmask(mask: Long): Set[Permission] = {
-    val builder = new mutable.SetBuilder[Permission, Set[Permission]](Set.empty)
-    (0 until Permission.values.size).map(math.pow(2, _).toInt).zipWithIndex.foreach {
-      case (one, pos) => if ((mask & one) != 0) builder += Permission(pos)
-    }
-    builder.result()
-  }
-
-  def encodeBitmask(ps: Set[Permission]): Long = {
-    var mask = 0L
-    (0 until Permission.values.size).map(math.pow(2, _).toLong).zipWithIndex.foreach {
-      case (m, i) => if (ps.contains(Permission(i))) mask = mask | m
-    }
-    mask
   }
 
   def computeHash(id: AccountId, password: String) =

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -25,11 +25,11 @@ case class Handle(string: String) extends AnyVal {
   override def toString : String = string
 
   def startsWithQuery(query: String): Boolean = {
-     string.startsWith(Handle.stripSymbol(query).toLowerCase)
+    query.nonEmpty && string.startsWith(Handle.stripSymbol(query).toLowerCase)
   }
 
   def exactMatchQuery(query: String): Boolean = {
-    string == Handle.stripSymbol(query).toLowerCase
+    query.nonEmpty && string == Handle.stripSymbol(query).toLowerCase
   }
 
   def withSymbol: String = if (string.startsWith("@")) string else s"@$string"

--- a/zmessaging/src/main/scala/com/waz/model/Handle.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Handle.scala
@@ -24,13 +24,13 @@ import com.waz.utils.Locales
 case class Handle(string: String) extends AnyVal {
   override def toString : String = string
 
-  def startsWithQuery(query: String): Boolean = {
+  def startsWithQuery(query: String): Boolean =
     query.nonEmpty && string.startsWith(Handle.stripSymbol(query).toLowerCase)
-  }
+  
 
-  def exactMatchQuery(query: String): Boolean = {
-    query.nonEmpty && string == Handle.stripSymbol(query).toLowerCase
-  }
+  def exactMatchQuery(query: String): Boolean =
+    string == Handle.stripSymbol(query).toLowerCase
+
 
   def withSymbol: String = if (string.startsWith("@")) string else s"@$string"
 }

--- a/zmessaging/src/main/scala/com/waz/model/SearchQuery.scala
+++ b/zmessaging/src/main/scala/com/waz/model/SearchQuery.scala
@@ -17,8 +17,16 @@
  */
 package com.waz.model
 
+import com.waz.model.SearchQuery.{Recommended, RecommendedHandle}
+
 sealed trait SearchQuery {
   def cacheKey: String
+
+  def filter: String = this match {
+    case Recommended(str)       => str
+    case RecommendedHandle(str) => str
+    case _                      => ""
+  }
 }
 
 object SearchQuery {

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -135,6 +135,13 @@ case class UserData(override val id:       UserId,
   def matchesFilter(filter: String, handleOnly: Boolean): Boolean =
     handle.exists(_.startsWithQuery(filter)) ||
       (!handleOnly && (SearchKey(filter).isAtTheStartOfAnyWordIn(searchKey) || email.exists(e => filter.trim.equalsIgnoreCase(e.str))))
+
+  // Whether the user matches a search query
+  def matchesQuery(query: Option[SearchKey] = None, handleOnly: Boolean = false) = (query match {
+    case Some(q) =>
+      this.handle.map(_.string).contains(q.asciiRepresentation) || (!handleOnly && q.isAtTheStartOfAnyWordIn(this.searchKey))
+    case _ => true
+  })
 }
 
 object UserData {

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -57,8 +57,7 @@ case class UserData(override val id:       UserId,
                     managedBy:             Option[ManagedBy]      = None,
                     fields:                Seq[UserField]         = Seq.empty,
                     permissions:           PermissionsMasks       = (0,0),
-                    createdBy:             Option[UserId]         = None
-                   ) extends Identifiable[UserId] {
+                    createdBy:             Option[UserId]         = None) extends Identifiable[UserId] {
 
   def isConnected = ConnectionStatus.isConnected(connection)
   def hasEmailOrPhone = email.isDefined || phone.isDefined
@@ -122,10 +121,8 @@ case class UserData(override val id:       UserId,
 
   def isGuest(ourTeamId: Option[TeamId]): Boolean = ourTeamId.isDefined && teamId != ourTeamId
 
-  def isPartner(ourTeamId: Option[TeamId]): Boolean = {
-    lazy val ps = decodeBitmask(permissions._1)
-    teamId.isDefined && teamId == ourTeamId && PartnerPermissions.subsetOf(ps) && PartnerPermissions.size == ps.size
-  }
+  def isPartner(ourTeamId: Option[TeamId]): Boolean =
+    teamId.isDefined && teamId == ourTeamId && decodeBitmask(permissions._1) == PartnerPermissions
 
   def matchesFilter(filter: String): Boolean = {
     val isHandleSearch = Handle.isHandle(filter)
@@ -136,12 +133,11 @@ case class UserData(override val id:       UserId,
     handle.exists(_.startsWithQuery(filter)) ||
       (!handleOnly && (SearchKey(filter).isAtTheStartOfAnyWordIn(searchKey) || email.exists(e => filter.trim.equalsIgnoreCase(e.str))))
 
-  // Whether the user matches a search query
-  def matchesQuery(query: Option[SearchKey] = None, handleOnly: Boolean = false) = (query match {
+  def matchesQuery(query: Option[SearchKey] = None, handleOnly: Boolean = false): Boolean = query match {
     case Some(q) =>
       this.handle.map(_.string).contains(q.asciiRepresentation) || (!handleOnly && q.isAtTheStartOfAnyWordIn(this.searchKey))
     case _ => true
-  })
+  }
 }
 
 object UserData {

--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -23,12 +23,11 @@ import com.waz.db.Dao
 import com.waz.model
 import com.waz.model.ManagedBy.ManagedBy
 import com.waz.model.UserData.ConnectionStatus
-import com.waz.model.UserField._
+import com.waz.model.UserPermissions._
 import com.waz.service.SearchKey
 import com.waz.sync.client.UserSearchClient.UserSearchEntry
 import com.waz.utils._
 import com.waz.utils.wrappers.{DB, DBCursor}
-import org.json.JSONObject
 
 import scala.concurrent.duration._
 
@@ -56,7 +55,10 @@ case class UserData(override val id:       UserId,
                     integrationId:         Option[IntegrationId]  = None,
                     expiresAt:             Option[RemoteInstant]  = None,
                     managedBy:             Option[ManagedBy]      = None,
-                    fields:                Seq[UserField]         = Seq.empty) extends Identifiable[UserId] {
+                    fields:                Seq[UserField]         = Seq.empty,
+                    permissions:           PermissionsMasks       = (0,0),
+                    createdBy:             Option[UserId]         = None
+                   ) extends Identifiable[UserId] {
 
   def isConnected = ConnectionStatus.isConnected(connection)
   def hasEmailOrPhone = email.isDefined || phone.isDefined
@@ -120,6 +122,11 @@ case class UserData(override val id:       UserId,
 
   def isGuest(ourTeamId: Option[TeamId]): Boolean = ourTeamId.isDefined && teamId != ourTeamId
 
+  def isPartner(ourTeamId: Option[TeamId]): Boolean = {
+    lazy val ps = decodeBitmask(permissions._1)
+    teamId.isDefined && teamId == ourTeamId && PartnerPermissions.subsetOf(ps) && PartnerPermissions.size == ps.size
+  }
+
   def matchesFilter(filter: String): Boolean = {
     val isHandleSearch = Handle.isHandle(filter)
     matchesFilter(filter, isHandleSearch)
@@ -173,51 +180,6 @@ object UserData {
 
   def apply(user: UserInfo, withSearchKey: Boolean): UserData = UserData(user.id, user.name.getOrElse(Name.Empty)).updated(user, withSearchKey)
 
-  implicit lazy val Decoder: JsonDecoder[UserData] = new JsonDecoder[UserData] {
-    import JsonDecoder._
-    override def apply(implicit js: JSONObject): UserData = UserData(
-      id = 'id, teamId = decodeOptTeamId('teamId), name = 'name, email = decodeOptEmailAddress('email), phone = decodeOptPhoneNumber('phone),
-      trackingId = decodeOptId[TrackingId]('trackingId), picture = decodeOptAssetId('assetId), accent = decodeInt('accent), searchKey = SearchKey('name),
-      connection = ConnectionStatus('connection), connectionLastUpdated = RemoteInstant.ofEpochMilli(decodeLong('connectionLastUpdated)), connectionMessage = decodeOptString('connectionMessage),
-      conversation = decodeOptRConvId('rconvId), relation = Relation.withId('relation),
-      syncTimestamp = decodeOptLocalInstant('syncTimestamp), 'displayName, Verification.valueOf('verified), deleted = 'deleted,
-      availability = Availability(decodeInt('activityStatus)), handle = decodeOptHandle('handle),
-      providerId = decodeOptId[ProviderId]('providerId), integrationId = decodeOptId[IntegrationId]('integrationId),
-      expiresAt = decodeOptISOInstant('expires_at).map(RemoteInstant(_)),
-      managedBy = ManagedBy.decodeOptManagedBy('managed_by),
-      fields = UserField.decodeUserFields('fields)
-    )
-  }
-
-  implicit lazy val Encoder: JsonEncoder[UserData] = new JsonEncoder[UserData] {
-    override def apply(v: UserData): JSONObject = JsonEncoder { o =>
-      o.put("id", v.id.str)
-      v.teamId foreach (id => o.put("teamId", id.str))
-      o.put("name", v.name)
-      v.email foreach (o.put("email", _))
-      v.phone foreach (o.put("phone", _))
-      v.trackingId foreach (id => o.put("trackingId", id.str))
-      v.picture foreach (id => o.put("assetId", id.str))
-      o.put("accent", v.accent)
-      o.put("connection", v.connection.code)
-      o.put("connectionLastUpdated", v.connectionLastUpdated.toEpochMilli)
-      v.connectionMessage foreach (o.put("connectionMessage", _))
-      v.conversation foreach (id => o.put("rconvId", id.str))
-      o.put("relation", v.relation.id)
-      v.syncTimestamp.foreach(v => o.put("syncTimestamp", v.toEpochMilli))
-      o.put("displayName", v.displayName)
-      o.put("verified", v.verified.name)
-      o.put("deleted", v.deleted)
-      o.put("availability", v.availability.id)
-      v.handle foreach(u => o.put("handle", u.string))
-      v.providerId.foreach { pId => o.put("providerId", pId.str) }
-      v.integrationId.foreach { iId => o.put("integrationId", iId.str) }
-      v.expiresAt.foreach(v => o.put("expires_at", v))
-      v.managedBy.foreach(o.put("managed_by", _))
-      o.put("fields", JsonEncoder.arr(v.fields))
-    }
-  }
-
   implicit object UserDataDao extends Dao[UserData, UserId] {
     val Id = id[UserId]('_id, "PRIMARY KEY").apply(_.id)
     val TeamId = opt(id[TeamId]('teamId))(_.teamId)
@@ -244,16 +206,21 @@ object UserData {
     val ExpiresAt = opt(remoteTimestamp('expires_at))(_.expiresAt)
     val Managed = opt(text[ManagedBy]('managed_by, _.toString, ManagedBy(_)))(_.managedBy)
     val Fields = json[Seq[UserField]]('fields)(UserField.userFieldsDecoder, UserField.userFieldsEncoder)(_.fields)
+    val SelfPermissions = long('self_permissions)(_.permissions._1)
+    val CopyPermissions = long('copy_permissions)(_.permissions._2)
+    val CreatedBy = opt(id[UserId]('created_by))(_.createdBy)
 
     override val idCol = Id
     override val table = Table(
       "Users", Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, ConnTime, ConnMessage,
-      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed
+      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId,
+      ExpiresAt, Managed, SelfPermissions, CopyPermissions, CreatedBy // Fields are now lazy-loaded from BE every time the user opens a profile
     )
 
     override def apply(implicit cursor: DBCursor): UserData = new UserData(
       Id, TeamId, Name, Email, Phone, TrackingId, Picture, Accent, SKey, Conn, RemoteInstant.ofEpochMilli(ConnTime.getTime), ConnMessage,
-      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed
+      Conversation, Rel, Timestamp, DisplayName, Verified, Deleted, AvailabilityStatus, Handle, ProviderId, IntegrationId, ExpiresAt, Managed,
+      Seq.empty, (SelfPermissions, CopyPermissions), CreatedBy
     )
 
     override def onCreate(db: DB): Unit = {

--- a/zmessaging/src/main/scala/com/waz/model/UserPermissions.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserPermissions.scala
@@ -1,0 +1,63 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.model
+
+import scala.collection.mutable
+
+object UserPermissions {
+  type PermissionsMasks = (Long, Long) //self and copy permissions
+
+  type Permission = Permission.Value
+  object Permission extends Enumeration {
+    val
+    CreateConversation,         // 0x001
+    DeleteConversation,         // 0x002
+    AddTeamMember,              // 0x004
+    RemoveTeamMember,           // 0x008
+    AddConversationMember,      // 0x010
+    RemoveConversationMember,   // 0x020
+    GetBilling,                 // 0x040
+    SetBilling,                 // 0x080
+    SetTeamData,                // 0x100
+    GetMemberPermissions,       // 0x200
+    GetTeamConversations,       // 0x400
+    DeleteTeam,                 // 0x800
+    SetMemberPermissions        // 0x1000
+    = Value
+  }
+
+  import Permission._
+  val AdminPermissions: Set[Permission] = Permission.values -- Set(GetBilling, SetBilling, DeleteTeam)
+  val PartnerPermissions: Set[Permission] = Set(CreateConversation, GetTeamConversations)
+
+  def decodeBitmask(mask: Long): Set[Permission] = {
+    val builder = new mutable.SetBuilder[Permission, Set[Permission]](Set.empty)
+    (0 until Permission.values.size).map(math.pow(2, _).toInt).zipWithIndex.foreach {
+      case (one, pos) => if ((mask & one) != 0) builder += Permission(pos)
+    }
+    builder.result()
+  }
+
+  def encodeBitmask(ps: Set[Permission]): Long = {
+    var mask = 0L
+    (0 until Permission.values.size).map(math.pow(2, _).toLong).zipWithIndex.foreach {
+      case (m, i) => if (ps.contains(Permission(i))) mask = mask | m
+    }
+    mask
+  }
+}

--- a/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/AccountsService.scala
@@ -223,8 +223,8 @@ class AccountsServiceImpl(val global: GlobalModule) extends AccountsService {
             _ <- acc.cookie.fold(Future.successful(()))(cookie => global.accountsStorage.insert(AccountData(acc.userId.get, teamId, cookie, acc.accessToken, acc.registeredPush, Some(Password("")))).map(_ => ()))
             _ <- prefs.preference(UserPreferences.SelfClient) := state
             _ <- prefs.preference(UserPreferences.PrivateMode) := acc.privateMode
-            _ <- prefs.preference(UserPreferences.SelfPermissions) := AccountDataOld.encodeBitmask(acc.selfPermissions)
-            _ <- prefs.preference(UserPreferences.CopyPermissions) := AccountDataOld.encodeBitmask(acc.copyPermissions)
+            _ <- prefs.preference(UserPreferences.SelfPermissions) := UserPermissions.encodeBitmask(acc.selfPermissions)
+            _ <- prefs.preference(UserPreferences.CopyPermissions) := UserPermissions.encodeBitmask(acc.copyPermissions)
           } yield {
             stor.db.close()
           }

--- a/zmessaging/src/main/scala/com/waz/service/Timeouts.scala
+++ b/zmessaging/src/main/scala/com/waz/service/Timeouts.scala
@@ -43,7 +43,6 @@ class Timeouts {
   }
 
   class GraphSearch {
-    def cacheRefreshInterval = 1.minute // time after which the search results should be synced again
     def cacheExpiryTime = 7.days // time after which the cache expires (results are considered invalid, and will be ignored)
     def localSearchDelay = 1.second // time after which we will return local search results if no result is available from backend
     def topPeopleMessageInterval = 30.days //top people will be sorted by the number of messages exchanged since this time

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -17,11 +17,14 @@
  */
 package com.waz.service
 
+import com.waz.ZLog
 import com.waz.ZLog.ImplicitTag._
+import com.waz.content.UserPreferences.SelfPermissions
 import com.waz.content._
 import com.waz.log.ZLog2._
 import com.waz.model.SearchQuery.{Recommended, RecommendedHandle}
 import com.waz.model.UserData.{ConnectionStatus, UserDataDao}
+import com.waz.model.UserPermissions.{PartnerPermissions, decodeBitmask}
 import com.waz.model.{SearchQuery, _}
 import com.waz.service.ZMessaging.clock
 import com.waz.service.conversation.{ConversationsService, ConversationsUiService}
@@ -42,6 +45,13 @@ case class SearchResults(top:   IndexedSeq[UserData]         = IndexedSeq.empty,
                          convs: IndexedSeq[ConversationData] = IndexedSeq.empty,
                          dir:   IndexedSeq[UserData]         = IndexedSeq.empty) { //directory (backend search)
   override def toString = s"SearchResults(top: ${top.size}, local: ${local.size}, convs: ${convs.size}, dir: ${dir.size})"
+
+  def isEmpty: Boolean = top.isEmpty && local.isEmpty && convs.isEmpty && dir.isEmpty
+}
+
+object SearchResults {
+  implicit val SearchResultsLogShow: LogShow[SearchResults] =
+    LogShow.create(sr => s"SearchResults(${sr.top.length}, ${sr.local.length}, ${sr.convs.length}, ${sr.dir.length})")
 }
 
 class UserSearchService(selfUserId:           UserId,
@@ -56,7 +66,9 @@ class UserSearchService(selfUserId:           UserId,
                         messages:             MessagesStorage,
                         convsStorage:         ConversationStorage,
                         convsUi:              ConversationsUiService,
-                        conversationsService: ConversationsService) {
+                        conversationsService: ConversationsService,
+                        userPrefs:            UserPreferences
+                       ) {
 
   import Threading.Implicits.Background
   import com.waz.service.UserSearchService._
@@ -67,34 +79,48 @@ class UserSearchService(selfUserId:           UserId,
   private val exactMatchUser = new SourceSignal[Option[UserData]]()
   private val signalMap = mutable.HashMap[SearchQuery, Signal[IndexedSeq[UserData]]]()
 
-  def usersForNewConversation(filter: Filter = "", teamOnly: Boolean): Signal[IndexedSeq[UserData]] =
-    searchLocal(filter).map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+  private lazy val isPartner = userPrefs(SelfPermissions).apply()
+    .map(decodeBitmask)
+    .map(ps => PartnerPermissions.subsetOf(ps) && PartnerPermissions.size == ps.size)
+
+  private def filterForPartner(query: Filter, searchResults: IndexedSeq[UserData]): Future[IndexedSeq[UserData]] = {
+    lazy val knownUsers = membersStorage.getByUsers(searchResults.map(_.id).toSet).map(_.map(_.userId).toSet)
+    isPartner.flatMap {
+      case true if teamId.isDefined =>
+        ZLog.verbose(s"filterForPartner1 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = true and teamId")
+        knownUsers.map(knownUsersIds => searchResults.filter(u => knownUsersIds.contains(u.id)))
+      case false if teamId.isDefined =>
+        ZLog.verbose(s"filterForPartner2 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = false and teamId")
+        knownUsers.map { knownUsersIds =>
+          searchResults.filter { u =>
+            knownUsersIds.contains(u.id) ||
+              u.teamId != teamId ||
+              (u.teamId == teamId && !u.isPartner(teamId)) ||
+              u.handle.exists(_.exactMatchQuery(query))
+          }
+        }
+      case _ => Future.successful(searchResults)
+    }
+  }
+
+  def usersForNewConversation(filter: Filter = "", teamOnly: Boolean): Signal[IndexedSeq[UserData]] = {
+    val isHandle = Handle.isHandle(filter)
+    searchLocal(filter, isHandle = isHandle)
+      .map(_.filter(u => !(u.isGuest(teamId) && teamOnly)))
+      .flatMap(res => Signal.future(filterForPartner(filter, res)))
+  }
 
   def usersToAddToConversation(filter: Filter = "", toConv: ConvId): Signal[IndexedSeq[UserData]] =
     for {
       curr <- membersStorage.activeMembers(toConv)
       conv <- convsStorage.signal(toConv)
-      res  <- searchLocal(filter, curr)
-    } yield res.filter(conv.isUserAllowed)
-
-  def searchUsersInConversation(convId: ConvId, filter: Filter, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =
-    for {
-      curr <- membersStorage.activeMembers(convId)
-      currData <- usersStorage.listSignal(curr)
-    } yield {
-      val included = currData.filter { user =>
-          (includeSelf || selfUserId != user.id) &&
-          !user.isWireBot &&
-          user.expiresAt.isEmpty &&
-          user.matchesFilter(filter) &&
-          user.connection != ConnectionStatus.Blocked
-      }
-      sortUsers(included, filter, isHandle = false, filter)
-    }
+      res  <- searchLocal(filter, curr, isHandle = Handle.isHandle(filter))
+      res  <- Signal.future(filterForPartner(filter, res.filter(conv.isUserAllowed)))
+    } yield res
 
   def mentionsSearchUsersInConversation(convId: ConvId, filter: Filter, includeSelf: Boolean = false): Signal[IndexedSeq[UserData]] =
     for {
-      curr <- membersStorage.activeMembers(convId)
+      curr     <- membersStorage.activeMembers(convId)
       currData <- usersStorage.listSignal(curr)
     } yield {
       val included = currData.filter { user =>
@@ -123,13 +149,12 @@ class UserSearchService(selfUserId:           UserId,
       }._2
     }
 
-  private def searchLocal(filter: Filter, excluded: Set[UserId] = Set.empty, showBlockedUsers: Boolean = false): Signal[IndexedSeq[UserData]] = {
-    val isHandle = Handle.isHandle(filter)
+  private def searchLocal(filter: Filter, excluded: Set[UserId] = Set.empty, showBlockedUsers: Boolean = false, isHandle: Boolean = false): Signal[IndexedSeq[UserData]] = {
     val symbolStripped = if (isHandle) Handle.stripSymbol(filter) else filter
     for {
       connected <- userService.acceptedOrBlockedUsers.map(_.values)
       members   <- teamId.fold(Signal.const(Set.empty[UserData])) { _ =>
-        teamsService.searchTeamMembers(if (filter.isEmpty) None else Some(SearchKey(filter)), handleOnly = Handle.isHandle(filter))
+        teamsService.searchTeamMembers(if (filter.isEmpty) None else Some(SearchKey(filter)), handleOnly = isHandle)
       }
     } yield {
       val included = (connected.toSet ++ members).filter { user =>
@@ -149,14 +174,15 @@ class UserSearchService(selfUserId:           UserId,
   private def sortUsers(results: IndexedSeq[UserData], filter: Filter, isHandle: Boolean, symbolStripped: Filter): IndexedSeq[UserData] = {
     def toLower(str: String) = Locales.transliteration.transliterate(str).trim.toLowerCase
 
+    lazy val toLowerSymbolStripped = toLower(symbolStripped)
+
     def bucket(u: UserData): Int =
       if (filter.isEmpty) 0
       else if (isHandle) {
         if (u.handle.exists(_.exactMatchQuery(filter))) 0 else 1
       } else {
         val userName = toLower(u.getDisplayName)
-        val query = toLower(symbolStripped)
-        if (userName == query) 0 else if (userName.startsWith(query)) 1 else 2
+        if (userName == toLowerSymbolStripped) 0 else if (userName.startsWith(toLowerSymbolStripped)) 1 else 2
       }
 
     results.sortWith { case (u1, u2) =>
@@ -181,10 +207,6 @@ class UserSearchService(selfUserId:           UserId,
     val shouldShowDirectorySearch    = !filter.isEmpty
 
     exactMatchUser ! None // reset the exact match to None on any query change
-
-    if (filter.isEmpty) Future.successful {
-      System.gc() // TODO: [AN-5497] the user search should not create so many objects to trigger GC in-between
-    }
 
     val topUsers: Signal[IndexedSeq[UserData]] =
       if (shouldShowTopUsers) topPeople.map(_.filter(!_.isWireBot)) else Signal.const(IndexedSeq.empty)
@@ -225,27 +247,35 @@ class UserSearchService(selfUserId:           UserId,
       }
 
     for {
-      top   <- topUsers
-      local <- searchLocal(filter, showBlockedUsers = true)
-      convs <- conversations
-      dir   <- directorySearch
+      top       <- topUsers
+      isPartner <- Signal.future(isPartner)
+      local     <- searchLocal(filter, showBlockedUsers = true, isHandle = isHandle)
+      local     <- Signal.future(filterForPartner(filter, local))
+      convs     <- conversations
+      dir       <- if (isPartner) Signal.const(IndexedSeq.empty[UserData]) else directorySearch
+      dir       <- Signal.future(filterForPartner(filter, dir))
     } yield SearchResults(top, local, convs, dir)
   }
 
   def updateSearchResults(query: SearchQuery, results: Seq[UserSearchEntry]) = {
-    def updating(ids: Vector[UserId])(cached: SearchQueryCache) = cached.copy(query, clock.instant(), if (ids.nonEmpty || cached.entries.isEmpty) Some(ids) else cached.entries)
+    def updating(ids: Vector[UserId])(cached: SearchQueryCache) =
+      cached.copy(query, clock.instant(), if (ids.nonEmpty || cached.entries.isEmpty) Some(ids) else cached.entries)
+
+    val ids = results.map(_.id)(breakOut): Vector[UserId]
 
     for {
-      updated <- userService.updateUsers(results)
-      _       <- userService.syncIfNeeded(updated.map(_.id), Duration.Zero)
-      ids     = results.map(_.id)(breakOut): Vector[UserId]
-      _       = verbose(l"updateSearchResults($query, ${results.map(_.handle)})")
-      _       <- queryCache.updateOrCreate(query, updating(ids), SearchQueryCache(query, clock.instant(), Some(ids)))
+      userData <- usersStorage.listAll(ids)
+      filtered <- filterForPartner(query.filter, userData)
+      filteredIds = filtered.map(_.id).toSet
+      updated <- userService.updateUsers(results.filter(r => filteredIds.contains(r.id)))
+      _       <- userService.syncIfNeeded(filteredIds, Duration.Zero)
+      _       <- queryCache.updateOrCreate(query, updating(filteredIds.toVector), SearchQueryCache(query, clock.instant(), Some(filteredIds.toVector)))
     } yield ()
 
     query match {
+      case Recommended(handle) if handle.length > 1 && !results.map(_.handle).exists(_.exactMatchQuery(handle)) =>
+        sync.exactMatchHandle(Handle(Handle.stripSymbol(handle)))
       case RecommendedHandle(handle) if !results.map(_.handle).exists(_.exactMatchQuery(handle)) =>
-        debug(l"exact match requested")
         sync.exactMatchHandle(Handle(Handle.stripSymbol(handle)))
       case _ =>
     }
@@ -255,21 +285,20 @@ class UserSearchService(selfUserId:           UserId,
 
   def updateExactMatch(handle: Handle, userId: UserId) = {
     val query = RecommendedHandle(handle.withSymbol)
-    def updating(id: UserId)(cached: SearchQueryCache) = cached.copy(query, clock.instant(), Some(cached.entries.map(_.toSet ++ Set(userId)).getOrElse(Set(userId)).toVector))
+    def updating(id: UserId)(cached: SearchQueryCache) =
+      cached.copy(query, clock.instant(), Some(cached.entries.map(_.toSet ++ Set(userId)).getOrElse(Set(userId)).toVector))
 
-    debug(l"update exact match: $handle, $userId")
     usersStorage.get(userId).collect {
       case Some(user) =>
-        debug(l"received exact match: ${user.handle}")
         exactMatchUser ! Some(user)
         queryCache.updateOrCreate(query, updating(userId), SearchQueryCache(query, clock.instant(), Some(Vector(userId))))
-    }(Threading.Background)
+    }
 
     Future.successful({})
   }
 
   def searchUserData(query: SearchQuery): Signal[IndexedSeq[UserData]] = signalMap.getOrElseUpdate(query, returning( startNewSearch(query) ) { _ =>
-    CancellableFuture.delay(cacheExpiryTime).map { _ =>
+    CancellableFuture.delay(cacheRefreshInterval).map { _ =>
       signalMap.remove(query)
       queryCache.remove(query)
     }
@@ -282,7 +311,8 @@ class UserSearchService(selfUserId:           UserId,
     case Some(cached) => cached.entries match {
       case None => Signal.const(IndexedSeq.empty[UserData])
       case Some(ids) if ids.isEmpty => Signal.const(IndexedSeq.empty[UserData])
-      case Some(ids) => usersStorage.listSignal(ids).map(_.toIndexedSeq)
+      case Some(ids) =>
+        usersStorage.listSignal(ids).flatMap(res => Signal.future(filterForPartner(query.filter, res)))
     }
   }
 

--- a/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserSearchService.scala
@@ -17,7 +17,7 @@
  */
 package com.waz.service
 
-import com.waz.ZLog
+import com.waz.ZLog.verbose
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content.UserPreferences.SelfPermissions
 import com.waz.content._
@@ -87,10 +87,10 @@ class UserSearchService(selfUserId:           UserId,
     lazy val knownUsers = membersStorage.getByUsers(searchResults.map(_.id).toSet).map(_.map(_.userId).toSet)
     isPartner.flatMap {
       case true if teamId.isDefined =>
-        ZLog.verbose(s"filterForPartner1 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = true and teamId")
+        verbose(s"filterForPartner1 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = true and teamId")
         knownUsers.map(knownUsersIds => searchResults.filter(u => knownUsersIds.contains(u.id)))
       case false if teamId.isDefined =>
-        ZLog.verbose(s"filterForPartner2 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = false and teamId")
+        verbose(s"filterForPartner2 Q: $query, RES: ${searchResults.map(_.getDisplayName)}) with partner = false and teamId")
         knownUsers.map { knownUsersIds =>
           searchResults.filter { u =>
             knownUsersIds.contains(u.id) ||

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -20,12 +20,12 @@ package com.waz.service.teams
 import com.waz.ZLog.ImplicitTag._
 import com.waz.content._
 import com.waz.log.ZLog2._
-import com.waz.model.AccountDataOld.PermissionsMasks
 import com.waz.model.ConversationData.ConversationDataDao
 import com.waz.model._
 import com.waz.service.EventScheduler.Stage
 import com.waz.service.conversation.ConversationsContentUpdater
 import com.waz.service.{EventScheduler, SearchKey}
+import com.waz.sync.client.TeamsClient.TeamMember
 import com.waz.sync.{SyncRequestService, SyncServiceHandle}
 import com.waz.threading.{CancellableFuture, SerialDispatchQueue}
 import com.waz.utils.ContentChange.{Added, Removed, Updated}
@@ -44,9 +44,9 @@ trait TeamsService {
 
   val selfTeam: Signal[Option[TeamData]]
 
-  def onTeamSynced(team: TeamData, members: Map[UserId, Option[PermissionsMasks]]): Future[Unit]
+  def onTeamSynced(team: TeamData, members: Seq[TeamMember]): Future[Unit]
 
-  def onMemberSynced(userId: UserId, permissions: Option[PermissionsMasks]): Future[Unit]
+  def onMemberSynced(member: TeamMember): Future[Unit]
 
   def guests: Signal[Set[UserId]]
 }
@@ -63,6 +63,15 @@ class TeamsServiceImpl(selfUser:           UserId,
                        userPrefs:          UserPreferences) extends TeamsService {
 
   private implicit val dispatcher = SerialDispatchQueue()
+
+  private val shouldSyncTeam = userPrefs.preference(UserPreferences.ShouldSyncTeam)
+
+  for {
+    shouldSync <- shouldSyncTeam()
+  } if (shouldSync && teamId.isDefined) {
+    verbose(l"Syncing the team $teamId")
+    sync.syncTeam().flatMap(_ => shouldSyncTeam := false)
+  }
 
   override val eventsProcessingStage: Stage.Atomic = EventScheduler.Stage[TeamEvent] { (_, events) =>
     verbose(l"Handling events: $events")
@@ -86,7 +95,7 @@ class TeamsServiceImpl(selfUser:           UserId,
 
   override def searchTeamMembers(query: Option[SearchKey] = None, handleOnly: Boolean = false) = teamId match {
     case None => Signal.empty
-    case Some(tId) => {
+    case Some(tId) =>
 
       val changesStream = EventStream.union[Seq[ContentChange[UserId, UserData]]](
         userStorage.onAdded.map(_.map(d => Added(d.id, d))),
@@ -119,7 +128,7 @@ class TeamsServiceImpl(selfUser:           UserId,
 
         current.filterNot(d => removed.contains(d.id) || added.exists(_.id == d.id)) ++ added
       })
-    }
+
   }
 
   override lazy val selfTeam: Signal[Option[TeamData]] = teamId match {
@@ -146,31 +155,37 @@ class TeamsServiceImpl(selfUser:           UserId,
     }
   }
 
-  override def onTeamSynced(team: TeamData, members: Map[UserId, Option[PermissionsMasks]]) = {
+  override def onTeamSynced(team: TeamData, members: Seq[TeamMember]) = {
     verbose(l"onTeamSynced: team: $team \nmembers: $members")
 
-    val memberIds = members.keys.toSet
-    val selfPermissions = members.get(selfUser)
+    val memberIds = members.map(_.user).toSet
 
     for {
       _ <- teamStorage.insert(team)
-      _ <- selfPermissions.fold(Future.successful(()))(perm => onMemberSynced(selfUser, perm))
       oldMembers <- userStorage.getByTeam(Set(team.id))
       _ <- userStorage.updateAll2(oldMembers.map(_.id) -- memberIds, _.copy(deleted = true))
       _ <- sync.syncUsers(memberIds).flatMap(syncRequestService.await)
       _ <- userStorage.updateAll2(memberIds, _.copy(teamId = teamId, deleted = false))
+      _ <- Future.sequence(members.map(onMemberSynced))
     } yield {}
   }
 
-  override def onMemberSynced(userId: UserId, permissions: Option[PermissionsMasks]) = {
-    import UserPreferences._
-    if (userId == selfUser && permissions.nonEmpty)
+  override def onMemberSynced(member: TeamMember) = member match {
+    case TeamMember(userId, Some(permissions), _) if userId == selfUser =>
+      import UserPreferences._
       for {
-        _ <- userPrefs(SelfPermissions) := permissions.get._1
-        _ <- userPrefs(CopyPermissions) := permissions.get._2
+        _ <- userPrefs(SelfPermissions) := permissions.self
+        _ <- userPrefs(CopyPermissions) := permissions.copy
       } yield ()
-    else Future.successful(())
+
+    case TeamMember(userId, permissions, createdBy) if userId != selfUser =>
+      userStorage
+        .update(userId, _.copy(permissions = permissions.fold((0L, 0L))(p => (p.self, p.copy)), createdBy = createdBy))
+        .map(_ => ())
+
+    case _ => Future.successful(()) // selfUser but with no permission info - don't update
   }
+
 
   private def onTeamUpdated(id: TeamId, name: Option[Name], icon: Option[RAssetId], iconKey: Option[AESKey]) = {
     verbose(l"onTeamUpdated: $id, name: $name, icon: $icon, iconKey: $iconKey")

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -108,12 +108,7 @@ class TeamsServiceImpl(selfUser:           UserId,
         case None    => userStorage.getByTeam(Set(tId))
       }
 
-      def userMatches(data: UserData) = data.teamId == teamId && (query match {
-        case Some(q) =>
-          if (handleOnly) data.handle.map(_.string).contains(q.asciiRepresentation)
-          else q.isAtTheStartOfAnyWordIn(data.searchKey)
-        case _ => true
-      })
+      def userMatches(data: UserData) = data.teamId == teamId && data.matchesQuery(query, handleOnly)
 
       new AggregatingSignal[Seq[ContentChange[UserId, UserData]], Set[UserData]](changesStream, load, { (current, changes) =>
         val added = changes.collect {
@@ -197,9 +192,10 @@ class TeamsServiceImpl(selfUser:           UserId,
   }
 
   private def onMembersJoined(members: Set[UserId]) = {
-    verbose(l"onTeamMembersJoined: members: $members")
+    verbose(l"onMembersJoined: members: $members")
     for {
       _ <- sync.syncUsers(members).flatMap(syncRequestService.await)
+      _ <- sync.syncTeam().flatMap(syncRequestService.await)
       _ <- userStorage.updateAll2(members, _.copy(teamId = teamId, deleted = false))
     } yield {}
   }

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -122,7 +122,7 @@ object TeamsClient {
   case class TeamMember(user: UserId, permissions: Option[Permissions], created_by: Option[UserId])
 
   implicit val TeamMemberLogShow: LogShow[TeamMember] =
-    LogShow.create(tm => s"TeamMember(${tm.user}, ${tm.permissions}, ${tm.created_by})")
+    LogShow.create(tm => s"TeamMember with permissions: ${tm.permissions}")
 
   case class Permissions(self: Long, copy: Long)
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -20,8 +20,10 @@ package com.waz.sync.client
 import com.waz.ZLog.ImplicitTag._
 import com.waz.ZLog.warn
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.AccountDataOld.PermissionsMasks
+import com.waz.log.ZLog2.LogShow
+import com.waz.model.UserPermissions.PermissionsMasks
 import com.waz.model._
+import com.waz.sync.client.TeamsClient.TeamMember
 import com.waz.utils.{CirceJSONSupport, JsonDecoder}
 import com.waz.znet2.AuthRequestInterceptor
 import com.waz.znet2.http.Request.UrlCreator
@@ -30,10 +32,11 @@ import com.waz.znet2.http.{HttpClient, RawBodyDeserializer, Request}
 import scala.util.Try
 
 trait TeamsClient {
-  def getTeamMembers(id: TeamId): ErrorOrResponse[Map[UserId, Option[PermissionsMasks]]]
+  def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]]
   def getTeamData(id: TeamId): ErrorOrResponse[TeamData]
 
   def getPermissions(teamId: TeamId, userId: UserId): ErrorOrResponse[Option[PermissionsMasks]]
+  def getTeamMember(teamId: TeamId, userId: UserId): ErrorOrResponse[TeamMember]
 }
 
 class TeamsClientImpl(implicit
@@ -50,15 +53,11 @@ class TeamsClientImpl(implicit
   private implicit val errorResponseDeserializer: RawBodyDeserializer[ErrorResponse] =
     objectFromCirceJsonRawBodyDeserializer[ErrorResponse]
 
-  override def getTeamMembers(id: TeamId): ErrorOrResponse[Map[UserId, Option[PermissionsMasks]]] = {
+  override def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]] = {
     Request.Get(relativePath = teamMembersPath(id))
       .withResultType[TeamMembers]
       .withErrorType[ErrorResponse]
-      .executeSafe { response =>
-        response.members
-          .map(member => member.user -> member.permissions.map(createPermissionsMasks))
-          .toMap
-      }
+      .executeSafe(_.members)
   }
 
   override def getTeamData(id: TeamId): ErrorOrResponse[TeamData] = {
@@ -77,6 +76,13 @@ class TeamsClientImpl(implicit
       .executeSafe { response =>
         response.permissions.map(createPermissionsMasks)
       }
+  }
+
+  override def getTeamMember(teamId: TeamId, userId: UserId): ErrorOrResponse[TeamMember] = {
+    Request.Get(relativePath = memberPath(teamId, userId))
+      .withResultType[TeamMember]
+      .withErrorType[ErrorResponse]
+      .executeSafe
   }
 
   private def createPermissionsMasks(permissions: Permissions): PermissionsMasks =
@@ -113,7 +119,10 @@ object TeamsClient {
 
   case class TeamMembers(members: Seq[TeamMember])
 
-  case class TeamMember(user: UserId, permissions: Option[Permissions])
+  case class TeamMember(user: UserId, permissions: Option[Permissions], created_by: Option[UserId])
+
+  implicit val TeamMemberLogShow: LogShow[TeamMember] =
+    LogShow.create(tm => s"TeamMember(${tm.user}, ${tm.permissions}, ${tm.created_by})")
 
   case class Permissions(self: Long, copy: Long)
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/TeamsSyncHandler.scala
@@ -61,10 +61,10 @@ class TeamsSyncHandlerImpl(userId:    UserId,
 
   override def syncMember(uId: UserId) = teamId match {
     case Some(tId) =>
-      client.getPermissions(tId, uId).future.flatMap {
-        case Right(p) =>
+      client.getTeamMember(tId, uId).future.flatMap {
+        case Right(member) =>
           service
-            .onMemberSynced(uId, p)
+            .onMemberSynced(member)
             .map(_ => SyncResult.Success)
         case Left(e) =>
           Future.successful(SyncResult(e))

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -40,7 +40,8 @@ class UsersSyncHandler(assetSync: AssetSyncHandler,
                        assets: AssetService,
                        usersClient: UsersClient,
                        imageGenerator: ImageAssetGenerator,
-                       otrSync: OtrSyncHandler) {
+                       otrSync: OtrSyncHandler
+                      ) {
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
 

--- a/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/UsersSyncHandler.scala
@@ -40,8 +40,7 @@ class UsersSyncHandler(assetSync: AssetSyncHandler,
                        assets: AssetService,
                        usersClient: UsersClient,
                        imageGenerator: ImageAssetGenerator,
-                       otrSync: OtrSyncHandler
-                      ) {
+                       otrSync: OtrSyncHandler) {
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
 

--- a/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -17,8 +17,8 @@
  */
 package com.waz.sync.client
 
-import com.waz.model.AccountDataOld._
-import com.waz.model.AccountDataOld.Permission._
+import com.waz.model.UserPermissions._
+import com.waz.model.UserPermissions.Permission._
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.TeamsClient.TeamMembers
 import com.waz.utils.CirceJSONSupport

--- a/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -23,6 +23,7 @@ import com.waz.service.teams.TeamsService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
 import com.waz.sync.client.TeamsClient
+import com.waz.sync.client.TeamsClient.{Permissions, TeamMember}
 import com.waz.testutils.TestUserPreferences
 import com.waz.threading.CancellableFuture
 
@@ -41,9 +42,9 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
       val teamId = TeamId()
       val teams = Seq((teamId, true))
       val teamData = TeamData(teamId, "name", UserId())
-      val members = Map(
-        UserId() -> Some(0L, 0L),
-        UserId() -> Some(0L, 0L)
+      val members = Seq(
+        TeamMember(UserId(), Option(Permissions(0L, 0L)), None),
+        TeamMember(UserId(), Option(Permissions(0L, 0L)), None)
       )
 
       (client.getTeamData(_: TeamId)).expects(teamId).once().returning(CancellableFuture.successful(Right(teamData)))


### PR DESCRIPTION
## What's new in this PR?

The functionality for filtering out from the user search results which should not be visible for partners. The results visible for standard team members are also slightly changed, taking into account that some of the results are partners.

For details please refer to the documentation:
https://github.com/wearezeta/documentation/blob/master/topics/teams/use%20cases/clients/101-search-for-partners.md
