### PR TITLE
Fix: Remove duplicate SQL command

### DIFF
--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -371,7 +371,6 @@ object ZMessagingDB {
             m
         }
       }
-      db.execSQL("ALTER TABLE Users ADD COLUMN managed_by TEXT DEFAULT null")
     }
   )
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

If the app is upgrade from a version built around 7th June, the app would launch to a black screen and it would be impossible to recover.

### Causes

The assets refactoring contained a database migration which unfortunately duplicated an SQL command already existing in the migration from `ZMessageDB` version 113 to 114. When the migration from 120 to 121 (for assets) occurred, it would fail and subsequently the database is left in an inconsistent state. Unfortunately this is not recoverable.

### Solutions

Remove the duplicated command.

### Testing

Tested manually.
