### PR TITLE
feat: Status Notifications

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -457,4 +457,7 @@ object UserPreferences {
 
   lazy val ReadReceiptsRemotelyChanged      = PrefKey[Boolean]("read_receipts_remotely_changed", customDefault = false)
 
+  lazy val StatusNotificationsPopupEnabled  = PrefKey[Boolean]("status_notifications_popup_enabled", customDefault = true)
+  lazy val ShouldWarnStatusNotifications    = PrefKey[Boolean]( "should_warn_status_notifications", customDefault = true)
+
 }

--- a/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/NotificationService.scala
@@ -62,6 +62,7 @@ class NotificationService(selfUserId:      UserId,
                           convs:           ConversationStorage,
                           pushService:     PushService,
                           uiController:    NotificationUiController,
+                          userService:     UserService,
                           clock:           Clock) {
 
   import Threading.Implicits.Background
@@ -135,21 +136,39 @@ class NotificationService(selfUserId:      UserId,
   private def pushNotificationsToUi(): Future[Unit] = {
     verbose(l"pushNotificationsToUi")
     for {
-      toShow <- storage.list().map(_.toSet)
+      Some(self)                <- userService.getSelfUser
+      toShow                    <- storage.list()
       notificationSourceVisible <- uiController.notificationsSourceVisible.head
-      convs <- convs.getAll(toShow.map(_.conv)).map(_.collect { case Some(c) => c.id -> c }.toMap)
-      (filteredShow, seen) = toShow.partition { n =>
-        val conv = convs(n.conv)
-        n.user != selfUserId &&
-          (conv.muted.isAllAllowed || (conv.muted.onlyMentionsAllowed && (n.isSelfMentioned || n.isReply))) &&
-          conv.lastRead.isBefore(n.time) &&
-          conv.cleared.forall(_.isBefore(n.time)) &&
-          !notificationSourceVisible.get(selfUserId).exists(_.contains(n.conv))
-      }
-      _ = verbose(l"filteredShow: $filteredShow, seen: $seen")
-      _ <- uiController.onNotificationsChanged(selfUserId, filteredShow)
-      _ <- storage.insertAll(filteredShow.map(_.copy(hasBeenDisplayed = true)))
-      _ <- storage.removeAll(seen.map(_.id))
+      convs                     <- convs.getAll(toShow.map(_.conv).toSet).map(_.collect { case Some(c) => c.id -> c }.toMap)
+      (show, ignore)            =  toShow.partition { n =>
+                                     val conv = convs(n.conv)
+                                     // broken down for better readability
+                                     val appAllows =
+                                       n.user != self.id &&
+                                       conv.lastRead.isBefore(n.time) &&
+                                       conv.cleared.forall(_.isBefore(n.time)) &&
+                                       !notificationSourceVisible.get(self.id).exists(_.contains(n.conv))
+                                     val isReplyOrMention = n.isSelfMentioned || n.isReply
+                                     if (!appAllows) {
+                                       false
+                                     } else {
+                                       if (self.availability == Availability.Away) {
+                                         false
+                                       } else if (self.availability == Availability.Busy) {
+                                         if (!isReplyOrMention) {
+                                           false
+                                         } else {
+                                           conv.muted.isAllAllowed || conv.muted.onlyMentionsAllowed
+                                         }
+                                       } else {
+                                         conv.muted.isAllAllowed  || (conv.muted.onlyMentionsAllowed && isReplyOrMention)
+                                       }
+                                     }
+                                   }
+      _                         =  verbose(l"show: $show, ignore: $ignore")
+      _                         <- uiController.onNotificationsChanged(self.id, show.toSet)
+      _                         <- storage.insertAll(show.map(_.copy(hasBeenDisplayed = true)))
+      _                         <- storage.removeAll(ignore.map(_.id))
     } yield {}
   }
 
@@ -161,7 +180,7 @@ class NotificationService(selfUserId:      UserId,
         drift      <- pushService.beDrift.head
         msgs       <- messages.findMessagesFrom(conv.id, eventTimes.min).map(_.filterNot(_.userId == selfUserId))
         quoteIds   <- messages
-          .getAll(msgs.filter(!_.hasMentionOf(selfUserId)).flatMap(_.quote.map(_.message)))
+          .getAll(msgs.filter(!_.hasMentionOf(selfUserId)).flatMap(_.quote.map(_.message)).toSet)
           .map(_.flatten.filter(_.userId == selfUserId).map(_.id).toSet)
       } yield {
         msgs.flatMap { msg =>
@@ -186,6 +205,7 @@ class NotificationService(selfUserId:      UserId,
           }
 
           tpe.map { tp =>
+            verbose(l"quoteIds: $quoteIds, message: $msg")
             NotificationData(
               id              = NotId(msg.id),
               msg             = if (msg.isEphemeral) "" else msg.contentString, msg.convId,

--- a/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/call/CallingServiceSpec.scala
@@ -20,7 +20,7 @@ package com.waz.service.call
 import com.sun.jna.Pointer
 import com.waz.api.NetworkMode
 import com.waz.content.GlobalPreferences.SkipTerminatingState
-import com.waz.content.MembersStorage
+import com.waz.content.{MembersStorage, UsersStorage}
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.model.ConversationData.ConversationType
 import com.waz.model.otr.ClientId
@@ -61,9 +61,11 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
   val messages       = mock[MessagesService]
   val permissions    = mock[PermissionsService]
   val push           = mock[PushService]
+  val usersStorage   = mock[UsersStorage]
   val globalPrefs    = new TestGlobalPreferences
 
   val selfUserId = UserId("self-user")
+  val selfUser   = UserData(selfUserId, "")
   val clientId   = ClientId("selfClient")
 
   val otherUser  = UserId("otherUser") //for one to one
@@ -956,9 +958,12 @@ class CallingServiceSpec extends AndroidFreeSpec with DerivedLogTag {
     (push.beDrift _).expects().anyNumberOfTimes().returning(Signal.const(Duration.ZERO))
 
     (avs.registerAccount _).expects(*).once().returning(Future.successful(wCall))
+
+    (usersStorage.get _).expects(selfUserId).anyNumberOfTimes().returning(Future.successful(Some(selfUser)))
+
     val s = new CallingServiceImpl(
       selfUserId, clientId, null, context, avs, convs, convsService, members, null,
-      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, tracking
+      flows, messages, media, push, network, null, prefs, globalPrefs, permissions, usersStorage, tracking
     )
     result(s.wCall)
     s


### PR DESCRIPTION
Depending on the availability status we restrict what notifications (if any) are pushed to UI to be displayed.
I had to add new requirements to the way `NotificationService` figures out what notifications to push to UI, and since the logic became a bit complex for one long expression, I decided to break it down in a series of i`f/else`s for better readability.
Also, I added unit tests, and refactored `NotificationServiceSpec`, putting code common to most unit tests in a private method.
Two new user preferences are going to be used in UI for displaying / not-displaying popups warning about the new functionality.