### PR TITLE
fix: Ignore markdown links

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -43,6 +43,7 @@ import org.threeten.bp.Instant.now
 
 import scala.collection.breakOut
 import scala.concurrent.duration._
+import scala.util.matching.Regex
 
 case class MessageData(override val id:   MessageId              = MessageId(),
                        convId:            ConvId                 = ConvId(),
@@ -117,16 +118,13 @@ case class MessageData(override val id:   MessageId              = MessageId(),
 
   def hasMentionOf(userId: UserId): Boolean = mentions.exists(_.userId.forall(_ == userId)) // a mention with userId == None is a "mention" of everyone, so it counts
 
-  lazy val imageDimensions: Option[Dim2] = {
-    val dims = protos.collectFirst {
+  lazy val imageDimensions: Option[Dim2] =
+    protos.collectFirst {
       case GenericMessageContent(Asset(AssetData.WithDimensions(d), _)) => d
       case GenericMessageContent(ImageAsset(AssetData.WithDimensions(d))) => d
     } orElse content.headOption.collect {
       case MessageContent(_, _, _, _, Some(_), w, h, _, _) => Dim2(w, h)
     }
-    verbose(l"dims $dims")
-    dims
-  }
 
   lazy val location =
     protos.collectFirst {
@@ -286,13 +284,18 @@ object MessageContent extends ((Message.Part.Type, String, Option[MediaAssetData
 object MessageData extends
   ((MessageId, ConvId, Message.Type, UserId, Seq[MessageContent], Seq[GenericMessage], Boolean, Set[UserId], Option[UserId],
     Option[String], Option[Name], Message.Status, RemoteInstant, LocalInstant, RemoteInstant, Option[FiniteDuration],
-    Option[LocalInstant], Boolean, Option[FiniteDuration], Option[QuoteContent], Option[Int]) => MessageData) {
+    Option[LocalInstant], Boolean, Option[FiniteDuration], Option[QuoteContent], Option[Int]) => MessageData)  with DerivedLogTag {
 
   val Empty = new MessageData(MessageId(""), ConvId(""), Message.Type.UNKNOWN, UserId(""))
   val Deleted = new MessageData(MessageId(""), ConvId(""), Message.Type.UNKNOWN, UserId(""), state = Message.Status.DELETED)
   val isUserContent = Set(TEXT, TEXT_EMOJI_ONLY, ASSET, ANY_ASSET, VIDEO_ASSET, AUDIO_ASSET, RICH_MEDIA, LOCATION, KNOCK)
 
   val EphemeralMessageTypes = Set(TEXT, TEXT_EMOJI_ONLY, KNOCK, ASSET, ANY_ASSET, VIDEO_ASSET, AUDIO_ASSET, RICH_MEDIA, LOCATION)
+
+  // A markdown link looks like that: [place for the text](here.goes.the.link)
+  // Links of this type will be handled by our Markdown library, we should ignore them here.
+  val markdownLinkPattern = """\[.+?\]\((.+?)\)""".r
+  val markdownReferencePattern = """(?m)^\[.+?\]:\s*(\S+)(\s+\".+\")?$""".r
 
   type MessageState = Message.Status
   import GenericMessage._
@@ -488,15 +491,19 @@ object MessageData extends
 
         val res = new MessageContentBuilder
 
-        val end = links.sortBy(_.urlOffset).foldLeft(0) { case (prevEnd, link) =>
-          if (link.urlOffset > prevEnd) res ++= RichMediaContentParser.splitContent(message.substring(prevEnd, link.urlOffset), mentions, prevEnd)
+        val markdownLinks = markdownLinkPattern.findAllMatchIn(message).map(_.group(1)).toSet ++ markdownReferencePattern.findAllMatchIn(message).map(_.group(1)).toSet
+        verbose(l"ignored markdown links: $markdownLinks")
 
-          returning(linkEnd(link.urlOffset)) { end =>
-            if (end > link.urlOffset) {
-              val openGraph = Option(link.getArticle).map { a => OpenGraphData(a.title, a.summary, None, "", Option(a.permanentUrl).filter(_.nonEmpty).map(URI.parse)) }
-              res += MessageContent(Message.Part.Type.WEB_LINK, message.substring(link.urlOffset, end), openGraph)
+        val end = links.filterNot(l => markdownLinks.contains(l.url)).sortBy(_.urlOffset).foldLeft(0) {
+          case (prevEnd, link) =>
+            if (link.urlOffset > prevEnd) res ++= RichMediaContentParser.splitContent(message.substring(prevEnd, link.urlOffset), mentions, prevEnd)
+
+            returning(linkEnd(link.urlOffset)) { end =>
+              if (end > link.urlOffset) {
+                val openGraph = Option(link.getArticle).map { a => OpenGraphData(a.title, a.summary, None, "", Option(a.permanentUrl).filter(_.nonEmpty).map(URI.parse)) }
+                res += MessageContent(Message.Part.Type.WEB_LINK, message.substring(link.urlOffset, end), openGraph)
+              }
             }
-          }
         }
 
         if (end < message.length) res ++= RichMediaContentParser.splitContent(message.substring(end), mentions, end)


### PR DESCRIPTION
There should be no preview displayed for a markdown link. Unfortunately, we parse the message data in SE and here we prepare links to be displayed with previews, but only much later in UI we apply markdown. When the parsed link part of the message is displayed in UI we no longer know that originally it was a markdown link, and it's difficult to find it out at that point.
Instead, I decided to ignore markdown links during the parsing in SE. It's a bit hacky (now even if there
was no markdown handling in UI we would still not display the preview), but it's much easier and faster.