### PR TITLE
Fix: team sync

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -31,6 +31,9 @@ case class TeamData(override val id: TeamId,
 
 object TeamData {
 
+  def apply(id: String, name: String, creator: String, icon: Option[String], iconKey: Option[String]): TeamData =
+    TeamData(TeamId(id), Name(name), UserId(creator), icon.map(i => RAssetId(i)), iconKey.map(i => AESKey(i)))
+
   implicit lazy val Decoder: JsonDecoder[TeamData] = new JsonDecoder[TeamData] {
     override def apply(implicit js: JSONObject): TeamData = {
       import JsonDecoder._

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -60,11 +60,17 @@ class TeamsClientImpl(implicit
   }
 
   override def getTeamData(id: TeamId): ErrorOrResponse[TeamData] = {
-
     Request.Get(relativePath = teamPath(id))
-      .withResultType[TeamData]
+      .withResultType[TeamDataResponse]
       .withErrorType[ErrorResponse]
-      .executeSafe
+      .executeSafe { response =>
+        TeamData(
+          response.id,
+          response.name,
+          response.creator,
+          Some(response.icon),
+          response.icon_key)
+      }
   }
 
   override def getPermissions(teamId: TeamId, userId: UserId): ErrorOrResponse[Option[PermissionsMasks]] = {
@@ -114,6 +120,8 @@ object TeamsClient {
           None
       }
   }
+
+  case class TeamDataResponse(id: String, name: String, creator: String, icon: String, icon_key: Option[String])
 
   case class TeamMembers(members: Seq[TeamMember])
 

--- a/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -20,7 +20,7 @@ package com.waz.sync.client
 import com.waz.model.UserPermissions._
 import com.waz.model.UserPermissions.Permission._
 import com.waz.specs.AndroidFreeSpec
-import com.waz.sync.client.TeamsClient.TeamMembers
+import com.waz.sync.client.TeamsClient.{TeamDataResponse, TeamMembers}
 import com.waz.utils.CirceJSONSupport
 
 //TODO Replace with integration test when AuthRequestInterceptor2 is introduced
@@ -58,7 +58,17 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
       println(result)
     }
 
+    scenario("Team data response decoding") {
+      import io.circe.parser._
+      val response = "{\"creator\":\"d22b442c-8a91-4773-8655-4d72b49b8c70\",\"icon\":\"abc\",\"name\":\"Potato\",\"id\":\"ddaad665-9227-4bd3-93d6-a3450bfbbfc7\",\"binding\": true,\"icon_key\": \"abcdefg\"}"
+      val result = decode[TeamDataResponse](response)
+
+      result shouldEqual Right(TeamDataResponse(
+        "ddaad665-9227-4bd3-93d6-a3450bfbbfc7",
+        "Potato",
+        "d22b442c-8a91-4773-8655-4d72b49b8c70",
+        "abc",
+        Some("abcdefg")))
+    }
   }
-
-
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app would sometimes get stuck in a sync loop. When syncing team data, the response from the backend would fail to decode. This caused the team sync to fail, but the request would continuously retry.

### Causes

The Circe json parser would fail to decode the response object from the backend. We use auto derivation to encode/decode json objects. In order for it to work, we must provide a data class the exactly models the json response object (though, only for the properties that we care about). 

In this specific case, the `TeamData` object is being used to model a response, however it contains inconsistent property names and data types for those properties. 

### Solutions

Provide a `TeamDataResponse` object to specifically model the response. Then convert the response object to a `TeamData` instance once decoding completes.

### Testing

A single unit test to decode the json response from the backend.

## Notes

The bigger issue here is that `TeamData` is a domain object and shouldn't have anything to do with backend responses. Client objects communicating with the backend should have their own response models, which should then be converted to the corresponding domain object. Enforcing the separation will help to avoid such critical bugs in the future, as changes to the domain objects would not affect how responses from the backend are decoded.

## Bonus

As a bonus, this also fixes a bug where the team icon is not displayed.