### PR TITLE
upgrade okhttp to newer version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.9.0",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.12.1",
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",


### PR DESCRIPTION
## What's new in this PR?

~~Possibly fixes, or at least improves upon #532 - to be tested once I get an APK built with this change in. (I currently have a problem with sbt/scala)~~

There are newer versions of this dependency than 3.12.1, but they're not backwards compatible for android < 5.