### PR TITLE
Fix/fix websocket behaviour

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.12.1",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.10.0",
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",

--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,7 @@ lazy val zmessaging = project
       "org.robolectric"               %  "android-all"           % RobolectricVersion % Test,
       "junit"                         %  "junit"                 % "4.8.2"            % Test, //to override version included in robolectric
       "io.fabric8"                    %  "mockwebserver"         % "0.1.0"            % Test,
+      "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version
       "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion % Test % Native classifier "darwin-x86_64",
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion  % Test % Native classifier "linux-x86_64",

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.9.0",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.12.1",
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",

--- a/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
@@ -25,6 +25,7 @@ import com.waz.znet2.WebSocketFactory.SocketEvent
 import com.waz.znet2.http.{Body, Request}
 import okio.ByteString
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 
 import scala.util.Try
 
@@ -56,7 +57,9 @@ object OkHttpWebSocketFactory extends WebSocketFactory with DerivedLogTag {
   import HttpClientOkHttpImpl.convertHttpRequest
 
   //TODO Should be created somewhere outside
-  private lazy val okHttpClient = new OkHttpClient()
+  private lazy val okHttpClient = new OkHttpClient.Builder()
+                                      .pingInterval(30000,  TimeUnit.MILLISECONDS)
+                                      .build();
 
   override def openWebSocket(request: Request[Body]): EventStream[SocketEvent] = {
     new EventStream[SocketEvent] {


### PR DESCRIPTION
## What's new in this PR?

### Issues

See #532 

### Causes

Any change to the network mode (i.e. disabling mobile internet, changing from 4G to wifi or vice-versa) is not noticed by the websocket code. This leads to the websocket **thinking** it's still alive while it is not.

### Solutions

Make use of okhttp's `pingInterval` feature - this sends a ping to the server, expects a pong, and if it does not, send a Closed event - which will then in turn re-establish a fresh websocket connection.

Currently I set the interval to 30 seconds (can be discussed what a good tradeoff with regards to battery consumption is)

### Testing

1. compile an APK
2. open the app, keep the app open, switch off and on mobile internet
3. before: no messages arrive. With this PR: after waiting up to 30 seconds, messages arrive again.

## Details

### Current behaviour:

```
2019-04-16T17:00:04.995Z-TID:1/V/DefaultNetworkModeService: updateNetworkMode: OFFLINE
2019-04-16T17:00:05Z-TID:1/W/AVS: NOT IMPLEMENTED: networkChanged

2019-04-16T17:00:12.012Z-TID:1/V/DefaultNetworkModeService: updateNetworkMode: _4G
2019-04-16T17:00:12.015Z-TID:1/W/AVS: NOT IMPLEMENTED: networkChanged
```

At this point, the websocket connection is effectively broken (no new messages arrive), but OkHttpWebSocketFactory and WSPushService did not notice this. There is no log entry showing that a `SocketEvent.Closed` has been sent. This will never recover on a phone without play services - not even after hours. This may recover on a phone with play services, but only if the app is put to the background or quit then re-opened.

### After this PR:

After a change to network mode:

```
2019-04-16T17:43:45.536Z-TID:1/V/DefaultNetworkModeService: updateNetworkMode: OFFLINE
2019-04-16T17:43:45.540Z-TID:1/W/AVS: NOT IMPLEMENTED: networkChanged

2019-04-16T17:43:53.734Z-TID:1/V/DefaultNetworkModeService: updateNetworkMode: _4G
2019-04-16T17:43:53.740Z-TID:1/W/AVS: NOT IMPLEMENTED: networkChanged

(...)
```

up to 30 seconds later we can see a "didn't receive pong", which then fails the websocket connection:

```
2019-04-16T17:44:16.164Z-TID:1641/W/OkHttpWebSocketFactory$: WebSocket connection has been failed.
java.net.SocketTimeoutException: sent ping but didn't receive pong within 30000ms (after 1 successful ping/pongs)
	at okhttp3.internal.ws.RealWebSocket.writePingFrame(RealWebSocket.java:546)
	at okhttp3.internal.ws.RealWebSocket$PingRunnable.run(RealWebSocket.java:530)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:428)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:278)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:273)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
	at java.lang.Thread.run(Thread.java:761)
(...)
```

which then enters the normal routine to restart the websocket connection, which is what we want.