### PR TITLE
chore: Logs for better investigation of the sync process

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
+++ b/zmessaging/src/main/scala/com/waz/content/ConvMessagesIndex.scala
@@ -70,8 +70,8 @@ class ConvMessagesIndex(convId: ConvId, messages: MessagesStorageImpl, selfUserI
     val lastMessageFromOther: Signal[Option[MessageData]] = returning(sources.lastMessageFromOther)(_.disableAutowiring())
 
     val unreadCount = for {
-      time <- sources.lastReadTime
-      _ <- Signal.wrap(LocalInstant.Epoch, indexChanged.map(_.time)).throttle(500.millis)
+      time   <- sources.lastReadTime
+      _      <- Signal.wrap(LocalInstant.Epoch, indexChanged.map(_.time)).throttle(500.millis)
       unread <- Signal.future(messages.countUnread(convId, time))
     } yield unread
 

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -514,7 +514,7 @@ object MessageData extends
 
         if (end < message.length) res ++= RichMediaContentParser.splitContent(message.substring(end), mentions, end)
 
-        (Message.Type.RICH_MEDIA, res.result())
+        (Message.Type.RICH_MEDIA, res.result)
       }
     }
 

--- a/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ConnectionService.scala
@@ -69,7 +69,6 @@ class ConnectionServiceImpl(selfUserId:      UserId,
   }
 
   def handleUserConnectionEvents(events: Seq[UserConnectionEvent]) = {
-    verbose(l"handleUserConnectionEvents: $events")
     def updateOrCreate(event: UserConnectionEvent)(user: Option[UserData]): UserData =
       user.fold {
         UserData(event.to, None, event.fromUserName.getOrElse(Name.Empty), None, None, connection = event.status, conversation = Some(event.convId), connectionMessage = event.message, searchKey = SearchKey.Empty, connectionLastUpdated = event.lastUpdated,

--- a/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/GenericMessageService.scala
@@ -38,7 +38,6 @@ class GenericMessageService(selfUserId: UserId,
   import com.waz.threading.Threading.Implicits.Background
 
   val eventProcessingStage = EventScheduler.Stage[GenericMessageEvent] { (_, events) =>
-    verbose(l"got events: ${events.map(_.from)}")
 
     def lastForConv(items: Seq[(RConvId, RemoteInstant)]) = items.groupBy(_._1).map { case (conv, times) => times.maxBy(_._2.toEpochMilli) }
 

--- a/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/service/call/CallingServiceImpl.scala
@@ -515,9 +515,10 @@ class CallingServiceImpl(val accountId:       UserId,
     }("setVideoSendState")
 
   val callMessagesStage: Stage.Atomic = EventScheduler.Stage[CallMessageEvent] {
-    case (_, events) => Future.successful(events.sortBy(_.time).foreach { e =>
-      receiveCallEvent(e.content, e.time, e.convId, e.from, e.sender)
-    })
+    case (_, events) =>
+      Future.successful(events.sortBy(_.time).foreach { e =>
+        receiveCallEvent(e.content, e.time, e.convId, e.from, e.sender)
+      })
   }
 
   private def receiveCallEvent(msg: String, msgTime: RemoteInstant, convId: RConvId, from: UserId, sender: ClientId): Unit =

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationOrderEventsService.scala
@@ -81,10 +81,10 @@ class ConversationOrderEventsService(selfUserId: UserId,
       case _ => shouldChangeOrder(event)
     }
 
-  val conversationOrderEventsStage: Stage.Atomic = EventScheduler.Stage[ConversationEvent] { (convId, es) =>
+  val conversationOrderEventsStage: Stage.Atomic = EventScheduler.Stage[ConversationEvent] { (convId, events) =>
 
-    val orderChanges    = processConversationOrderEvents(convId, es.filter(shouldChangeOrder))
-    val unarchiveConvs  = processConversationUnarchiveEvents(convId, es.filter(shouldUnarchive))
+    val orderChanges    = processConversationOrderEvents(convId, events.filter(shouldChangeOrder))
+    val unarchiveConvs  = processConversationUnarchiveEvents(convId, events.filter(shouldUnarchive))
 
     for {
       _ <- orderChanges

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -114,7 +114,7 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
   }
 
   push.onHistoryLost { req =>
-    verbose(l"onSlowSyncNeeded($req)")
+    verbose(l"SYNC onSlowSyncNeeded($req)")
     // TODO: this is just very basic implementation creating empty message
     // This should be updated to include information about possibly missed changes
     // this message will be shown rarely (when notifications stream skips data)

--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsUiService.scala
@@ -400,9 +400,7 @@ class ConversationsUiServiceImpl(selfUserId:      UserId,
   } yield Some(msg)
 
   override def setLastRead(convId: ConvId, msg: MessageData): Future[Option[ConversationData]] = {
-
     def sendReadReceipts(from: RemoteInstant, to: RemoteInstant, readReceiptSettings: ReadReceiptSettings): Future[Seq[SyncId]] = {
-      verbose(l"sendReadReceipts($from, $to, $readReceiptSettings)")
       if (!readReceiptSettings.selfSettings && readReceiptSettings.convSetting.isEmpty) {
         Future.successful(Seq())
       } else {

--- a/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessagesContentUpdater.scala
@@ -132,16 +132,16 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
       }
     }
 
-  private[service] def addMessages(convId: ConvId, msgs: Seq[MessageData]): Future[Set[MessageData]] = {
-    verbose(l"addMessages: ${msgs.map(_.id)}")
-
+  private[service] def addMessages(convId: ConvId, msgs: Seq[MessageData]): Future[Set[MessageData]] =
     for {
       toAdd <- skipPreviouslyDeleted(msgs)
       (systemMsgs, contentMsgs) = toAdd.partition(_.isSystemMessage)
       sm <- addSystemMessages(convId, systemMsgs)
+      _  =  verbose(l"SYNC system messages added (${sm.size})")
       cm <- addContentMessages(convId, contentMsgs)
+      _  =  verbose(l"SYNC content messages added (${cm.size})")
     } yield sm.toSet ++ cm
-  }
+
 
   private def skipPreviouslyDeleted(msgs: Seq[MessageData]) =
     deletions.getAll(msgs.map(_.id)) map { deletions =>
@@ -182,6 +182,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
 
   private def addContentMessages(convId: ConvId, msgs: Seq[MessageData]): Future[Set[MessageData]] = {
     // merge data from multiple events in single message
+    verbose(l"SYNC addContentMessages($convId, ${msgs.map(_.id)})")
     def merge(msgs: Seq[MessageData]): MessageData = {
 
       def mergeLocal(m: MessageData, msg: MessageData) =
@@ -204,6 +205,7 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
 
       if (msgs.size == 1) msgs.head
       else msgs.reduce { (prev, msg) =>
+        verbose(l"msgs reduce from $prev to $msg")
         if (prev.isLocal && prev.userId == msg.userId) mergeLocal(prev, msg)
         else if (prev.userId == msg.userId) mergeMatching(prev, msg)
         else {
@@ -215,12 +217,15 @@ class MessagesContentUpdater(messagesStorage: MessagesStorage,
     }
 
     if (msgs.isEmpty) Future.successful(Set.empty)
-    else
-      messagesStorage.updateOrCreateAll (
-        msgs.groupBy(_.id).mapValues { data =>
-          { (prev: Option[MessageData]) => merge(prev.toSeq ++ data) }
-        }
-      )
+    else {
+      val grouped = msgs.groupBy(_.id).map {
+        case (id, data) => id -> { prev: Option[MessageData] => merge(prev.toSeq ++ data) }
+      }
+      verbose(l"SYNC before update or create all for ${msgs.size}")
+      returning(messagesStorage.updateOrCreateAll(grouped)) {
+        _.foreach(_ => verbose(l"SYNC after update or create all for ${msgs.size}"))
+      }
+    }
   }
 
   private[service] def addMessage(msg: MessageData): Future[Option[MessageData]] = addMessages(msg.convId, Seq(msg)).map(_.headOption)

--- a/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/queue/SyncExecutor.scala
@@ -61,7 +61,7 @@ class SyncExecutor(account:     UserId,
         withJob(execute)
       }.flatMap {
         case Retry(_) => apply(job)
-        case res => Future.successful(res)
+        case res      => Future.successful(res)
       }
     }
   }

--- a/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/CachedStorageImpl.scala
@@ -17,6 +17,8 @@
  */
 package com.waz.utils
 
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue}
+
 import android.support.v4.util.LruCache
 import com.waz.content.Database
 import com.waz.db.DaoIdOps
@@ -208,6 +210,8 @@ trait CachedStorage[K, V <: Identifiable[K]] {
   def onDeleted: EventStream[Seq[K]]
   def onChanged: EventStream[Seq[V]]
 
+  def blockStreams(block: Boolean): Unit
+
   protected def load(key: K)(implicit db: DB): Option[V]
   protected def load(keys: Set[K])(implicit db: DB): Seq[V]
   protected def save(values: Seq[V])(implicit db: DB): Unit
@@ -266,6 +270,29 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
   val onAdded = EventStream[Seq[V]]()
   val onUpdated = EventStream[Seq[(V, V)]]()
   val onDeleted = EventStream[Seq[K]]()
+
+  private val onAddedQueue:   BlockingQueue[Seq[V]]     = new LinkedBlockingQueue[Seq[V]]
+  private val onUpdatedQueue: BlockingQueue[Seq[(V,V)]] = new LinkedBlockingQueue[Seq[(V,V)]]
+  private val onDeletedQueue: BlockingQueue[Seq[K]]     = new LinkedBlockingQueue[Seq[K]]
+  private var streamsBlocked = false
+
+  override def blockStreams(block: Boolean): Unit = if (block != streamsBlocked) {
+    if (!block) {
+      while(!onAddedQueue.isEmpty) onAdded ! onAddedQueue.take()
+      while(!onUpdatedQueue.isEmpty) onUpdated ! onUpdatedQueue.take()
+      while(!onDeletedQueue.isEmpty) onDeleted ! onDeletedQueue.take()
+    }
+    streamsBlocked = block
+  }
+
+  private def tellAdded(events: Seq[V]): Unit =
+    if (!streamsBlocked) onAdded ! events else onAddedQueue.put(events)
+
+  private def tellUpdated(events: Seq[(V,V)]): Unit =
+    if (!streamsBlocked) onUpdated ! events else onUpdatedQueue.put(events)
+
+  private def tellDeleted(events: Seq[K]): Unit =
+    if (!streamsBlocked) onDeleted ! events else onDeletedQueue.put(events)
 
   val onChanged = onAdded.union(onUpdated.map(_.map(_._2)))
 
@@ -400,7 +427,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
         if (updated.isEmpty) Future.successful(Vector.empty)
         else
           db(save(updated.map(_._2))(_)).future.map { _ =>
-            onUpdated ! updated
+            tellUpdated(updated)
             updated
           }
       }
@@ -443,8 +470,8 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
         val updatedResult = updated.result
 
         db(save(toSave.result)(_)).future.map { _ =>
-          if (addedResult.nonEmpty) onAdded ! addedResult
-          if (updatedResult.nonEmpty) onUpdated ! updatedResult
+          if (addedResult.nonEmpty) tellAdded(addedResult)
+          if (updatedResult.nonEmpty) tellUpdated(updatedResult)
           result
         }
       }
@@ -453,7 +480,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
   private def addInternal(key: K, value: V): Future[V] = {
     cache.put(key, Some(value))
     db(save(Seq(value))(_)).future.map { _ =>
-      onAdded ! Seq(value)
+      tellAdded(Seq(value))
       value
     }
   }
@@ -464,7 +491,7 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
     else {
       cache.put(key, Some(updated))
       db(save(Seq(updated))(_)).future.map { _ =>
-        onUpdated ! Seq((current, updated))
+        tellUpdated(Seq((current, updated)))
         Some((current, updated))
       }
     }
@@ -477,22 +504,16 @@ class CachedStorageImpl[K, V <: Identifiable[K]](cache: LruCache[K, Option[V]], 
   def remove(key: K): Future[Unit] = Future {
     cache.put(key, None)
     db(delete(Seq(key))(_)).future.map { _ =>
-      onDeleted ! Seq(key)
+      tellDeleted(Seq(key))
     }
   } .flatten
 
   def removeAll(keys: Iterable[K]): Future[Unit] = Future {
     keys foreach { key => cache.put(key, None) }
     db(delete(keys)(_)).future.map { _ =>
-      onDeleted ! keys.toVector
+      tellDeleted(keys.toVector)
     }
   } .flatten
-
-  private val changesStream = EventStream.union[Seq[ContentChange[K, V]]](
-    onAdded.map(_.map(d => Added(d.id, d))),
-    onUpdated.map(_.map { case (prv, curr) => Updated(prv.id, prv, curr) }),
-    onDeleted.map(_.map(Removed(_)))
-  )
 
   def cacheIfNotPresent(key: K, value: V) = cachedOrElse(key, Future {
     Option(cache.get(key)).getOrElse { returning(Some(value))(cache.put(key, _)) }

--- a/zmessaging/src/main/scala/com/waz/utils/EventProcessingQueue.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/EventProcessingQueue.scala
@@ -99,11 +99,14 @@ class SerialProcessingQueue[A](processor: Seq[A] => Future[Any], name: String = 
   } else
     Future.successful(())
 
-  protected def processQueue(): Future[Any] = post(processQueueNow())
+  protected def processQueue(): Future[Any] = {
+    verbose(l"SYNC processQueue")
+    post(processQueueNow())
+  }
 
   protected def processQueueNow(): Future[Any] = {
     val events = Iterator.continually(queue.poll()).takeWhile(_ != null).toVector
-    verbose(l"processQueueNow, events: ???")
+    verbose(l"SYNC processQueueNow, events: $events")
     if (events.nonEmpty) processor(events).recoverWithLog()
     else Future.successful(())
   }
@@ -126,7 +129,7 @@ class ThrottledProcessingQueue[A](delay: FiniteDuration, processor: Seq[A] => Fu
     if (waiting.compareAndSet(false, true)) {
       post {
         val d = math.max(0, lastDispatched - System.currentTimeMillis() + delay.toMillis)
-        verbose(l"processQueue, delaying: $d millis")
+        verbose(l"SYNC processQueue, delaying: $d millis")
         waitFuture = CancellableFuture.delay(d.millis)
         if (!waiting.get()) waitFuture.cancel()(logTag) // to avoid race conditions with `flush`
         waitFuture.future.flatMap { _ =>


### PR DESCRIPTION
All logs starting with 'SYNC' should be treated as temporary. They were added in order to investigate why sometimes the app gets stuck when syncing on initialization. They can be removed when the bug is fixed.
Apart form adding logs I made two changes:
1. In `Message contentUpdater.addContentMessages` I changed `msgs.mapValues` to `msgs.map`.  `mapValues` does not really map the values - it provides a wrapper with a mapping function, and the mapping takes places only when the value is accessed which may have side-effects. I'd like to gradually remove `mapValues` form the code.
2. In `CachedStorage` I added a functionality which blocks streams: `onAdded`, `onUpdated`, and `onDeleted`. During sync we add, update, and delete a lot of data. It might make sense to postpone sending events about it to the rest of the app until the whole process is done. Right now I use this functionality only when syncing messages. It might be helpful in fixing the stuck-on-sync bug - iff not, we can remove it later.