### PR TITLE
fix: Production builds were set to "debug"

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -19,6 +19,7 @@ package com.waz.content
 
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.{Context, SharedPreferences}
+import com.waz.api.ZmsVersion
 import com.waz.content.Preferences.Preference.PrefCodec
 import com.waz.content.Preferences.{PrefKey, Preference}
 import com.waz.log.BasicLogging.LogTag
@@ -34,7 +35,6 @@ import com.waz.threading.{DispatchQueue, SerialDispatchQueue, Threading}
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.events.{Signal, SourceSignal}
 import com.waz.utils.{CachedStorageImpl, JsonDecoder, JsonEncoder, Serialized, TrimmingLruCache, returning}
-import com.waz.zms.BuildConfig
 import org.json.JSONObject
 import org.threeten.bp.{Duration, Instant}
 
@@ -379,7 +379,7 @@ object GlobalPreferences {
 
   lazy val ShouldCreateFullConversation = PrefKey[Boolean]("should_create_full_conv", customDefault = false)
 
-  lazy val LogsEnabled: PrefKey[Boolean] = PrefKey[Boolean]("logs_enabled", customDefault = BuildConfig.DEBUG)
+  lazy val LogsEnabled: PrefKey[Boolean] = PrefKey[Boolean]("logs_enabled", customDefault = ZmsVersion.DEBUG)
 
 
   //DEPRECATED!!! Use the UserPreferences instead!!


### PR DESCRIPTION

## What's new in this PR?

### Issues

Public builds had logging enabled by default, instead of this being off.

### Causes

This was caused due to us reading a boolean variable set in BuildConfig which is always set to true. This is because it's generated by the Android build tools, presumably as a result of our NDK build, but this has nothing to do with the Sync Engine build proper, so we shouldn't use it.

### Solutions

Use a different file which we manually generate in build.sbt to determine debug status

### Testing

This was tested manually.
