### PR TITLE
Add trimming in case of bugs where notification stats aren't processed

### DIFF
--- a/zmessaging/src/main/scala/com/waz/repository/FCMNotificationStatsRepository.scala
+++ b/zmessaging/src/main/scala/com/waz/repository/FCMNotificationStatsRepository.scala
@@ -67,8 +67,10 @@ class FCMNotificationStatsRepositoryImpl(fcmTimestamps: FCMNotificationsReposito
       if (update.stage == FCMNotification.FinishedPipeline)
         FCMNotificationsDao.deleteEvery(FCMNotification.everyStage.map((stageTimestamp.id, _)))
     }.andThen { case _ =>
-      //this op is not done as part of the transaction because we will eventually retry
-      fcmTimestamps.trimExcessRows(update.stage)
+      //this op is not done as part of the transaction because it's not essential, it's just an
+      //extra check to ensure the FCM timestamps table doesn't grow overly long due to bugs
+      if (update.stage == FCMNotification.FinishedPipeline)
+        fcmTimestamps.trimExcessRows()
     }(Threading.Background)
 
   override def listAllStats(): Future[Vector[FCMNotificationStats]] = db.read(list(_))

--- a/zmessaging/src/main/scala/com/waz/repository/FCMNotificationStatsRepository.scala
+++ b/zmessaging/src/main/scala/com/waz/repository/FCMNotificationStatsRepository.scala
@@ -47,12 +47,10 @@ trait FCMNotificationStatsRepository {
 }
 
 class FCMNotificationStatsRepositoryImpl(fcmTimestamps: FCMNotificationsRepository)
-                                        (implicit db: Database)
+                                        (implicit val db: Database, ec: ExecutionContext)
   extends FCMNotificationStatsRepository {
 
   import com.waz.repository.FCMNotificationStatsRepository.FCMNotificationStatsDao._
-
-  private implicit val ec: ExecutionContext = Threading.Background
 
   override def writeTimestampAndStats(update: FCMNotificationStats, stageTimestamp: FCMNotification): Future[Unit] =
     db.withTransaction { implicit db =>
@@ -71,7 +69,7 @@ class FCMNotificationStatsRepositoryImpl(fcmTimestamps: FCMNotificationsReposito
       //extra check to ensure the FCM timestamps table doesn't grow overly long due to bugs
       if (update.stage == FCMNotification.FinishedPipeline)
         fcmTimestamps.trimExcessRows()
-    }(Threading.Background)
+    }
 
   override def listAllStats(): Future[Vector[FCMNotificationStats]] = db.read(list(_))
 }

--- a/zmessaging/src/main/scala/com/waz/repository/FCMNotificationsRepository.scala
+++ b/zmessaging/src/main/scala/com/waz/repository/FCMNotificationsRepository.scala
@@ -20,10 +20,12 @@ package com.waz.repository
 import com.waz.content.Database
 import com.waz.db.Col.{id, text, timestamp}
 import com.waz.db.Dao2
+import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.{FCMNotification, Uid}
 import com.waz.threading.Threading
 import com.waz.utils.wrappers.DBCursor
 import org.threeten.bp.Instant
+import com.waz.log.LogSE._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -32,10 +34,10 @@ trait FCMNotificationsRepository {
   def getPreviousStageTime(id: Uid, stage: String): Future[Option[Instant]]
   def deleteAllWithId(id: Uid): Future[Unit]
   def exists(ids: Set[Uid]): Future[Set[Uid]]
-  def trimExcessRows(stage: String): Future[Unit]
+  def trimExcessRows(): Future[Unit]
 }
 
-class FCMNotificationsRepositoryImpl(implicit db: Database) extends FCMNotificationsRepository {
+class FCMNotificationsRepositoryImpl(implicit db: Database) extends FCMNotificationsRepository with DerivedLogTag {
 
   import FCMNotificationsRepository._
   import FCMNotificationsDao._
@@ -57,27 +59,18 @@ class FCMNotificationsRepositoryImpl(implicit db: Database) extends FCMNotificat
     iterating(FCMNotificationsDao.findInSet(Id, ids)).acquire(_.map(_.id).toSet)
   }
 
-  override def trimExcessRows(stage: String): Future[Unit] =
+  override def trimExcessRows(): Future[Unit] =
     db.withTransaction { implicit db =>
-      val c = db.query(table.name, Array(Id.name, Stage.name), null, null,
-        null, null, StageStartTime.name, null)
+      val c = db.query(table.name, Array(StageStartTime.name), null, null,
+        null, null, s"${StageStartTime.name} DESC", null)
       c.moveToFirst()
-      if(c.getCount > maxRows) {
-        val toDeleteCursor = db.query(table.name, Array(Id.name, Stage.name), null, null,
-          null, null, StageStartTime.name, s"LIMIT ${maxRows - c.getCount}")
-        val b = iterating(toDeleteCursor)
-        deleteEvery(b.acquire(identity))
-        toDeleteCursor.close()
+      if (c.getCount > maxRows) {
+        c.moveToPosition(maxRows - 1)
+        val maxTime = c.getLong(c.getColumnIndex(StageStartTime.name))
+        single(db.rawQuery(s"DELETE FROM ${table.name} WHERE ${StageStartTime.name} < $maxTime", null))
       }
       c.close()
     }
-    //if(stage == FCMNotification.FinishedPipeline) {
-    //  db.read(FCMNotificationsDao.list(_)).flatMap { case rows if rows.size > maxRows =>
-    //    val rowsToRemove = getOldestExcessRows(rows).map(p => (p.id, p.stage))
-    //    db.apply(FCMNotificationsDao.deleteEvery(rowsToRemove)(_))
-    //  }
-    //} else Future.successful(())
-
 }
 
 object FCMNotificationsRepository {

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -190,7 +190,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val callingClient      = new CallingClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val propertiesClient: PropertiesClient = new PropertiesClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val fcmNotsRepo        = new FCMNotificationsRepositoryImpl()(db)
-  lazy val fcmNotStatsRepo    = new FCMNotificationStatsRepositoryImpl()(db)
+  lazy val fcmNotStatsRepo    = new FCMNotificationStatsRepositoryImpl(fcmNotsRepo)(db)
 
   lazy val convsContent: ConversationsContentUpdaterImpl = wire[ConversationsContentUpdaterImpl]
   lazy val messagesContent: MessagesContentUpdater = wire[MessagesContentUpdater]

--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -190,7 +190,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val callingClient      = new CallingClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val propertiesClient: PropertiesClient = new PropertiesClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val fcmNotsRepo        = new FCMNotificationsRepositoryImpl()(db)
-  lazy val fcmNotStatsRepo    = new FCMNotificationStatsRepositoryImpl(fcmNotsRepo)(db)
+  lazy val fcmNotStatsRepo    = new FCMNotificationStatsRepositoryImpl(fcmNotsRepo)(db, Threading.Background)
 
   lazy val convsContent: ConversationsContentUpdaterImpl = wire[ConversationsContentUpdaterImpl]
   lazy val messagesContent: MessagesContentUpdater = wire[MessagesContentUpdater]

--- a/zmessaging/src/test/scala/com/waz/repository/FCMNotificationsRepositorySpec.scala
+++ b/zmessaging/src/test/scala/com/waz/repository/FCMNotificationsRepositorySpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.repository
+
+import com.waz.model.{FCMNotification, Uid}
+import com.waz.specs.AndroidFreeSpec
+import org.threeten.bp.Instant
+import org.threeten.bp.temporal.ChronoUnit._
+
+class FCMNotificationsRepositorySpec extends AndroidFreeSpec {
+
+  import FCMNotification._
+  import com.waz.repository.FCMNotificationsRepository._
+
+  scenario("Oldest row is removed first when trimming") {
+    val time1 = Instant.now
+    val time3 = Instant.now.plus(10, HOURS)
+    val time2 = Instant.now.plus(5, HOURS)
+    val times = Vector(time1, time2, time3)
+    val input = times.map(t => FCMNotification(Uid("test"), StartedPipeline, t))
+    val expectedOutput = Vector(FCMNotification(Uid("test"), StartedPipeline, time1))
+
+    getOldestExcessRows(input, 2) shouldEqual expectedOutput
+  }
+
+  scenario("Oldest rows are ordered temporally when trimming") {
+    val time1 = Instant.now
+    val time3 = Instant.now.plus(10, HOURS)
+    val time2 = Instant.now.plus(5, HOURS)
+    val times = Vector(time1, time2, time3)
+    val input = times.map(t => FCMNotification(Uid("test"), StartedPipeline, t))
+    val expectedOutput = Vector(
+      FCMNotification(Uid("test"), StartedPipeline, time1),
+      FCMNotification(Uid("test"), StartedPipeline, time2))
+
+    getOldestExcessRows(input, 1) shouldEqual expectedOutput
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/service/FCMNotificationStatsServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/FCMNotificationStatsServiceSpec.scala
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.waz.model
+package com.waz.service
 
+import com.waz.model.{FCMNotification, Uid}
 import com.waz.repository.{FCMNotificationStats, FCMNotificationStatsRepository, FCMNotificationsRepository}
-import com.waz.service.FCMNotificationStatsServiceImpl
 import com.waz.specs.AndroidFreeSpec
 import org.threeten.bp.Instant
 import org.threeten.bp.temporal.ChronoUnit._


### PR DESCRIPTION
## What's new in this PR?

### Issues

If there are bugs in how we delete the timestamps of notifications, then we might end up with an ever-growing table of timestamps. To avoid this, a check is added when we write the final timestamp to delete the oldest row over a limit. This limit has been set to 1000 rows as this should be enough for even extreme situations.