### PR TITLE
Flush logs before cleaning in BufferedLogOutput.

### DIFF
--- a/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
+++ b/zmessaging/src/main/scala/com/waz/log/BufferedLogOutput.scala
@@ -91,7 +91,10 @@ class BufferedLogOutput(baseDir: String,
     }
   }
 
-  override def clear(): Unit = paths foreach { path => new File(path).delete() }
+  override def clear(): Unit = {
+    flush()
+    paths foreach { path => new File(path).delete() }
+  }
 
   private def writeToFile(fileName: String, contents: String): Unit = this.synchronized {
     try {


### PR DESCRIPTION
## What's new in this PR?

### Issues

After disabling global logging, few logs statements still printed to log files.

### Solutions

We do explicit `flush` before clearing `BufferedLogOutput`
