### PR TITLE
Feature/strong password

### DIFF
--- a/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
@@ -1,0 +1,51 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.utils
+
+import com.waz.utils.PasswordValidator._
+
+/// A minimal password validator that enforces length only.
+class PasswordValidator(minLength: Int, maxLength: Int) {
+
+  private val lengthRule: Rule = p => {
+    val length = p.codePointCount(0, p.length)
+    length >= minLength && length <= maxLength
+  }
+
+  private var rules: Seq[Rule] = Seq(lengthRule)
+
+  def add(rule: Rule): Unit = rules = rules :+ rule
+  def add(rules: Seq[Rule]): Unit = this.rules = this.rules ++ rules
+  def isValidPassword(password: String): Boolean = rules.forall(_(password))
+}
+
+/// A strong password validator that enforces length and the existence of a lowercase,
+/// uppercase, digit and special character.
+class StrongPasswordValidator(minLength: Int)
+  extends PasswordValidator(minLength, maxLength = 101) {
+
+  add(rules = Seq(
+    p => p.exists(_.isLower),
+    p => p.exists(_.isUpper),
+    p => p.exists(_.isDigit) // TODO: add special rule
+  ))
+}
+
+object PasswordValidator {
+  type Rule = String => Boolean
+}

--- a/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
@@ -20,7 +20,7 @@ package com.waz.utils
 import com.waz.utils.PasswordValidator._
 
 /// A minimal password validator that enforces length only.
-class PasswordValidator(minLength: Int, maxLength: Int) {
+class PasswordValidator(val minLength: Int, val maxLength: Int) {
 
   private val lengthRule: Rule = p => {
     val length = p.codePointCount(0, p.length)

--- a/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/PasswordValidator.scala
@@ -36,14 +36,16 @@ class PasswordValidator(val minLength: Int, val maxLength: Int) {
 
 /// A strong password validator that enforces length and the existence of a lowercase,
 /// uppercase, digit and special character.
-class StrongPasswordValidator(minLength: Int)
-  extends PasswordValidator(minLength, maxLength = 101) {
+class StrongPasswordValidator(minLength: Int, maxLength: Int = 101)
+  extends PasswordValidator(minLength, maxLength) {
 
   add(rules = Seq(
-    p => p.exists(_.isLower),
-    p => p.exists(_.isUpper),
-    p => p.exists(_.isDigit) // TODO: add special rule
+    p => "[a-z]".r.findFirstIn(p).isDefined,
+    p => "[A-Z]".r.findFirstIn(p).isDefined,
+    p => "[0-9]".r.findFirstIn(p).isDefined,
+    p => "[^a-zA-Z0-9]".r.findFirstIn(p).isDefined
   ))
+
 }
 
 object PasswordValidator {

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.{FeatureSpec, Matchers}
 
 class PasswordValidatorSpec extends FeatureSpec with Matchers {
 
-  private lazy val sut = new StrongPasswordValidator(minLength = 8, maxLength = 16)
+  private lazy val sut = PasswordValidator.createStrongPasswordValidator(minLength = 8, maxLength = 16)
 
   private val validPasswords = Seq(
     "Passw0rd!",            // plain old vanilla password

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -24,10 +24,10 @@ class PasswordValidatorSpec extends FeatureSpec with Matchers {
   private lazy val sut = new StrongPasswordValidator(minLength = 8, maxLength = 16)
 
   private val validPasswords = Seq(
-    "Passw0rd!",
-    "Pass w0rd!",
-    "Päss w0rd!",
-    "Päss\uD83D\uDC3Cw0rd!"
+    "Passw0rd!",            // plain old vanilla password
+    "Pass w0rd!",           // contains space
+    "Päss w0rd!",           // contains umlaut
+    "Päss\uD83D\uDC3Cw0rd!" // contains emoji
   )
 
   private val invalidPasswords = Seq(

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.utils
+
+import org.scalatest.{FeatureSpec, Matchers}
+
+class PasswordValidatorSpec extends FeatureSpec with Matchers {
+
+  private lazy val sut = new StrongPasswordValidator(minLength = 8)
+
+  // TODO: Add cases
+  private val validPasswords = Seq(
+    "Passw0rd"
+  )
+
+  // TODO: Add cases
+  private val invalidPasswords = Seq(
+    "short"
+  )
+
+  feature("Strong password") {
+
+    scenario("validates valid passwords") {
+      validPasswords.foreach { p =>
+        assert(sut.isValidPassword(p), s"-> p: $p should be valid.")
+      }
+    }
+
+    scenario("validates invalid passwords") {
+      invalidPasswords.foreach { p =>
+        assert(!sut.isValidPassword(p), s"-> p: $p should not be valid.")
+      }
+    }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -33,7 +33,7 @@ class PasswordValidatorSpec extends FeatureSpec with Matchers {
   private val invalidPasswords = Seq(
     "aA1!",                 // too short
     "aA1!aA1!aA1!aA1!aA1!", // too long
-    "A1!A1!A1!A1!",         // no no lowercase
+    "A1!A1!A1!A1!",         // no lowercase
     "a1!a1!a1!a1!",         // no uppercase
     "aA!aA!aA!aA!",         // no numbers
     "aA1aA1aA1aA1"          // no symbols

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -21,16 +21,22 @@ import org.scalatest.{FeatureSpec, Matchers}
 
 class PasswordValidatorSpec extends FeatureSpec with Matchers {
 
-  private lazy val sut = new StrongPasswordValidator(minLength = 8)
+  private lazy val sut = new StrongPasswordValidator(minLength = 8, maxLength = 16)
 
-  // TODO: Add cases
   private val validPasswords = Seq(
-    "Passw0rd"
+    "Passw0rd!",
+    "Pass w0rd!",
+    "Päss w0rd!",
+    "Päss\uD83D\uDC3Cw0rd!"
   )
 
-  // TODO: Add cases
   private val invalidPasswords = Seq(
-    "short"
+    "aA1!",                 // too short
+    "aA1!aA1!aA1!aA1!aA1!", // too long
+    "A1!A1!A1!A1!",         // no no lowercase
+    "a1!a1!a1!a1!",         // no uppercase
+    "aA!aA!aA!aA!",         // no numbers
+    "aA1aA1aA1aA1"          // no symbols
   )
 
   feature("Strong password") {


### PR DESCRIPTION
## What's new in this PR?

This PR introduces the first changes for the strong password feature. Included is a definition of a `PasswordValidator`, which minimally enforces password length. It is intended to be the base implementation for more complex validators (should we ever need to create more than one). Also defined is `StrongPasswordValidator`, which enforces the requirements defined in the specs.

The minimum length of the password will be derived from a feature flag, which will have to be set on the UI side. I decided however to implement the validator here for the sake of tests. 


### Testing

I've added test stubs to check a sequence of valid passwords and another sequence for invalid passwords.

## Notes

The implementation is incomplete as I'm still waiting for the specs to be finalized.