### PR TITLE
refactor: Add logging to debug dup conv creation

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -241,8 +241,8 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
 
   private def updateConversations(responses: Seq[ConversationResponse]): Future[(Seq[ConversationData], Seq[ConversationData])] = {
 
-    def updateConversationData() = {
-      def findExistingId = convsStorage { convsById =>
+    def updateConversationData(): Future[(Set[ConversationData], Seq[ConversationData])] = {
+      def findExistingId: Future[Seq[(ConvId, ConversationResponse)]] = convsStorage { convsById =>
         def byRemoteId(id: RConvId) = convsById.values.find(_.remoteId == id)
 
         responses.map { resp =>
@@ -255,7 +255,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
             }
           }
 
-          (matching.fold(newId)(_.id), resp)
+          val r = (matching.fold(newId)(_.id), resp)
+          verbose(l"Returning conv id pair $r, isOneToOne: ${isOneToOne(resp.convType)}")
+          r
         }
       }
 

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -351,6 +351,9 @@ class ConversationsUiServiceImpl(selfUserId:      UserId,
         onlyUs     = allMembers.groupBy { case (c, _) => c }.map { case (cid, us) => cid -> us.map(_._2).toSet }.collect { case (c, us) if us == Set(other, selfUserId) => c }
         convs      <- convStorage.getAll(onlyUs).map(_.flatten)
       } yield {
+        verbose(l"allConvs size: ${allConvs.size}")
+        verbose(l"allMembers size: ${allMembers.size}")
+        verbose(l"OnlyUs convs size: ${onlyUs.size}")
         if (convs.size > 1)
           warn(l"Found ${convs.size} available team conversations with user: $other, returning first conversation found")
         else verbose(l"Found ${convs.size} convs with other user: $other")


### PR DESCRIPTION
## What's new in this PR?

### Issues

There is an issue where occasionally we create multiple conversations instead of just one when opening the conversation with a user for the first time.