### PR TITLE
fix: Sync users after the migration to new assets (no profile pictures)

### DIFF
--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -318,7 +318,7 @@ object ZMessagingDB {
 
       //Remove old assetId from user's profile pictures and sync to get the remote id instead
       db.execSQL("UPDATE Users SET picture = null")
-      db.execSQL("UPDATE KeyValues SET value = 'true' WHERE key = 'should_sync_users'")
+      db.execSQL("UPDATE KeyValues SET value = 'true' WHERE key = 'should_sync_users_1'")
 
       //Convert old assets to new assets (public assets won't be converted)
       def convertAsset(old: AssetData): Try[Asset] = Try {


### PR DESCRIPTION
Back in April we changed the name of the user preference `ShouldSyncUsers`. The migration code for new assets specified that after the migration the users shoulds be synced, so that their profile pictures will now use new assets. The bug was that the code still used the old name of the preference.

It should be save to simply modify the migration. If someone experiences the bug in Internal (they should) they just have to perform full sync.

fixes: https://wearezeta.atlassian.net/browse/AN-6287