### PR TITLE
fix: If the conversation is set to mentions & replies, a call should also go through

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -233,7 +233,7 @@ class CallingServiceImpl(val accountId:       UserId,
         others = Map(userId -> Some(LocalInstant.Now)),
         startedAsVideoCall = videoCall,
         videoSendState = VideoState.NoCameraPermission,
-        shouldRing = conv.muted.isAllAllowed && shouldRing)
+        shouldRing = !conv.muted.isAllMuted && shouldRing)
 
       callProfile.mutate { p =>
         // If we have a call in the profile with the same id, this incoming call should be just a GROUPCHECK


### PR DESCRIPTION
("mentions & replies" really means "mentions, replies & calls")

## What's new in this PR?

When we introduced mentions & replies, we added a possibility to filter notifications from a conversation, so the user was notified only when a message in the conversation was a reply or a mention. For some reason, probably connected to the fact that notifications about call work differently in iOS and Android, and we didn't catch that it would be a problem in Android, the filter ignored calls. This was caught only now, when the decision tree for notifications was updated because now notifications are also affected by the availability status. 

This PR changes the filter so that calls also go through if the conversation is set to "Mentions & Replies only". Basically, this mode means "Mentions, Replies & Calls".
