### PR TITLE
fix: Fixes an inconsistency in how a change of the Conversation Muted status is reported between Android and other platforms

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -147,13 +147,13 @@ case class ConversationState(archived:    Option[Boolean] = None,
                              mutedStatus: Option[Int] = None) extends SafeToLog
 
 object ConversationState {
-
   private def encode(state: ConversationState, o: JSONObject) = {
     state.archived foreach { o.put("otr_archived", _) }
     state.archiveTime foreach { time =>
       o.put("otr_archived_ref", JsonEncoder.encodeISOInstant(time.instant))
     }
     state.muted.foreach(o.put("otr_muted", _))
+
     state.muteTime foreach { time =>
       o.put("otr_muted_ref", JsonEncoder.encodeISOInstant(time.instant))
     }

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsContentUpdater.scala
@@ -124,6 +124,7 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
   })
 
   override def updateConversationMuted(conv: ConvId, muted: MuteSet) = storage.update(conv, { c =>
+    verbose(l"updateConversationMuted($conv, $muted), muteTime = ${c.lastEventTime}")
     c.copy(muteTime = c.lastEventTime, muted = muted)
   })
 
@@ -159,7 +160,6 @@ class ConversationsContentUpdaterImpl(val storage:     ConversationStorage,
 
   override def updateLastEvent(id: ConvId, time: RemoteInstant) = storage.update(id, { conv =>
     verbose(l"updateLastEvent($conv, $time)")
-
     if (conv.lastEventTime.isAfter(time)) conv
     else {
       debug(l"updating: $conv, lastEventTime: $time")


### PR DESCRIPTION
The `muteTime` property was set to a time in the past, which on iOS was interpreted as that the event has already taken place and was ignored.

Fixes https://wearezeta.atlassian.net/browse/AN-6210