### PR TITLE
Fix: traversable show

### DIFF
--- a/zmessaging/src/main/scala/com/waz/log/LogShow.scala
+++ b/zmessaging/src/main/scala/com/waz/log/LogShow.scala
@@ -113,9 +113,9 @@ object LogShow {
   }
 
   implicit def traversableShow[T](implicit show: LogShow[T]): LogShow[Traversable[T]] = {
-    def createString(xs: Traversable[T], toString: T => String, elemsToPrint: Int = 3): String = {
+    def createString(xs: Traversable[T], obfuscate: T => String, elemsToPrint: Int = 3): String = {
       val end = if (xs.size > elemsToPrint) s" and ${xs.size - elemsToPrint} other elements..." else ""
-      xs.take(elemsToPrint).mkString("", ", ", end)
+      xs.take(elemsToPrint).map(e => obfuscate(e)).mkString("", ", ", end)
     }
 
     create(

--- a/zmessaging/src/test/scala/com/waz/log/ZLog2Spec.scala
+++ b/zmessaging/src/test/scala/com/waz/log/ZLog2Spec.scala
@@ -63,6 +63,15 @@ class ZLog2Spec extends ZSpec with DerivedLogTag {
       personLog.buildMessageUnsafe shouldBe s"person: ${nonImplicitPersonLogShow.showUnsafe(testPerson)}"
     }
 
-  }
+    scenario("compile and create Log for types in a collection") {
+      implicit val PersonLogShow: LogShow[Person] = new LogShow[Person] {
+        override def showSafe(value: Person): String   = "Safe"
+        override def showUnsafe(value: Person): String = "Unsafe"
+      }
 
+      val collectionLog = l"${List(testPerson, testPerson, testPerson, testPerson)}"
+      collectionLog.buildMessageSafe shouldBe "Safe, Safe, Safe and 1 other elements..."
+      collectionLog.buildMessageUnsafe shouldBe "Unsafe, Unsafe, Unsafe and 1 other elements..."
+    }
+  }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Collections were not being properly logged.

### Causes

The obfuscation function was not being applied before joining the elements into a string.

### Solutions

Apply the obfuscation function before joining the elements.

### Testing

Added a single unit test checking the outputs of logging a collection.