### PR TITLE
fix: name updating for memberless conversations

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/conversation/ConversationsService.scala
@@ -53,7 +53,7 @@ trait ConversationsService {
   def updateRemoteId(id: ConvId, remoteId: RConvId): Future[Unit]
   def setConversationArchived(id: ConvId, archived: Boolean): Future[Option[ConversationData]]
   def setReceiptMode(id: ConvId, receiptMode: Int): Future[Option[ConversationData]]
-  def forceNameUpdate(id: ConvId): Future[Option[(ConversationData, ConversationData)]]
+  def forceNameUpdate(id: ConvId, defaultName: String): Future[Option[(ConversationData, ConversationData)]]
   def onMemberAddFailed(conv: ConvId, users: Set[UserId], error: Option[ErrorType], resp: ErrorResponse): Future[Unit]
   def groupConversation(convId: ConvId): Signal[Boolean]
   def isGroupConversation(convId: ConvId): Future[Boolean]
@@ -332,9 +332,9 @@ class ConversationsServiceImpl(teamId:          Option[TeamId],
     _ <- msgContent.deleteMessagesForConversation(convId: ConvId)
   } yield ()
 
-  def forceNameUpdate(id: ConvId) = {
+  def forceNameUpdate(id: ConvId, defaultName: String) = {
     warn(l"forceNameUpdate($id)")
-    nameUpdater.forceNameUpdate(id)
+    nameUpdater.forceNameUpdate(id, defaultName)
   }
 
   def onMemberAddFailed(conv: ConvId, users: Set[UserId], error: Option[ErrorType], resp: ErrorResponse) = for {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The logs were getting spammed full of "forceNameUpdate" messages. See [AN-6259](https://wearezeta.atlassian.net/browse/AN-6259).

### Causes

Conversations with only the self user were not getting their generated name set correctly, resulting in attempts to update their name every time the conversation list was scrolled. This was due to the user list being empty after the self user was filtered out, resulting in an empty name, which would generate the `forceNameUpdate` again later.

### Solutions

A check was added for the case where the conversation members are only the self user. In this case, a  default name is used.

### Testing

This was tested manually, and the logs are now cleaner. A unit test is unfortunately not possible in this case, as the generated name is provided inside a closure as an argument to `ConversationStorage.update`, ([see here](https://github.com/wireapp/wire-android-sync-engine/pull/562/files#diff-4583cf16f7ca97f70a7e81403050e864R130)) and thus can't be checked for equality using the testing framework we use. It might be possible to find a workaround.
