### PR TITLE
fix: opening convs with bots works again

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -50,6 +50,7 @@ trait ConversationsService {
   def processConversationEvent(ev: ConversationStateEvent, selfUserId: UserId, retryCount: Int = 0): Future[Any]
   def getSelfConversation: Future[Option[ConversationData]]
   def updateConversationsWithDeviceStartMessage(conversations: Seq[ConversationResponse]): Future[Unit]
+  def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit]
   def setConversationArchived(id: ConvId, archived: Boolean): Future[Option[ConversationData]]
   def setReceiptMode(id: ConvId, receiptMode: Int): Future[Option[ConversationData]]
   def forceNameUpdate(id: ConvId): Future[Option[(ConversationData, ConversationData)]]
@@ -307,6 +308,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     } yield
       (convs.toSeq, created)
   }
+
+  def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit] =
+    convsStorage.update(id, c => c.copy(remoteId = remoteId)).map(_ => ())
 
   def setConversationArchived(id: ConvId, archived: Boolean) = content.updateConversationArchived(id, archived) flatMap {
     case Some((_, conv)) =>

--- a/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/handler/ConversationsSyncHandler.scala
@@ -151,9 +151,11 @@ class ConversationsSyncHandler(selfUserId:          UserId,
     val initState = ConversationInitState(users = toCreate, name = name, team = team, access = access, accessRole = accessRole, receiptMode = receiptMode)
     conversationsClient.postConversation(initState).future.flatMap {
       case Right(response) =>
-        convService.updateConversationsWithDeviceStartMessage(Seq(response)).flatMap { _ =>
-          if (toAdd.nonEmpty) postConversationMemberJoin(convId, toAdd)
-          else Future.successful(Success)
+        convService.updateRemoteId(convId, response.id).flatMap { _ =>
+          convService.updateConversationsWithDeviceStartMessage(Seq(response)).flatMap { _ =>
+            if (toAdd.nonEmpty) postConversationMemberJoin(convId, toAdd)
+            else Future.successful(Success)
+          }
         }
       case Left(resp@ErrorResponse(403, msg, "not-connected")) =>
         warn(l"got error: $resp")


### PR DESCRIPTION
## What's new in this PR?

### Issues

Fixes AN-6162. The issue is that opening a conversation with a bot always failed, although I did get it to work occasionally in testing. It's possible this PR will also address the duplicate conversation issue we were having, since everytime creating a conv with a bot fails, we create an empty conversation which is never used again.

### Causes

The cause was that `ConversationsService.updateConversations` doesn't handle updating the remoteId properly. This is because despite the method's name, it doesn't handle updating conversations in the general case. It relies on being able to find the conversation through various means, but none of these work in the case of creating conversations for bots, since those conversations have random or duplicate Ids, in the case of the `ConvId` and `RConvId` respectively.

### Solutions

For now, I've separated the updating of the remoteId into a separate method, since it's only used in one place and doesn't need to be rolled into `updateConversations`.

### Testing

It was tested manually, where I can reproduce it pretty reliably, I tested it several times.

## Notes

`updateConversations` needs to be rewritten or at least simplified. It's complex and hard to follow, and tries to do a million things at once. It's being used as a generic way to do all conversation updates, but we do too many different types of updates to be handled by one method. It also makes it very brittle. It's not clear why it doesn't simply take `ConvId` parameters in the first place, since elsewhere we pass around `Map[ConvId, ConversationData]` objects. If `ConvId` really isn't/aren't available, then that logic should be a separate method, to keep the size and complexity of the methods down.

