### PR TITLE
fix: Adding a bitmask to the Availability status, to help handle statuses in UI

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -457,7 +457,7 @@ object UserPreferences {
 
   lazy val ReadReceiptsRemotelyChanged      = PrefKey[Boolean]("read_receipts_remotely_changed", customDefault = false)
 
-  lazy val StatusNotificationsPopupEnabled  = PrefKey[Boolean]("status_notifications_popup_enabled", customDefault = true)
+  lazy val StatusNotificationsBitmask       = PrefKey[Int]("status_notifications_bitmask", customDefault = 0)
   lazy val ShouldWarnStatusNotifications    = PrefKey[Boolean]( "should_warn_status_notifications", customDefault = true)
 
 }

--- a/zmessaging/src/main/scala/com/waz/model/Availability.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Availability.scala
@@ -19,13 +19,29 @@ package com.waz.model
 
 import com.waz.log.LogShow.SafeToLog
 
-sealed trait Availability extends SafeToLog { val id: Int }
+sealed trait Availability extends SafeToLog {
+  val id: Int
+  val bitmask: Int // used to enable/disable warnings about the status change, see User Preferences
+}
 
 object Availability {
-  case object None      extends Availability { override val id = 0 }
-  case object Available extends Availability { override val id = 1 }
-  case object Away      extends Availability { override val id = 2 }
-  case object Busy      extends Availability { override val id = 3 }
+  case object None extends Availability {
+    override val id: Int = 0
+    override val bitmask: Int = 1 << 0
+  }
+
+  case object Available extends Availability {
+    override val id: Int = 1
+    override val bitmask: Int = 1 << 1
+  }
+  case object Away extends Availability {
+    override val id: Int = 2
+    override val bitmask: Int = 1 << 2
+  }
+  case object Busy extends Availability {
+    override val id: Int = 3
+    override val bitmask: Int = 1 << 3
+  }
 
   val all = List(None, Available, Away, Busy)
 


### PR DESCRIPTION
This is a part of the fix to https://wearezeta.atlassian.net/browse/AN-6200
We need to display a warning popup for each availability status, and then allow the user
to click "Never show that (one particular) warning again".
Instead of keeping a separate flag for each one I decided to keep one bitmask. This solution may also come in handy in the future, in other situations when we have to handle availability statuses.