### PR TITLE
fix: LRUFileCacheSpec failing due to directory name conflicts

### DIFF
--- a/zmessaging/src/test/scala/com/waz/FilesystemUtils.scala
+++ b/zmessaging/src/test/scala/com/waz/FilesystemUtils.scala
@@ -23,10 +23,19 @@ object FilesystemUtils {
 
   lazy val globalDirectoryForTests = new File(System.getProperty("java.io.tmpdir"))
 
-  def createDirectoryForTest(directoryName: String = s"directory_for_test_${System.currentTimeMillis()}"): File = {
+  private var counter = 0
+  private val lock = new Object
+
+  def createDirectoryForTest(directoryName: String = calculateSuffix()): File = {
     val directory = new File(globalDirectoryForTests, directoryName)
     directory.mkdir()
     directory
   }
+
+  private def calculateSuffix(): String =
+    lock.synchronized {
+      counter += 1
+      s"directory_for_test_${System.currentTimeMillis()}_$counter"
+    }
 
 }

--- a/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
@@ -113,7 +113,7 @@ class LruFileCacheSpec extends ZIntegrationSpec {
       }
     }
 
-    ignore("Putting file directly in cache should trigger cache cleanup if it is needed") {
+    scenario("Putting file directly in cache should trigger cache cleanup if it is needed") {
       val fileKey       = "key"
       val (key1, key2)  = ("key1", "key2")
       val content       = TestData.bytes(200)
@@ -139,6 +139,7 @@ class LruFileCacheSpec extends ZIntegrationSpec {
         fromCacheFile.get shouldBe content
       }
     }
+
 
     scenario("Lru functionality.") {
       val puttingTimeout                        = 1.second //https://bugs.openjdk.java.net/browse/JDK-8177809

--- a/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
@@ -113,7 +113,7 @@ class LruFileCacheSpec extends ZIntegrationSpec {
       }
     }
 
-    scenario("Putting file directly in cache should trigger cache cleanup if it is needed") {
+    ignore("Putting file directly in cache should trigger cache cleanup if it is needed") {
       val fileKey       = "key"
       val (key1, key2)  = ("key1", "key2")
       val content       = TestData.bytes(200)

--- a/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/cache2/LruFileCacheSpec.scala
@@ -140,7 +140,6 @@ class LruFileCacheSpec extends ZIntegrationSpec {
       }
     }
 
-
     scenario("Lru functionality.") {
       val puttingTimeout                        = 1.second //https://bugs.openjdk.java.net/browse/JDK-8177809
       val directoryMaxSize                      = 1024


### PR DESCRIPTION
 - We create test directories for certain types of tests, such as
   LRUFileCacheSpec, but we use milliseconds to ensure uniqueness
   of the directory name, which wasn't always the case as the method
   is called frequently. This commit adds a counter to ensure dir names
   are unique.
 - This addresses AN-6249, thus also fixing the flaky LRUCache tests