### PR TITLE
fix: broken link previews

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -478,11 +478,7 @@ object MessageData extends
           case (1, Message.Part.Type.TEXT_EMOJI_ONLY) => (Message.Type.TEXT_EMOJI_ONLY, ct)
           case _ => (Message.Type.RICH_MEDIA, ct)
         }
-        (ct.size, ct.head.tpe) match {
-          case (1, Message.Part.Type.TEXT) => (Message.Type.TEXT, ct)
-          case (1, Message.Part.Type.TEXT_EMOJI_ONLY) => (Message.Type.TEXT_EMOJI_ONLY, ct)
-          case _ => (Message.Type.RICH_MEDIA, ct)
-        }
+        
       } else {
         // apply links
         def linkEnd(offset: Int) = {

--- a/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
@@ -30,14 +30,11 @@ class OkHttpUserAgentInterceptor(metadata: MetaDataService) extends Interceptor 
     s"Android $androidVersion / Wire $wireVersion / HttpLibrary $okHttpDefaultUserAgent"
   }
 
-  override def intercept(chain: Interceptor.Chain): Response = {
-    Option(chain.request().header("User-Agent")) match {
-      case Some(_) =>
-        chain.proceed(chain.request())
-      case None =>
-        val request = chain.request.newBuilder.header("User-Agent", WireUserAgent).build
-        chain.proceed(request)
-    }
-  }
-
+  override def intercept(chain: Interceptor.Chain): Response = 
+    chain.proceed(
+      if (Option(chain.request.header("User-Agent")).isDefined) 
+        chain.request
+      else 
+        chain.request.newBuilder.header("User-Agent", WireUserAgent).build
+    )
 }

--- a/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/OkHttpUserAgentInterceptor.scala
@@ -31,8 +31,13 @@ class OkHttpUserAgentInterceptor(metadata: MetaDataService) extends Interceptor 
   }
 
   override def intercept(chain: Interceptor.Chain): Response = {
-    val request = chain.request.newBuilder.header("User-Agent", WireUserAgent).build
-    chain.proceed(request)
+    Option(chain.request().header("User-Agent")) match {
+      case Some(_) =>
+        chain.proceed(chain.request())
+      case None =>
+        val request = chain.request.newBuilder.header("User-Agent", WireUserAgent).build
+        chain.proceed(request)
+    }
   }
 
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Several links no longer generate link previews. These include Facebook, Twitter, and Spotify.

### Causes

When we detect a link in a sent message, we make a GET request to search the body for open graph tags. In the request we specify a desktop user agent so that the response contains the tags (mobile versions of sites often do not contain the tags).

However... in https://github.com/wireapp/wire-android-sync-engine/pull/470 we introduced a request interceptor to set a custom user agent. This would overwrite any existing user agent specified in the header at an earlier stage (such as when the request is created).

### Solutions

When intercepting the request, only set the custom user agent if one does not already exist.

### Testing

Manually tested.

### Notes

I found some duplicated code so I removed that too.