### PR TITLE
fix: Self-replies don't show up on Android

### DIFF
--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -57,11 +57,11 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   val prefs             = new TestGlobalPreferences()
 
   val messagesInStorage = Signal[Seq[MessageData]](Seq.empty)
-  (storage.getMessages _).expects(*).anyNumberOfTimes.onCall { ids: Traversable[MessageId] =>
+  (storage.getMessages _).expects(*).atLeastOnce.onCall { ids: Traversable[MessageId] =>
     messagesInStorage.head.map(msgs => ids.map(id => msgs.find(_.id == id)).toSeq)(Threading.Background)
   }
 
-  (replyHashing.hashMessages _).expects(*).anyNumberOfTimes.onCall { msgs: Seq[MessageData] =>
+  (replyHashing.hashMessages _).expects(*).atLeastOnce.onCall { msgs: Seq[MessageData] =>
     Future.successful(msgs.filter(m => m.quote.isDefined && m.quote.flatMap(_.hash).isDefined).map(m => m.id -> m.quote.flatMap(_.hash).get).toMap)
   }
 


### PR DESCRIPTION
## What's new in this PR?

A fix to a regression bug.
fixes: https://wearezeta.atlassian.net/browse/AN-6279

### Issues

When a user from another platform sent a reply to their own message, Android displayed an error message instead. 

### Causes

The bug was regression. It occured after the new assets were merged. In changes to `MessageEventProcessor` a call to the `checkReplyHashes` method was deleted. The call has to be there, because we need to recreate locally the hash of the quoted message. If not, the hashes may differ and the quoted message will be treated as invalid (look to the specs of of the replies feature for details).

### Solutions

The fix simply adds back the call to `checkReplyHashes`.

### Testing

Preconditions: User1 is on Android, User2 is on webapp, connected
1) Open 1:1 with User2
2) User 2 sends a message (text, audio etc)
3) User 2 replies on his own message/User1 replies on User2 messages

### Notes

There's only one new line in the whole file. The rest is refactoring.
