### PR TITLE
fix: read receipts not updating

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -211,6 +211,7 @@ object Event {
         case "user.client-add" => OtrClientAddEvent(OtrClient.ClientsResponse.client(js.getJSONObject("client")))
         case "user.client-remove" => OtrClientRemoveEvent(decodeId[ClientId]('id)(js.getJSONObject("client"), implicitly))
         case "user.properties-set" => PropertyEvent.Decoder(js)
+        case "user.properties-delete" => PropertyEvent.Decoder(js)
         case _ =>
           error(l"unhandled event: $js")
           UnknownEvent(js)
@@ -410,7 +411,11 @@ object PropertyEvent {
     override def apply(implicit js: JSONObject): PropertyEvent = {
       import PropertyKey._
       decodePropertyKey('key) match {
-        case ReadReceiptsEnabled => ReadReceiptEnabledPropertyEvent('value)
+        case ReadReceiptsEnabled => decodeString('type) match {
+          case "user.properties-set" => ReadReceiptEnabledPropertyEvent(1)
+          case "user.properties-delete" => ReadReceiptEnabledPropertyEvent(0)
+          case e => UnknownPropertyEvent(ReadReceiptsEnabled, e)
+        }
         case key => UnknownPropertyEvent(key, 'value)
       }
     }

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -412,7 +412,7 @@ object PropertyEvent {
       import PropertyKey._
       decodePropertyKey('key) match {
         case ReadReceiptsEnabled => decodeString('type) match {
-          case "user.properties-set" => ReadReceiptEnabledPropertyEvent(1)
+          case "user.properties-set" => ReadReceiptEnabledPropertyEvent('value)
           case "user.properties-delete" => ReadReceiptEnabledPropertyEvent(0)
           case e => UnknownPropertyEvent(ReadReceiptsEnabled, e)
         }

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -20,6 +20,7 @@ package com.waz.model
 import com.waz.model.Event.EventDecoder
 import com.waz.model.nano.Messages
 import com.waz.model.otr.ClientId
+import com.waz.service.PropertyKey
 import com.waz.specs.AndroidFreeSpec
 import com.waz.utils.JsonDecoder
 import org.json.JSONObject
@@ -47,6 +48,29 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       event.asInstanceOf[UserConnectionEvent].from should be(selfUser.id)
       event.asInstanceOf[UserConnectionEvent].lastUpdated should be(RemoteInstant.ofEpochMilli(JsonDecoder.parseDate("2014-06-12T10:04:02.047Z").getTime))
       event.asInstanceOf[UserConnectionEvent].message should be(Some("Hello Test"))
+    }
+
+    scenario("Read receipt off messages are parsed correctly") {
+      val userConectionEventData = new JSONObject(
+      s"""{
+         |  "key": "${PropertyKey.ReadReceiptsEnabled}",
+         |  "value": "0"
+         |}""".stripMargin)
+      val res = PropertyEvent.Decoder(userConectionEventData).asInstanceOf[ReadReceiptEnabledPropertyEvent]
+      res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true
+      res.asInstanceOf[ReadReceiptEnabledPropertyEvent].value shouldEqual 0
+    }
+
+    scenario("Read receipt on messages are parsed correctly") {
+      val userConectionEventData = new JSONObject(
+        s"""{
+           |  "key": "${PropertyKey.ReadReceiptsEnabled}",
+           |  "value": "1"
+           |}""".stripMargin)
+      val res = PropertyEvent.Decoder(userConectionEventData)
+        .asInstanceOf[ReadReceiptEnabledPropertyEvent]
+      res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true
+      res.asInstanceOf[ReadReceiptEnabledPropertyEvent].value shouldEqual 1
     }
 
     scenario("parse otr message event") {

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -51,24 +51,23 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
     }
 
     scenario("Read receipt off messages are parsed correctly") {
-      val userConectionEventData = new JSONObject(
+      val readReceiptJson = new JSONObject(
       s"""{
          |  "key": "${PropertyKey.ReadReceiptsEnabled}",
-         |  "value": "0"
+         |  "type": "user.properties-delete"
          |}""".stripMargin)
-      val res = PropertyEvent.Decoder(userConectionEventData).asInstanceOf[ReadReceiptEnabledPropertyEvent]
+      val res = PropertyEvent.Decoder(readReceiptJson)
       res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true
       res.asInstanceOf[ReadReceiptEnabledPropertyEvent].value shouldEqual 0
     }
 
     scenario("Read receipt on messages are parsed correctly") {
-      val userConectionEventData = new JSONObject(
+      val readReceiptData = new JSONObject(
         s"""{
            |  "key": "${PropertyKey.ReadReceiptsEnabled}",
-           |  "value": "1"
+           |  "type": "user.properties-set"
            |}""".stripMargin)
-      val res = PropertyEvent.Decoder(userConectionEventData)
-        .asInstanceOf[ReadReceiptEnabledPropertyEvent]
+      val res = PropertyEvent.Decoder(readReceiptData)
       res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true
       res.asInstanceOf[ReadReceiptEnabledPropertyEvent].value shouldEqual 1
     }

--- a/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/model/EventSpec.scala
@@ -54,7 +54,8 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       val readReceiptJson = new JSONObject(
       s"""{
          |  "key": "${PropertyKey.ReadReceiptsEnabled}",
-         |  "type": "user.properties-delete"
+         |  "type": "user.properties-delete",
+         |  "value": "0"
          |}""".stripMargin)
       val res = PropertyEvent.Decoder(readReceiptJson)
       res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true
@@ -65,7 +66,8 @@ class EventSpec extends AndroidFreeSpec with GivenWhenThen {
       val readReceiptData = new JSONObject(
         s"""{
            |  "key": "${PropertyKey.ReadReceiptsEnabled}",
-           |  "type": "user.properties-set"
+           |  "type": "user.properties-set",
+           |  "value": "1"
            |}""".stripMargin)
       val res = PropertyEvent.Decoder(readReceiptData)
       res.isInstanceOf[ReadReceiptEnabledPropertyEvent] shouldEqual true


### PR DESCRIPTION
### Issues

This commit adds missing support for updating local read receipt setting when it's changed on another client. This fixes a [related issue](https://wearezeta.atlassian.net/browse/AN-6110) where the popup notifying of the change was not displaying.

### Causes

I think this small detail was simply left out during implementation of this feature

### Solutions

The missing event type decoding has been implemented.

### Testing

Manual testing has been done. The option was toggled using a web client whilst the correct behaviour was observed on the device.