### PR TITLE
refactor: remove some redundancy in UserSearchServiceSpec

### DIFF
--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -359,20 +359,16 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     /**
     * Helper class to keep track of mocked query
       */
-    class PreparedSearch(service: UserSearchService, query: String) {
+    case class PreparedSearch(inTeam: Boolean, selfId: UserId, query: String) {
 
       def perform() = {
-        this.service.search(query).map(_.local.map(_.id).toSet).head
+        val service = getService(this.inTeam, this.selfId)
+        service.search(query).map(_.local.map(_.id).toSet).head
       }
     }
 
     /**
     * Will mock all services, instantiate a UserSearchService to test, and store the query to expect
-      * @param query
-      * @param selfId
-      * @param conversationMembers
-      * @param connectedUsers
-      * @return
       */
     def prepareTestSearch(query: String,
                             selfId: UserId,
@@ -416,10 +412,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
       val user = users(selfId)
       userPrefs.setValue(UserPreferences.SelfPermissions, user.permissions._1)
 
-      // Return the service, configured for that user
-      val service = getService(true, selfId)
-
-      return new PreparedSearch(service, query)
+      PreparedSearch(true, selfId, query)
     }
 
     scenario("as a member, search partners that are not in a conversation with me") {

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -38,7 +38,6 @@ import scala.concurrent.Future
 
 class UserSearchServiceSpec extends AndroidFreeSpec {
 
-  val selfId            = id('selfUser)
   val emptyTeamId       = Option.empty[TeamId]
   val teamId            = Option(TeamId("59bbc94c-2618-491a-8dba-cf6f94c65873"))
   val partnerPermissions: Long = 1025
@@ -59,8 +58,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
   val userPrefs         = new TestUserPreferences
 
   lazy val users = Map(
-    id('selfUser) -> UserData(id('selfUser), "self user"),
-
+    id('me) -> UserData(id('me), "A user"),
     id('a) -> UserData(id('a), "other user 1"),
     id('b) -> UserData(id('b), "other user 2"),
     id('c) -> UserData(id('c), "some name"),
@@ -146,7 +144,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"rod")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"rod")
     result(res.filter(_.size == 1).head)
   }
 
@@ -158,7 +156,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"bjo")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"bjo")
     result(res.filter(_.size == 1).head)
   }
 
@@ -170,7 +168,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"rn")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"rn")
     result(res.filter{u => println(u.map(_.displayName));u.size == 1}.head)
   }
 
@@ -182,7 +180,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"mores")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"mores")
     result(res.filter(_.size == 2).head)
   }
 
@@ -194,7 +192,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"smores")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"smores")
     result(res.filter(_.size == 1).head)
   }
 
@@ -207,7 +205,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     (membersStorage.activeMembers _).expects(*).anyNumberOfTimes().returning(Signal.const(convMembers))
     (usersStorage.listSignal _).expects(*).once().returning(Signal.const(convMembers.map(users).toVector))
 
-    val res = getService(false, selfId).mentionsSearchUsersInConversation(ConvId("123"),"john")
+    val res = getService(false, id('me)).mentionsSearchUsersInConversation(ConvId("123"),"john")
 
     result(res.filter(_.equals(correctOrder)).head)
   }
@@ -249,7 +247,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     querySignal ! Some(firstQueryCache)
     result(querySignal.filter(_.contains(firstQueryCache)).head)
     
-    val resSignal = getService(false, selfId).searchUserData(Recommended(prefix)).map(_.map(_.id)).disableAutowiring()
+    val resSignal = getService(false, id('me)).searchUserData(Recommended(prefix)).map(_.map(_.id)).disableAutowiring()
 
     result(querySignal.filter(_.contains(secondQueryCache)).head)
 
@@ -286,7 +284,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
       (userService.acceptedOrBlockedUsers _).expects().returns(Signal.const(Map.empty[UserId, UserData]))
       (messagesStorage.countLaterThan _).expects(*, *).repeated(3).returning(Future.successful(1L))
 
-      val res = getService(false, selfId).search("").map(_.top.map(_.id).toSet)
+      val res = getService(false, id('me)).search("").map(_.top.map(_.id).toSet)
 
       result(res.filter(_ == expected).head)
     }
@@ -318,7 +316,7 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
 
       (usersStorage.listSignal _).expects(*).never()
 
-      val res = getService(false, selfId).search("fr").map(_.local.map(_.id).toSet)
+      val res = getService(false, id('me)).search("fr").map(_.local.map(_.id).toSet)
 
       result(res.filter(_ == expected).head)
     }
@@ -350,25 +348,44 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
 
      (usersStorage.listSignal _).expects(expected.toVector).once().returning(Signal.const(expected.map(users).toVector))
 
-      val res = getService(false, selfId).search("ot").map(_.dir.map(_.id).toSet)
+      val res = getService(false, id('me)).search("ot").map(_.dir.map(_.id).toSet)
 
       result(res.filter(_.nonEmpty).head)
     }
   }
 
-  feature("search Inside the team") {
+  feature("search inside the team") {
 
-    def mockServicesForTeam(query: String,
+    /**
+    * Helper class to keep track of mocked query
+      */
+    class PreparedSearch(service: UserSearchService, query: String) {
+
+      def perform() = {
+        this.service.search(query).map(_.local.map(_.id).toSet).head
+      }
+    }
+
+    /**
+    * Will mock all services, instantiate a UserSearchService to test, and store the query to expect
+      * @param query
+      * @param selfId
+      * @param conversationMembers
+      * @param connectedUsers
+      * @return
+      */
+    def prepareTestSearch(query: String,
                             selfId: UserId,
                             conversationMembers: Set[UserId] = Set(),
                             connectedUsers: Set[UserId] = Set()
-                           ): Unit = {
+                           ): PreparedSearch = {
       val convId = ConvId("e7969e91-366d-4ec5-9d85-4e8a4f9d53e6")
       val searchQuery = Recommended(query)
 
       val querySignal = new SourceSignal[Option[SearchQueryCache]]()
       val queryCache = SearchQueryCache(searchQuery, Instant.now, Some(Vector.empty[UserId]))
 
+      // Stubs
       (queryCacheStorage.deleteBefore _).stubs(*).returning(Future.successful[Unit]({}))
       (queryCacheStorage.optSignal _).stubs(searchQuery).returning(querySignal)
 
@@ -394,18 +411,27 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
           SyncId()
         }
       }
+
+      // Set up user permissions according to role
+      val user = users(selfId)
+      userPrefs.setValue(UserPreferences.SelfPermissions, user.permissions._1)
+
+      // Return the service, configured for that user
+      val service = getService(true, selfId)
+
+      return new PreparedSearch(service, query)
     }
 
     scenario("as a member, search partners that are not in a conversation with me") {
       // GIVEN
-      val selfId = id('mm1)
-      mockServicesForTeam(query = "Partner", selfId = selfId, conversationMembers = ids('a, 'mm1))
+      val preparedSearch = prepareTestSearch(
+        query = "Partner",
+        selfId = id('mm1),
+        conversationMembers = ids('a, 'mm1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Partner").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -414,32 +440,30 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a member, search partners that are in a conversation with me") {
 
       // GIVEN
-      val selfId = id('mm1)
-      mockServicesForTeam(query = "Partner", selfId = selfId, conversationMembers = ids('pp1, 'k, 'mm1))
+      val preparedSearch = prepareTestSearch(
+        query = "Partner",
+        selfId = id('mm1),
+        conversationMembers = ids('pp1, 'k, 'mm1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Partner").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('pp1)
-
-      // AFTER
     }
 
     scenario("as a member, search partners that are not in a conversation with me by exact handle") {
 
       // GIVEN
-      val selfId = id('mm1)
-      mockServicesForTeam(query = "pp1", selfId = selfId, conversationMembers = ids('k, 'a, 'mm1))
+      val preparedSearch = prepareTestSearch(
+        query = "pp1",
+        selfId = id('mm1),
+        conversationMembers = ids('a, 'k, 'mm1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("pp1").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('pp1)
@@ -448,14 +472,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a member, search team members whether they are in a conversation with me or not") {
 
       // GIVEN
-      val selfId = id('mm3)
-      mockServicesForTeam(query = "Member", selfId = selfId, conversationMembers = ids('mm2, 'pp1))
+      val preparedSearch = prepareTestSearch(
+        query = "Member",
+        selfId = id('mm3),
+        conversationMembers = ids('mm2, 'pp1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Member").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('mm1, 'mm2)
@@ -464,14 +488,15 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a member, search connected guests whether they are in a conversation with me or not") {
 
       // GIVEN
-      val selfId = id('mm1)
-      mockServicesForTeam(query = "related", selfId = selfId, conversationMembers = ids('mm2, 'pp1, 'e), connectedUsers = ids('d, 'e))
+      val preparedSearch = prepareTestSearch(
+        query = "related",
+        selfId = id('mm1),
+        conversationMembers = ids('mm2, 'pp1, 'e),
+        connectedUsers = ids('d, 'e)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("related").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('d, 'e)
@@ -480,14 +505,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a member, search not connected guests") {
 
       // GIVEN
-      val selfId = id('mm1)
-      mockServicesForTeam(query = "related", selfId = selfId, conversationMembers = ids('mm2, 'pp1, 'e))
+      val preparedSearch = prepareTestSearch(
+        query = "related",
+        selfId = id('mm1),
+        conversationMembers = ids('mm2, 'pp1, 'e)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("related").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -496,15 +521,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search team members that are not in a conversation with me") {
 
       // GIVEN
-      val selfId = id('pp1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "Member", selfId = selfId, conversationMembers = ids('pp1, 'k))
+      val preparedSearch = prepareTestSearch(
+        query = "Member",
+        selfId = id('pp1),
+        conversationMembers = ids('pp1, 'k)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Member").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -513,15 +537,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, show no team members") {
 
       // GIVEN
-      val selfId = id('pp3)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "", selfId = selfId, conversationMembers = ids('pp3, 'k))
+      val preparedSearch = prepareTestSearch(
+        query = "",
+        selfId = id('pp3),
+        conversationMembers = ids('pp3, 'k)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -530,15 +553,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search team members that are in a conversation with me") {
 
       // GIVEN
-      val selfId = id('pp1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "Member", selfId = selfId, conversationMembers = ids('mm1, 'k))
+      val preparedSearch = prepareTestSearch(
+        query = "Member",
+        selfId = id('pp1),
+        conversationMembers = ids('mm1, 'k)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Member").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('mm1)
@@ -547,15 +569,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search partners that are in a conversation with me") {
 
       // GIVEN
-      val selfId = id('pp2)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "Partner", selfId = selfId, conversationMembers = ids('pp1, 'pp2))
+      val preparedSearch = prepareTestSearch(
+        query = "Partner",
+        selfId = id('pp2),
+        conversationMembers = ids('pp1, 'pp2)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Partner").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('pp1)
@@ -564,15 +585,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search partners that are not in a conversation with me") {
 
       // GIVEN
-      val selfId = id('pp1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "Partner", selfId = selfId, conversationMembers = Set(id('mm1)))
+      val preparedSearch = prepareTestSearch(
+        query = "Partner",
+        selfId = id('pp1),
+        conversationMembers = ids('mm1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Partner").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -581,15 +601,15 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search connected guests whether they are in a conversation with me or not") {
 
       // GIVEN
-      val selfId = id('pp1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "related", selfId = selfId, conversationMembers = ids('mm2, 'pp1, 'e), connectedUsers = ids('d, 'e))
+      val preparedSearch = prepareTestSearch(
+        query = "related",
+        selfId = id('pp1),
+        conversationMembers = ids('mm2, 'pp1, 'e),
+        connectedUsers = ids('d, 'e)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("related").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('e)
@@ -598,15 +618,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, search not connected guests") {
 
       // GIVEN
-      val selfId = id('pp1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "related", selfId = selfId, conversationMembers = ids('mm2, 'pp1, 'e))
+      val preparedSearch = prepareTestSearch(
+        query = "related",
+        selfId = id('pp1),
+        conversationMembers = ids('mm2, 'pp1, 'e)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("related").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids()
@@ -615,15 +634,13 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as an admin, search the partners that I invited") {
 
       // GIVEN
-      val selfId = id('aa1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, adminPermissions)
-      mockServicesForTeam(query = "Partner", selfId = selfId, conversationMembers = ids())
+      val preparedSearch = prepareTestSearch(
+        query = "Partner",
+        selfId = id('aa1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("Partner").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('pp1)
@@ -633,15 +650,13 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as an admin, see the partners that I invited") {
 
       // GIVEN
-      val selfId = id('aa1)
-      userPrefs.setValue(UserPreferences.SelfPermissions, adminPermissions)
-      mockServicesForTeam(query = "", selfId = selfId, conversationMembers = ids())
+      val preparedSearch = prepareTestSearch(
+        query = "",
+        selfId = id('aa1)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids(
@@ -654,15 +669,13 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
     scenario("as a partner, see the admin that invited me") {
 
       // GIVEN
-      val selfId = id('pp2)
-      userPrefs.setValue(UserPreferences.SelfPermissions, partnerPermissions)
-      mockServicesForTeam(query = "", selfId = selfId, conversationMembers = ids())
+      val preparedSearch = prepareTestSearch(
+        query = "",
+        selfId = id('pp2)
+      )
 
       // WHEN
-      val res = result(getService(
-        true,
-        selfId
-      ).search("").map(_.local.map(_.id).toSet).head)
+      val res = result(preparedSearch.perform())
 
       // THEN
       res shouldBe ids('aa2)

--- a/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/UserSearchServiceSpec.scala
@@ -390,14 +390,14 @@ class UserSearchServiceSpec extends AndroidFreeSpec {
       }
       (usersStorage.find(_: UserData => Boolean, _: DB => Managed[TraversableOnce[UserData]], _: UserData => UserData)(_: CanBuild[UserData, Vector[UserData]]))
         .stubs(*, *, *, *).returning(Future.successful(Vector.empty[UserData]))
-      (userService.acceptedOrBlockedUsers _).stubs().returning(Signal.const(connectedUsers.map(k => (k -> users(k))).toMap))
+      (userService.acceptedOrBlockedUsers _).stubs().returning(Signal.const(users.filterKeys(connectedUsers.contains)))
       (userService.getSelfUser _).stubs().onCall(_ => Future.successful(users.get(selfId)))
 
       (convsStorage.findGroupConversations _).stubs(*, *, *, *).returns(Future.successful(IndexedSeq.empty[ConversationData]))
       (queryCacheStorage.updateOrCreate _).stubs(*, *, *).returning(Future.successful(queryCache))
 
       (membersStorage.getByUsers _).stubs(*).onCall { ids: Set[UserId] =>
-        Future.successful(ids.filter(i => conversationMembers.contains(i)).map(ConversationMemberData(_, convId)).toIndexedSeq)
+        Future.successful(ids.intersect(conversationMembers).map(ConversationMemberData(_, convId)).toIndexedSeq)
       }
 
       (sync.syncSearchQuery _).stubs(*).onCall { _: SearchQuery =>


### PR DESCRIPTION
The previous code required the test author to repeat some information in functions call, that could actually be inferred from previous parameters. It was easy to make a mistake and pass in a different information the second time, leading to unexpected test results.

I removed the redundancy, requiring the test author to repeat the following information only once:
- query
- who is the self user

I also removed the need to pass the role for the user. Now it's inferred automatically from the user id.
