### PR TITLE
Fix websocket behaviour (and rewrite tests)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,8 +170,8 @@ lazy val zmessaging = project
       "com.wire"                      %% "robotest"              % "0.7"              % Test exclude("org.scalatest", "scalatest"),
       "org.robolectric"               %  "android-all"           % RobolectricVersion % Test,
       "junit"                         %  "junit"                 % "4.8.2"            % Test, //to override version included in robolectric
-      "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test,
       "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version
+      "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test,
       "com.typesafe.akka"             %% "akka-http"             % "10.1.8"           % Test,
       "com.typesafe.akka"             %% "akka-http-testkit"     % "10.1.8"           % Test,
       "com.typesafe.akka"             %% "akka-actor"            % "2.5.22"           % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.12.1",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.10.0",
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",

--- a/build.sbt
+++ b/build.sbt
@@ -171,6 +171,7 @@ lazy val zmessaging = project
       "org.robolectric"               %  "android-all"           % RobolectricVersion % Test,
       "junit"                         %  "junit"                 % "4.8.2"            % Test, //to override version included in robolectric
       "io.fabric8"                    %  "mockwebserver"         % "0.1.0"            % Test,
+      "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version
       "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion % Test % Native classifier "darwin-x86_64",
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion  % Test % Native classifier "linux-x86_64",

--- a/build.sbt
+++ b/build.sbt
@@ -170,9 +170,12 @@ lazy val zmessaging = project
       "com.wire"                      %% "robotest"              % "0.7"              % Test exclude("org.scalatest", "scalatest"),
       "org.robolectric"               %  "android-all"           % RobolectricVersion % Test,
       "junit"                         %  "junit"                 % "4.8.2"            % Test, //to override version included in robolectric
-      "io.fabric8"                    %  "mockwebserver"         % "0.1.0"            % Test,
+      "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test,
       "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version
-      "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test
+      "com.typesafe.akka"             %% "akka-http"             % "10.1.8"           % Test,
+      "com.typesafe.akka"             %% "akka-http-testkit"     % "10.1.8"           % Test,
+      "com.typesafe.akka"             %% "akka-actor"            % "2.5.22"           % Test,
+      "com.typesafe.akka"             %% "akka-stream"           % "2.5.22"           % Test
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion % Test % Native classifier "darwin-x86_64",
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion  % Test % Native classifier "linux-x86_64",
     )

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.9.0",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.12.1",
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val zmessaging = project
       compilerPlugin("com.github.ghik" %% "silencer-plugin"       % "0.6"),
 
       "org.scala-lang.modules"        %% "scala-async"           % "0.9.7",
-      "com.squareup.okhttp3"          %  "okhttp"                % "3.10.0",
+      "com.squareup.okhttp3"          %  "okhttp"                % "3.10.0", // should match okhttp3's mockserver version (see test dependencies)
       "com.googlecode.libphonenumber" %  "libphonenumber"        % "7.1.1", // 7.2.x breaks protobuf
       "com.wire"                      %  "cryptobox-android"     % "1.0.0",
       "com.wire"                      %  "generic-message-proto" % "1.23.0",
@@ -170,10 +170,9 @@ lazy val zmessaging = project
       "com.wire"                      %% "robotest"              % "0.7"              % Test exclude("org.scalatest", "scalatest"),
       "org.robolectric"               %  "android-all"           % RobolectricVersion % Test,
       "junit"                         %  "junit"                 % "4.8.2"            % Test, //to override version included in robolectric
-      "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version
+      "com.squareup.okhttp3"          %  "mockwebserver"         % "3.10.0"           % Test, //should match okhttp version.
       "org.apache.httpcomponents"     %  "httpclient"            % "4.5.3"            % Test,
       "com.typesafe.akka"             %% "akka-http"             % "10.1.8"           % Test,
-      "com.typesafe.akka"             %% "akka-http-testkit"     % "10.1.8"           % Test,
       "com.typesafe.akka"             %% "akka-actor"            % "2.5.22"           % Test,
       "com.typesafe.akka"             %% "akka-stream"           % "2.5.22"           % Test
 //      "com.wire.cryptobox" % "cryptobox-jni" % cryptoboxVersion % Test % Native classifier "darwin-x86_64",

--- a/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
+++ b/zmessaging/src/main/scala/com/waz/znet2/WebSocketFactory.scala
@@ -25,6 +25,7 @@ import com.waz.znet2.WebSocketFactory.SocketEvent
 import com.waz.znet2.http.{Body, Request}
 import okio.ByteString
 import org.json.JSONObject
+import java.util.concurrent.TimeUnit
 
 import scala.util.Try
 
@@ -56,7 +57,9 @@ object OkHttpWebSocketFactory extends WebSocketFactory with DerivedLogTag {
   import HttpClientOkHttpImpl.convertHttpRequest
 
   //TODO Should be created somewhere outside
-  private lazy val okHttpClient = new OkHttpClient()
+  private lazy val okHttpClient = new OkHttpClient.Builder()
+                                      .pingInterval(30000,  TimeUnit.MILLISECONDS)
+                                      .build();
 
   override def openWebSocket(request: Request[Body]): EventStream[SocketEvent] = {
     new EventStream[SocketEvent] {

--- a/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
@@ -33,18 +33,19 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
   import EventContext.Implicits.global
   import com.waz.BlockingSyntax.toBlocking
 
-  // private val testPath = "/test"
+  private val wsPort = 8080
   private val testPath = "http://localhost:8080/test"
   private val defaultWaiting = 100
   private def testWebSocketRequest(url: String): Request[Body] = Request.create(method = Method.Get, url = new URL(url))
 
 
-
+  import akka.NotUsed
+  import akka.util.ByteString
   import akka.actor.ActorSystem
   import akka.stream.ActorMaterializer
   import akka.stream.scaladsl.{ Flow, Source, Sink, Keep }
   import akka.http.scaladsl.Http
-  import akka.http.scaladsl.model.ws.{ TextMessage, Message }
+  import akka.http.scaladsl.model.ws.{ TextMessage, Message, BinaryMessage }
   import akka.http.scaladsl.server.Directives
   import scala.io.StdIn
   import scala.concurrent.{ Future, Promise }
@@ -54,61 +55,45 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
 
   import Directives._
 
-  // The Greeter WebSocket Service expects a "name" per message and
-  // returns a greeting message for that name
-  val greeterWebSocketService =
-    Flow[Message]
-      .collect {
-        case tm: TextMessage => TextMessage(Source.single("Hello ") ++ tm.textStream)
-        // ignore binary messages
-        // TODO #20096 in case a Streamed message comes in, we should runWith(Sink.ignore) its data
-      }
-
-
-      // using emit "one" and "two" and then keep the connection open
-  val flow: Flow[Message, Message, Promise[Option[Message]]] =
-      Flow.fromSinkAndSourceMat(
-        Sink.foreach[Message](println),
-        Source(List(TextMessage("one"), TextMessage("two")))
-          .concatMat(Source.maybe[Message])(Keep.right))(Keep.right)
-
-  //#websocket-routing
-  val route =
-    path("test") {
-      get {
-        handleWebSocketMessages(flow)
-      }
-    }
-  //#websocket-routing
-
-  import system.dispatcher // for the future transformations
-
-  val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+  private var bindingFuture: Future[Http.ServerBinding] = _
 
   override protected def beforeEach(): Unit = {
     println(s"Akka-http websocket server online at http://localhost:8080/")
   }
 
-  override protected def afterEach(): Unit = {
+  private def stopWebsocketServer(): Unit = {
+    import system.dispatcher // for the future transformations
     bindingFuture
         .flatMap(_.unbind()) // trigger unbinding from the port
         .onComplete(_ => system.terminate()) // and shutdown when done
+  }
+
+  override protected def afterEach(): Unit = {
+    stopWebsocketServer()
   }
 
   "OkHttp events stream" should {
 
     "provide all okHttp events properly when socket closed without error." in {
       val textMessage = "Text message"
-      val bytesMessage = Array[Byte](1, 2, 3, 4)
+      val bytesMessage = ByteString(1, 2, 3, 4)
 
-      // mockServer.expect().get().withPath(testPath)
-      //   .andUpgradeToWebSocket()
-      //   .open()
-      //   .waitFor(defaultWaiting).andEmit(textMessage)
-      //   .waitFor(defaultWaiting).andEmit(bytesMessage)
-      //   .done().once()
+      // -- set up websocket server --
+      // emit two messages and then close the connection
+      val flowTwoMessageClose: Flow[Message, Message, NotUsed] =
+          Flow.fromSinkAndSource(
+            Sink.foreach[Message](println),
+            Source(List(TextMessage(textMessage), BinaryMessage(bytesMessage)))
+          )
+      val route =
+        path("test") {
+          get {
+            handleWebSocketMessages(flowTwoMessageClose)
+          }
+        }
+      bindingFuture = Http().bindAndHandle(route, "localhost", wsPort)
 
-
+      // -- connect and assert --
       toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(testPath))) { stream =>
         val firstEvent :: secondEvent :: thirdEvent :: fourthEvent :: Nil = stream.takeEvents(4)
 
@@ -123,34 +108,39 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
       }
     }
 
-    // "provide all okHttp events properly when socket closed with error." in {
-    //   // mockServer.expect().get().withPath(testPath)
-    //   //   .andUpgradeToWebSocket()
-    //   //   .open()
-    //   //   .waitFor(10000).andEmit("")
-    //   //   .done().once()
+    "provide all okHttp events properly when socket closed with error." in {
+      // -- set up websocket server --
+      // emit nothing and then keep the connection open
+      val flowWait: Flow[Message, Message, Promise[Option[Message]]] =
+        Flow.fromSinkAndSourceMat(
+          Sink.foreach[Message](println),
+          Source.empty
+            .concatMat(Source.maybe[Message])(Keep.right))(Keep.right)
+      val route =
+        path("test") {
+          get {
+            handleWebSocketMessages(flowWait)
+          }
+        }
+      bindingFuture = Http().bindAndHandle(route, "localhost", wsPort)
 
-    //   toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(mockServer.url(testPath)))) { stream =>
-    //     val firstEvent = stream.getEvent(0)
-    //     Try { mockServer.shutdown() } //we do not care about this error
-    //   val secondEvent = stream.getEvent(1)
+      toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(testPath))) { stream =>
+        val firstEvent = stream.getEvent(0)
+        Try { stopWebsocketServer() } //we do not care about this error
+        val secondEvent = stream.getEvent(1)
 
-    //     firstEvent mustBe an[SocketEvent.Opened]
-    //     secondEvent mustBe an[SocketEvent.Closed]
+        firstEvent mustBe an[SocketEvent.Opened]
+        secondEvent mustBe an[SocketEvent.Closed]
 
-    //     inside(secondEvent) { case SocketEvent.Closed(_, error) =>
-    //       error mustBe an[Some[_]]
-    //     }
+        inside(secondEvent) { case SocketEvent.Closed(_, error) =>
+          error mustBe an[Some[_]]
+        }
 
-    //     withClue("No events should be emitted after socket has been closed") {
-    //       stream.waitForEvents(2.seconds) mustBe List.empty[SocketEvent]
-    //     }
-    //   }
-    // }
+        withClue("No events should be emitted after socket has been closed") {
+          stream.waitForEvents(2.seconds) mustBe List.empty[SocketEvent]
+        }
+      }
+    }
   }
 
-
-
-
 }
-

--- a/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/znet2/OkHttpWebSocketSpec.scala
@@ -23,7 +23,6 @@ import com.waz.utils.events.EventContext
 import com.waz.znet2
 import com.waz.znet2.WebSocketFactory.SocketEvent
 import com.waz.znet2.http.{Body, Method, Request}
-import io.fabric8.mockwebserver.DefaultMockServer
 import org.scalatest.{BeforeAndAfterEach, Inside, MustMatchers, WordSpec}
 
 import scala.concurrent.duration._
@@ -34,19 +33,66 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
   import EventContext.Implicits.global
   import com.waz.BlockingSyntax.toBlocking
 
-  private val testPath = "/test"
+  // private val testPath = "/test"
+  private val testPath = "http://localhost:8080/test"
   private val defaultWaiting = 100
   private def testWebSocketRequest(url: String): Request[Body] = Request.create(method = Method.Get, url = new URL(url))
 
-  private var mockServer: DefaultMockServer = _
+
+
+  import akka.actor.ActorSystem
+  import akka.stream.ActorMaterializer
+  import akka.stream.scaladsl.{ Flow, Source, Sink, Keep }
+  import akka.http.scaladsl.Http
+  import akka.http.scaladsl.model.ws.{ TextMessage, Message }
+  import akka.http.scaladsl.server.Directives
+  import scala.io.StdIn
+  import scala.concurrent.{ Future, Promise }
+
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+
+  import Directives._
+
+  // The Greeter WebSocket Service expects a "name" per message and
+  // returns a greeting message for that name
+  val greeterWebSocketService =
+    Flow[Message]
+      .collect {
+        case tm: TextMessage => TextMessage(Source.single("Hello ") ++ tm.textStream)
+        // ignore binary messages
+        // TODO #20096 in case a Streamed message comes in, we should runWith(Sink.ignore) its data
+      }
+
+
+      // using emit "one" and "two" and then keep the connection open
+  val flow: Flow[Message, Message, Promise[Option[Message]]] =
+      Flow.fromSinkAndSourceMat(
+        Sink.foreach[Message](println),
+        Source(List(TextMessage("one"), TextMessage("two")))
+          .concatMat(Source.maybe[Message])(Keep.right))(Keep.right)
+
+  //#websocket-routing
+  val route =
+    path("test") {
+      get {
+        handleWebSocketMessages(flow)
+      }
+    }
+  //#websocket-routing
+
+  import system.dispatcher // for the future transformations
+
+  val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
 
   override protected def beforeEach(): Unit = {
-    mockServer = new DefaultMockServer()
-    mockServer.start()
+    println(s"Akka-http websocket server online at http://localhost:8080/")
   }
 
   override protected def afterEach(): Unit = {
-    mockServer.shutdown()
+    bindingFuture
+        .flatMap(_.unbind()) // trigger unbinding from the port
+        .onComplete(_ => system.terminate()) // and shutdown when done
   }
 
   "OkHttp events stream" should {
@@ -55,15 +101,15 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
       val textMessage = "Text message"
       val bytesMessage = Array[Byte](1, 2, 3, 4)
 
-      mockServer.expect().get().withPath(testPath)
-        .andUpgradeToWebSocket()
-        .open()
-        .waitFor(defaultWaiting).andEmit(textMessage)
-        .waitFor(defaultWaiting).andEmit(bytesMessage)
-        .done().once()
+      // mockServer.expect().get().withPath(testPath)
+      //   .andUpgradeToWebSocket()
+      //   .open()
+      //   .waitFor(defaultWaiting).andEmit(textMessage)
+      //   .waitFor(defaultWaiting).andEmit(bytesMessage)
+      //   .done().once()
 
 
-      toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(mockServer.url(testPath)))) { stream =>
+      toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(testPath))) { stream =>
         val firstEvent :: secondEvent :: thirdEvent :: fourthEvent :: Nil = stream.takeEvents(4)
 
         firstEvent mustBe an[SocketEvent.Opened]
@@ -77,30 +123,30 @@ class OkHttpWebSocketSpec extends WordSpec with MustMatchers with Inside with Be
       }
     }
 
-    "provide all okHttp events properly when socket closed with error." in {
-      mockServer.expect().get().withPath(testPath)
-        .andUpgradeToWebSocket()
-        .open()
-        .waitFor(10000).andEmit("")
-        .done().once()
+    // "provide all okHttp events properly when socket closed with error." in {
+    //   // mockServer.expect().get().withPath(testPath)
+    //   //   .andUpgradeToWebSocket()
+    //   //   .open()
+    //   //   .waitFor(10000).andEmit("")
+    //   //   .done().once()
 
-      toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(mockServer.url(testPath)))) { stream =>
-        val firstEvent = stream.getEvent(0)
-        Try { mockServer.shutdown() } //we do not care about this error
-      val secondEvent = stream.getEvent(1)
+    //   toBlocking(znet2.OkHttpWebSocketFactory.openWebSocket(testWebSocketRequest(mockServer.url(testPath)))) { stream =>
+    //     val firstEvent = stream.getEvent(0)
+    //     Try { mockServer.shutdown() } //we do not care about this error
+    //   val secondEvent = stream.getEvent(1)
 
-        firstEvent mustBe an[SocketEvent.Opened]
-        secondEvent mustBe an[SocketEvent.Closed]
+    //     firstEvent mustBe an[SocketEvent.Opened]
+    //     secondEvent mustBe an[SocketEvent.Closed]
 
-        inside(secondEvent) { case SocketEvent.Closed(_, error) =>
-          error mustBe an[Some[_]]
-        }
+    //     inside(secondEvent) { case SocketEvent.Closed(_, error) =>
+    //       error mustBe an[Some[_]]
+    //     }
 
-        withClue("No events should be emitted after socket has been closed") {
-          stream.waitForEvents(2.seconds) mustBe List.empty[SocketEvent]
-        }
-      }
-    }
+    //     withClue("No events should be emitted after socket has been closed") {
+    //       stream.waitForEvents(2.seconds) mustBe List.empty[SocketEvent]
+    //     }
+    //   }
+    // }
   }
 
 


### PR DESCRIPTION
Same as #534 (see that PR for detailed description) with the only difference relating to tests: this removes the (unstable, not well-maintained) `"io.fabric8" "mockwebserver" `. Instead, this uses akka-http's real websocket server in the tests. 

Do you prefer this over #534  @marcoconti83 @CalumMcCall ?