### PR TITLE
Fix/logging global preference

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -378,6 +378,9 @@ object GlobalPreferences {
 
   lazy val ShouldCreateFullConversation = PrefKey[Boolean]("should_create_full_conv", customDefault = false)
 
+  lazy val LogsEnabled: PrefKey[Boolean] = PrefKey[Boolean]("logs_enabled", customDefault = false)
+
+
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts          = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")
   lazy val _DarkTheme              = PrefKey[Boolean]("DarkTheme")
@@ -453,5 +456,4 @@ object UserPreferences {
 
   lazy val ReadReceiptsRemotelyChanged      = PrefKey[Boolean]("read_receipts_remotely_changed", customDefault = false)
 
-  lazy val LogsEnabled: PrefKey[Boolean] = PrefKey[Boolean]("logs_enabled", customDefault = false)
 }

--- a/zmessaging/src/main/scala/com/waz/log/AndroidLogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/AndroidLogOutput.scala
@@ -34,6 +34,11 @@ class AndroidLogOutput(override val showSafeOnly: Boolean = false) extends LogOu
       case Verbose => Log.v(tag.value, str)
       case _ =>
     }
+
+  override def clear(): Unit = {
+    import scala.sys.process._
+    Process(Seq("logcat", "-c")).run()
+  }
 }
 
 object AndroidLogOutput {

--- a/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogShowInstancesSE.scala
@@ -78,6 +78,8 @@ trait LogShowInstancesSE {
   implicit val JSONObjectLogShow: LogShow[JSONObject] = logShowWithHash
 
   //TODO how much of a file/uri can we show in prod?
+  // There might be UUIDs in the URL, so we should obfuscate them.
+
   //common types
   implicit val FileLogShow: LogShow[File] = create(_ => "<file>", _.getAbsolutePath)
   implicit val AUriLogShow: LogShow[Uri]  = create(_ => "<uri>", _.toString)
@@ -156,7 +158,7 @@ trait LogShowInstancesSE {
     }
 
   implicit val CookieShow: LogShow[Cookie] = create(
-    c => s"Cookie(${c.str.take(10)}, exp: ${c.expiry}, isValid: ${c.isValid})",
+    c => s"Cookie(exp: ${c.expiry}, isValid: ${c.isValid})",
     c => s"Cookie(${c.str}, exp: ${c.expiry}, isValid: ${c.isValid})"
   )
 

--- a/zmessaging/src/main/scala/com/waz/log/LogsService.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogsService.scala
@@ -17,49 +17,34 @@
  */
 package com.waz.log
 
-import com.waz.content.UserPreferences
+import com.waz.content.GlobalPreferences
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.UserId
-import com.waz.service.AccountsService
 import com.waz.utils.events.Signal
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 trait LogsService {
   def logsEnabledGlobally: Signal[Boolean]
-  def logsEnabled(userId: UserId): Future[Boolean]
-  def setLogsEnabled(userId: UserId, enabled: Boolean): Future[Unit]
+  def logsEnabled: Future[Boolean]
+  def setLogsEnabled(enabled: Boolean): Future[Unit]
 }
 
 //TODO Think about cycle dependency between LogsService and InternalLog
-class LogsServiceImpl(accountsService: AccountsService)(implicit ec: ExecutionContext)
+class LogsServiceImpl(globalPreferences: GlobalPreferences)
   extends LogsService with DerivedLogTag {
 
   import com.waz.utils.events.EventContext.Implicits._
 
-  override val logsEnabledGlobally: Signal[Boolean] =
-    for {
-      zmss <- accountsService.zmsInstances
-      prefSignals = zmss.map(_.userPrefs(UserPreferences.LogsEnabled).signal)
-      prefs <- Signal.sequence(prefSignals.toSeq: _*)
-    } yield prefs.forall(identity)
+  override lazy val logsEnabledGlobally: Signal[Boolean] =
+    globalPreferences(GlobalPreferences.LogsEnabled).signal
 
   logsEnabledGlobally.ifFalse.apply { _ =>
     InternalLog.clearAll()
   }
 
-  override def logsEnabled(userId: UserId): Future[Boolean] =
-    for {
-      zmss <- accountsService.zmsInstances.head
-      zms = zmss.filter(_.selfUserId == userId).head
-      enabled <- zms.userPrefs(UserPreferences.LogsEnabled).apply()
-    } yield enabled
+  override def logsEnabled: Future[Boolean] =
+    globalPreferences(GlobalPreferences.LogsEnabled).apply()
 
-  override def setLogsEnabled(userId: UserId, enabled: Boolean): Future[Unit] =
-    for {
-      zmss <- accountsService.zmsInstances.head
-      zms = zmss.filter(_.selfUserId == userId).head
-      _ <- zms.userPrefs(UserPreferences.LogsEnabled) := enabled
-    } yield ()
-
+  override def setLogsEnabled(enabled: Boolean): Future[Unit] =
+    globalPreferences(GlobalPreferences.LogsEnabled) := enabled
 }

--- a/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GlobalModule.scala
@@ -27,6 +27,7 @@ import com.waz.bitmap.video.VideoTranscoder
 import com.waz.cache.CacheService
 import com.waz.client.{RegistrationClient, RegistrationClientImpl}
 import com.waz.content._
+import com.waz.log.{LogsService, LogsServiceImpl}
 import com.waz.permissions.PermissionsService
 import com.waz.service.assets.{AudioTranscoder, GlobalRecordAndPlayService}
 import com.waz.service.call._
@@ -101,6 +102,8 @@ trait GlobalModule {
   def mediaManager:             MediaManagerService
 
   def trackingService:          TrackingService
+
+  def logsService:              LogsService
 }
 
 class GlobalModuleImpl(val context:                 AContext,
@@ -176,6 +179,8 @@ class GlobalModuleImpl(val context:                 AContext,
 
   lazy val flowmanager:         FlowManagerService               = wire[DefaultFlowManagerService]
   lazy val mediaManager:        MediaManagerService              = wire[DefaultMediaManagerService]
+
+  lazy val logsService:         LogsService                      = new LogsServiceImpl(prefs)
 }
 
 class EmptyGlobalModule extends GlobalModule {
@@ -226,5 +231,6 @@ class EmptyGlobalModule extends GlobalModule {
   override def httpClientForLongRunning: HttpClient                                          = ???
   override def syncRequests:             SyncRequestService                                  = ???
   override def syncHandler:              SyncHandler                                         = ???
+  override def logsService:              LogsService                                         = ???
 }
 

--- a/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/otr/CryptoSessionService.scala
@@ -79,7 +79,7 @@ class CryptoSessionService(cryptoBox: CryptoBoxService) extends DerivedLogTag {
     def decrypt(arg: Option[CryptoBox]): (CryptoSession, Array[Byte]) = arg match {
       case None => throw new Exception("CryptoBox missing")
       case Some(cb) =>
-        verbose(l"decryptMessage($sessionId for message: ${msg.length} = ${showString(AESUtils.base64(msg))})")
+        verbose(l"decryptMessage($sessionId. Message length: ${msg.length})")
         loadSession(cb, sessionId).fold {
           val sm = cb.initSessionFromMessage(sessionId.toString, msg)
           onCreate ! sessionId

--- a/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/specs/AndroidFreeSpec.scala
@@ -186,6 +186,6 @@ object AndroidFreeSpec {
 
 class DummyLogsService extends LogsService {
   override def logsEnabledGlobally: Signal[Boolean] = Signal.const(true)
-  override def logsEnabled(userId: UserId): Future[Boolean] = ???
-  override def setLogsEnabled(userId: UserId, enabled: Boolean): Future[Unit] = ???
+  override def logsEnabled: Future[Boolean] = ???
+  override def setLogsEnabled(enabled: Boolean): Future[Unit] = ???
 }


### PR DESCRIPTION
## What's new in this PR?

This PR contains some minor changes needed to use `LogsService` in the UI project.

### Issues

- the `LogsEnabled` preference is now a `GlobalPreference`. We don't currently support account independent logging, so it makes more sense to make the preference global.
- `LogsService` has been updated to handle only the global preference.
- the `LogsServiceImpl` singleton is owned by the global module, since it relies on `GlobalPreferences` which is also owned by the global module.
- the `clear` method has been implmented for `AndroidLogOutput`, so that logcat output will not persists if the user disables logs.