### PR TITLE
Fix: google map previews

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
+++ b/zmessaging/src/main/scala/com/waz/service/ZMessaging.scala
@@ -191,6 +191,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val eventStorage: PushNotificationEventsStorage = wire[PushNotificationEventsStorageImpl]
   lazy val readReceiptsStorage: ReadReceiptsStorage    = wire[ReadReceiptsStorageImpl]
 
+  lazy val googleMapsClient   = new GoogleMapsClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val youtubeClient      = new YouTubeClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val soundCloudClient   = new SoundCloudClientImpl()(urlCreator, httpClient, authRequestInterceptor)
   lazy val assetClient        = new AssetClientImpl(cache)(urlCreator, httpClientForLongRunning, authRequestInterceptor)
@@ -250,6 +251,7 @@ class ZMessaging(val teamId: Option[TeamId], val clientId: ClientId, account: Ac
   lazy val giphy: GiphyService                        = new GiphyServiceImpl(giphyClient)(Threading.Background)
   lazy val youtubeMedia                               = wire[YouTubeMediaService]
   lazy val soundCloudMedia                            = wire[SoundCloudMediaService]
+  lazy val googleMapsMediaService                     = wire[GoogleMapsMediaServiceImpl]
   lazy val otrService: OtrServiceImpl                 = wire[OtrServiceImpl]
   lazy val genericMsgs: GenericMessageService         = wire[GenericMessageService]
   lazy val reactions: ReactionsService                = wire[ReactionsService]

--- a/zmessaging/src/main/scala/com/waz/service/media/GoogleMapsMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/GoogleMapsMediaService.scala
@@ -18,10 +18,10 @@
 package com.waz.service.media
 
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
-import com.waz.model.AssetMetaData.Image.Tag.Medium
 import com.waz.model._
 import com.waz.service.media.RichMediaContentParser.GoogleMapsLocation
 import com.waz.sync.client.GoogleMapsClient
+import com.waz.utils.wrappers.URI
 
 object GoogleMapsMediaService extends DerivedLogTag {
 
@@ -29,17 +29,12 @@ object GoogleMapsMediaService extends DerivedLogTag {
   val ImageDimensions = Dim2(MaxImageWidth, MaxImageWidth * 3 / 4)
   val PreviewWidth = 64
 
-  def mapImageAsset(id: AssetId, loc: com.waz.api.MessageContent.Location, dimensions: Dim2 = ImageDimensions): AssetData =
-    mapImageAsset(id, GoogleMapsLocation(loc.getLatitude.toString, loc.getLongitude.toString, loc.getZoom.toString), dimensions)
+  def getImagePath(loc: com.waz.api.MessageContent.Location, dimensions: Dim2 = ImageDimensions): URI =
+    getImagePath(GoogleMapsLocation(loc.getLatitude.toString, loc.getLongitude.toString, loc.getZoom.toString), dimensions)
 
-  def mapImageAsset(id: AssetId, location: GoogleMapsLocation, dimensions: Dim2): AssetData = {
-
+  def getImagePath(location: GoogleMapsLocation, dimensions: Dim2): URI = {
     val mapWidth = math.min(MaxImageWidth, dimensions.width)
     val mapHeight = mapWidth * dimensions.height / dimensions.width
-
-    val mediumPath = GoogleMapsClient.getStaticMapPath(location, mapWidth, mapHeight)
-
-    //TODO Dean see if preview is still needed?
-    AssetData(mime = Mime.Image.Png, metaData = Some(AssetMetaData.Image(Dim2(mapWidth, mapHeight), Medium)), proxyPath = Some(mediumPath))
+    GoogleMapsClient.getStaticMapPath(location, mapWidth, mapHeight)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/service/media/GoogleMapsMediaService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/media/GoogleMapsMediaService.scala
@@ -17,24 +17,45 @@
  */
 package com.waz.service.media
 
-import com.waz.log.BasicLogging.LogTag.DerivedLogTag
+import java.io.InputStream
+
+import com.waz.api.MessageContent.Location
 import com.waz.model._
 import com.waz.service.media.RichMediaContentParser.GoogleMapsLocation
 import com.waz.sync.client.GoogleMapsClient
-import com.waz.utils.wrappers.URI
+import com.waz.threading.CancellableFuture
 
-object GoogleMapsMediaService extends DerivedLogTag {
+import scala.concurrent.ExecutionContext
+
+trait GoogleMapsMediaService {
+  def loadMapPreview(location: Location, dimensions: Dim2): CancellableFuture[InputStream]
+}
+
+class GoogleMapsMediaServiceImpl(googleMapsClient: GoogleMapsClient)(implicit executionContext: ExecutionContext)
+  extends GoogleMapsMediaService {
+
+  import com.waz.service.media.GoogleMapsMediaService._
+
+  def loadMapPreview(location: Location, dimensions: Dim2 = ImageDimensions): CancellableFuture[InputStream] = {
+    val googleMapsLocation = GoogleMapsLocation(location.getLatitude.toString, location.getLongitude.toString, location.getZoom.toString)
+    val constrainedDimensions = constrain(dimensions)
+
+    googleMapsClient.loadMapPreview(googleMapsLocation, constrainedDimensions).flatMap {
+      case Left(error) => CancellableFuture.failed(error)
+      case Right(result) => CancellableFuture.successful(result)
+    }
+  }
+}
+
+object GoogleMapsMediaService {
 
   val MaxImageWidth = 640 // free maps api limitation
   val ImageDimensions = Dim2(MaxImageWidth, MaxImageWidth * 3 / 4)
   val PreviewWidth = 64
 
-  def getImagePath(loc: com.waz.api.MessageContent.Location, dimensions: Dim2 = ImageDimensions): URI =
-    getImagePath(GoogleMapsLocation(loc.getLatitude.toString, loc.getLongitude.toString, loc.getZoom.toString), dimensions)
-
-  def getImagePath(location: GoogleMapsLocation, dimensions: Dim2): URI = {
+  def constrain(dimensions: Dim2): Dim2 = {
     val mapWidth = math.min(MaxImageWidth, dimensions.width)
     val mapHeight = mapWidth * dimensions.height / dimensions.width
-    GoogleMapsClient.getStaticMapPath(location, mapWidth, mapHeight)
+    Dim2(mapWidth, mapHeight)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/client/GoogleMapsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/GoogleMapsClient.scala
@@ -20,13 +20,14 @@ package com.waz.sync.client
 import java.net.URLEncoder
 
 import com.waz.service.media.RichMediaContentParser.GoogleMapsLocation
+import com.waz.utils.wrappers.URI
 
 object GoogleMapsClient {
-  val StaticMapsPathBase = "/proxy/googlemaps/api/staticmap"
+  val StaticMapsPathBase = "https://maps.googleapis.com/maps/api/staticmap"
 
-  def getStaticMapPath(location: GoogleMapsLocation, width: Int, height: Int): String = {
+  def getStaticMapPath(location: GoogleMapsLocation, width: Int, height: Int): URI = {
     val center = URLEncoder.encode(s"${location.x},${location.y}", "utf8")
     val zoom = URLEncoder.encode(location.zoom, "utf8")
-    s"$StaticMapsPathBase?center=$center&zoom=$zoom&size=${width}x$height"
+    URI.parse(s"$StaticMapsPathBase?center=$center&zoom=$zoom&size=${width}x$height")
   }
 }

--- a/zmessaging/src/main/scala/com/waz/sync/client/GoogleMapsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/GoogleMapsClient.scala
@@ -17,17 +17,48 @@
  */
 package com.waz.sync.client
 
+import java.io.InputStream
 import java.net.URLEncoder
 
+import com.waz.api.impl.ErrorResponse
+import com.waz.model.Dim2
 import com.waz.service.media.RichMediaContentParser.GoogleMapsLocation
-import com.waz.utils.wrappers.URI
+import com.waz.utils.CirceJSONSupport
+import com.waz.znet2.AuthRequestInterceptor
+import com.waz.znet2.http.HttpClient.AutoDerivation._
+import com.waz.znet2.http.HttpClient.dsl._
+import com.waz.znet2.http.Request.UrlCreator
+import com.waz.znet2.http._
+
+trait GoogleMapsClient {
+  def loadMapPreview(location: GoogleMapsLocation, dimensions: Dim2): ErrorOrResponse[InputStream]
+}
+
+class GoogleMapsClientImpl(implicit
+                           urlCreator: UrlCreator,
+                           httpClient: HttpClient,
+                           authRequestInterceptor: AuthRequestInterceptor) extends GoogleMapsClient with CirceJSONSupport {
+
+  import GoogleMapsClient._
+
+  private implicit def inputStreamBodyDeserializer: RawBodyDeserializer[InputStream] = RawBodyDeserializer.create(_.data())
+
+  def loadMapPreview(location: GoogleMapsLocation, dimensions: Dim2): ErrorOrResponse[InputStream] =
+    Request
+      .Get(relativePath = getStaticMapPath(location, dimensions.width, dimensions.height))
+      .withResultType[InputStream]
+      .withErrorType[ErrorResponse]
+      .executeSafe
+
+}
 
 object GoogleMapsClient {
-  val StaticMapsPathBase = "https://maps.googleapis.com/maps/api/staticmap"
 
-  def getStaticMapPath(location: GoogleMapsLocation, width: Int, height: Int): URI = {
+  val StaticMapsPathBase = "/proxy/googlemaps/api/staticmap"
+
+  def getStaticMapPath(location: GoogleMapsLocation, width: Int, height: Int): String = {
     val center = URLEncoder.encode(s"${location.x},${location.y}", "utf8")
     val zoom = URLEncoder.encode(location.zoom, "utf8")
-    URI.parse(s"$StaticMapsPathBase?center=$center&zoom=$zoom&size=${width}x$height")
+    s"$StaticMapsPathBase?center=$center&zoom=$zoom&size=${width}x$height"
   }
 }

--- a/zmessaging/src/test/scala/com/waz/service/media/GoogleMapsMediaServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/media/GoogleMapsMediaServiceSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Wire
+ * Copyright (C) 2016 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.waz.service.media
+
+import com.waz.api.MessageContent.Location
+import com.waz.model.Dim2
+import com.waz.specs.AndroidFreeSpec
+import com.waz.sync.client.GoogleMapsClient.StaticMapsPathBase
+import com.waz.utils.wrappers.URI
+
+class GoogleMapsMediaServiceSpec extends AndroidFreeSpec {
+
+  feature("google map previews") {
+
+    scenario("get the map preview url") {
+      // Given
+      val location = new Location(52.523842f, 13.402276f, "Head Quarters", 2)
+
+      // When
+      val actual = GoogleMapsMediaService.getImagePath(location, Dim2(100, 200))
+
+      // Then
+      val expected = URI.parse(s"$StaticMapsPathBase?center=${location.getLatitude}%2C${location.getLongitude}&zoom=2&size=100x200")
+      actual shouldEqual expected
+    }
+  }
+}

--- a/zmessaging/src/test/scala/com/waz/sync/client/GoogleMapsClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/GoogleMapsClientSpec.scala
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2016 Wire Swiss GmbH
+ * Copyright (C) 2019 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,27 +15,25 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.waz.service.media
+package com.waz.sync.client
 
-import com.waz.api.MessageContent.Location
-import com.waz.model.Dim2
+import com.waz.service.media.RichMediaContentParser.GoogleMapsLocation
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.client.GoogleMapsClient.StaticMapsPathBase
-import com.waz.utils.wrappers.URI
 
-class GoogleMapsMediaServiceSpec extends AndroidFreeSpec {
+class GoogleMapsClientSpec extends AndroidFreeSpec {
 
   feature("google map previews") {
 
     scenario("get the map preview url") {
       // Given
-      val location = new Location(52.523842f, 13.402276f, "Head Quarters", 2)
+      val location = GoogleMapsLocation("13.402276", "52.523842", "2")
 
       // When
-      val actual = GoogleMapsMediaService.getImagePath(location, Dim2(100, 200))
+      val actual = GoogleMapsClient.getStaticMapPath(location, 100, 200)
 
       // Then
-      val expected = URI.parse(s"$StaticMapsPathBase?center=${location.getLatitude}%2C${location.getLongitude}&zoom=2&size=100x200")
+      val expected = s"$StaticMapsPathBase?center=${location.x}%2C${location.y}&zoom=2&size=100x200"
       actual shouldEqual expected
     }
   }


### PR DESCRIPTION
## What's new in this PR?

After the assets refactoring, the code used to load map previews died. This PR repurposes this code to help facilitate fetching map previews.

The map previews can now be loaded using Glide by simply providing a url. As such, we no longer have to return an `AssetData`, rather a `URI` now suffices.

## Edit

We couldn't make the direct request to google due to privacy issues, so I've reverted back to using the proxy. As a result, I've changed `GoogleMapsClient` to make the request to the backend as we do with other clients. `GoogleMapsMediaService` is responsible for invoking the request, and returns an `InputStream` containing the image data. This stream will be used in the UI to load via _Glide_.

