### PR TITLE
fix: An update of the profile picture is propagated to other users

### DIFF
--- a/zmessaging/src/main/scala/com/waz/model/UserData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/UserData.scala
@@ -21,13 +21,13 @@ import com.waz.api.Verification
 import com.waz.db.Col._
 import com.waz.db.Dao
 import com.waz.model
-import com.waz.model.UserData.{ConnectionStatus, Picture}
+import com.waz.model.AssetMetaData.Image.Tag.Medium
 import com.waz.model.ManagedBy.ManagedBy
-import com.waz.model.UserData.ConnectionStatus
+import com.waz.model.UserData.{ConnectionStatus, Picture}
 import com.waz.model.UserPermissions._
 import com.waz.service.SearchKey
-import com.waz.service.assets2.StorageCodecs
 import com.waz.service.UserSearchService.UserSearchEntry
+import com.waz.service.assets2.StorageCodecs
 import com.waz.utils._
 import com.waz.utils.wrappers.{DB, DBCursor}
 
@@ -74,31 +74,31 @@ case class UserData(override val id:       UserId,
 
   def updated(user: UserInfo): UserData = updated(user, withSearchKey = true)
   def updated(user: UserInfo, withSearchKey: Boolean): UserData = copy(
-    name = user.name.getOrElse(name),
-    email = user.email.orElse(email),
-    phone = user.phone.orElse(phone),
-    accent = user.accentId.getOrElse(accent),
-    trackingId = user.trackingId.orElse(trackingId),
-    searchKey = SearchKey(if (withSearchKey) user.name.getOrElse(name).str else ""),
-    picture = user.mediumPicture.map(p => Picture.Uploaded(p.id)).orElse(picture),
-    deleted = user.deleted,
-    handle = user.handle match {
+    name          = user.name.getOrElse(name),
+    email         = user.email.orElse(email),
+    phone         = user.phone.orElse(phone),
+    accent        = user.accentId.getOrElse(accent),
+    trackingId    = user.trackingId.orElse(trackingId),
+    searchKey     = SearchKey(if (withSearchKey) user.name.getOrElse(name).str else ""),
+    picture       = user.picture.flatMap(_.collectFirst { case p if p.tag == Medium => Picture.Uploaded(p.id) }).orElse(picture),
+    deleted       = user.deleted,
+    providerId    = user.service.map(_.provider).orElse(providerId),
+    integrationId = user.service.map(_.id).orElse(integrationId),
+    expiresAt     = user.expiresAt.orElse(expiresAt),
+    teamId        = user.teamId.orElse(teamId),
+    managedBy     = user.managedBy.orElse(managedBy),
+    fields        = user.fields.getOrElse(fields),
+    handle        = user.handle match {
       case Some(h) if !h.toString.isEmpty => Some(h)
       case _ => handle
-    },
-    providerId = user.service.map(_.provider).orElse(providerId),
-    integrationId = user.service.map(_.id).orElse(integrationId),
-    expiresAt = user.expiresAt.orElse(expiresAt),
-    teamId = user.teamId.orElse(teamId),
-    managedBy = user.managedBy.orElse(managedBy),
-    fields = user.fields.getOrElse(fields)
+    }
   )
 
   def updated(user: UserSearchEntry): UserData = copy(
-    name = user.name,
+    name      = user.name,
     searchKey = SearchKey(user.name),
-    accent = user.colorId.getOrElse(accent),
-    handle = Some(user.handle)
+    accent    = user.colorId.getOrElse(accent),
+    handle    = Some(user.handle)
   )
 
   def updateConnectionStatus(status: UserData.ConnectionStatus, time: Option[RemoteInstant] = None, message: Option[String] = None): UserData = {

--- a/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
+++ b/zmessaging/src/main/scala/com/waz/model/sync/SyncRequest.scala
@@ -116,7 +116,7 @@ object SyncRequest {
     override val mergeKey: Any = (cmd, messageId)
   }
 
-  case class PostSelfPicture(assetId: Option[AssetId]) extends BaseRequest(Cmd.PostSelfPicture) {
+  case class PostSelfPicture(assetId: UploadAssetId) extends BaseRequest(Cmd.PostSelfPicture) {
     override def merge(req: SyncRequest) = mergeHelper[PostSelfPicture](req)(Merged(_))
   }
 
@@ -351,7 +351,7 @@ object SyncRequest {
           case Cmd.PostCleared               => PostCleared(convId, 'time)
           case Cmd.PostTypingState           => PostTypingState(convId, 'typing)
           case Cmd.PostConnectionStatus      => PostConnectionStatus(userId, opt('status, js => ConnectionStatus(js.getString("status"))))
-          case Cmd.PostSelfPicture           => PostSelfPicture(decodeOptAssetId('asset))
+          case Cmd.PostSelfPicture           => PostSelfPicture(decodeUploadAssetId('asset))
           case Cmd.PostSelfName              => PostSelfName('name)
           case Cmd.PostSelfAccentColor       => PostSelfAccentColor(AccentColor(decodeInt('color)))
           case Cmd.PostAvailability          => PostAvailability(Availability(decodeInt('availability)))
@@ -428,7 +428,7 @@ object SyncRequest {
         case DeletePushToken(token)           => putId("token", token)
         case RegisterPushToken(token)         => putId("token", token)
         case SyncRichMedia(messageId)         => putId("message", messageId)
-        case PostSelfPicture(assetId)         => assetId.foreach(putId("asset", _))
+        case PostSelfPicture(assetId)         => putId("asset", assetId)
         case PostSelfName(name)               => o.put("name", name)
         case PostSelfAccentColor(color)       => o.put("color", color.id)
         case PostAvailability(availability)   => o.put("availability", availability.id)

--- a/zmessaging/src/main/scala/com/waz/service/UserService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/UserService.scala
@@ -327,7 +327,7 @@ class UserServiceImpl(selfUserId:        UserId,
     val contentForUpload = ContentForUpload("profile-picture", content)
     for {
       asset <- assets.createAndSaveUploadAsset(contentForUpload, NoEncryption, public = true, Retention.Eternal, None)
-      _ <- updateAndSync(_.copy(picture = Some(Picture.NotUploaded(asset.id))), _ => sync.postSelfPicture(None))
+      _     <- updateAndSync(_.copy(picture = Some(Picture.NotUploaded(asset.id))), _ => sync.postSelfPicture(asset.id))
     } yield ()
   }
 

--- a/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/SyncServiceHandle.scala
@@ -54,7 +54,7 @@ trait SyncServiceHandle {
   def postRemoveBot(cId: ConvId, botId: UserId): Future[SyncId]
 
   def postSelfUser(info: UserInfo): Future[SyncId]
-  def postSelfPicture(picture: Option[AssetId]): Future[SyncId]
+  def postSelfPicture(picture: UploadAssetId): Future[SyncId]
   def postSelfName(name: Name): Future[SyncId]
   def postSelfAccentColor(color: AccentColor): Future[SyncId]
   def postAvailability(status: Availability): Future[SyncId]
@@ -136,7 +136,7 @@ class AndroidSyncServiceHandle(account: UserId, service: SyncRequestService, tim
   def syncRichMedia(id: MessageId, priority: Int = Priority.MinPriority) = addRequest(SyncRichMedia(id), priority = priority)
 
   def postSelfUser(info: UserInfo) = addRequest(PostSelf(info))
-  def postSelfPicture(picture: Option[AssetId]) = addRequest(PostSelfPicture(picture))
+  def postSelfPicture(picture: UploadAssetId) = addRequest(PostSelfPicture(picture))
   def postSelfName(name: Name) = addRequest(PostSelfName(name))
   def postSelfAccentColor(color: AccentColor) = addRequest(PostSelfAccentColor(color))
   def postAvailability(status: Availability) = addRequest(PostAvailability(status))
@@ -236,7 +236,7 @@ class AccountSyncHandler(accounts: AccountsService) extends SyncHandler {
           case SyncSelfPermissions                                 => zms.teamsSync.syncSelfPermissions()
           case DeleteAccount                                       => zms.usersSync.deleteAccount()
           case PostSelf(info)                                      => zms.usersSync.postSelfUser(info)
-          case PostSelfPicture(_)                                  => zms.usersSync.postSelfPicture()
+          case PostSelfPicture(assetId)                            => zms.usersSync.postSelfPicture(assetId)
           case PostSelfName(name)                                  => zms.usersSync.postSelfName(name)
           case PostSelfAccentColor(color)                          => zms.usersSync.postSelfAccentColor(color)
           case PostAvailability(availability)                      => zms.usersSync.postAvailability(availability)

--- a/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/JsonDecoder.scala
@@ -194,6 +194,7 @@ object JsonDecoder {
   implicit def decodeClientId(s: Symbol)(implicit js: JSONObject): ClientId = ClientId(js.getString(s.name))
   implicit def decodeRConvId(s: Symbol)(implicit js: JSONObject): RConvId = RConvId(js.getString(s.name))
   implicit def decodeAssetId(s: Symbol)(implicit js: JSONObject): AssetId = AssetId(js.getString(s.name))
+  implicit def decodeUploadAssetId(s: Symbol)(implicit js: JSONObject): UploadAssetId = UploadAssetId(js.getString(s.name))
   implicit def decodeRAssetId(s: Symbol)(implicit js: JSONObject): RAssetId = RAssetId(js.getString(s.name))
   implicit def decodeMessageId(s: Symbol)(implicit js: JSONObject): MessageId = MessageId(js.getString(s.name))
   implicit def decodeHandle(s: Symbol)(implicit js: JSONObject): Handle = Handle(js.getString(s.name))

--- a/zmessaging/src/test/scala/com/waz/Generators.scala
+++ b/zmessaging/src/test/scala/com/waz/Generators.scala
@@ -244,6 +244,7 @@ object Generators {
   implicit lazy val arbRAssetDataId: Arbitrary[RAssetId] = Arbitrary(sideEffect(RAssetId()))
   implicit lazy val arbAssetIdGeneral: Arbitrary[GeneralAssetId] = Arbitrary(sideEffect(AssetId()))
   implicit lazy val arbAssetId: Arbitrary[AssetId]       = Arbitrary(sideEffect(AssetId()))
+  implicit lazy val arbUploadAssetId: Arbitrary[UploadAssetId]       = Arbitrary(sideEffect(UploadAssetId()))
   implicit lazy val arbPublicAssetId: Arbitrary[Picture]       = Arbitrary(sideEffect(Picture.Uploaded(AssetId())))
   implicit lazy val arbSyncId: Arbitrary[SyncId]         = Arbitrary(sideEffect(SyncId()))
   implicit lazy val arbGcmId: Arbitrary[PushToken]           = Arbitrary(sideEffect(PushToken()))

--- a/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/utils/PasswordValidatorSpec.scala
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2019 Wire Swiss GmbH
+ * Copyright (C) 2016 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## What's new in this PR?

A fix to an assets bug: A change in the profile picture was not propagated to other users.

### Issues
In `UsersSyncHandler.postSelfPicture` the assetId was not retrieved correctly.

### Solutions

 On top of that updating the  picture used different logic than other self updates: name, availability, handle, etc. I decided to change the way updating the picture works so it matches more closely the rest.

### Testing

1. Create a conversation with at least one device on Android.
2. On the Android device, change the profile picture.
3. On the other device, the chathead of the user should change.

### Notes

I removed a method used for old (V2) pictures handling. It was not used anymore.
