### PR TITLE
fix: The sender's device fails to play the video the first time

### DIFF
--- a/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/assets2/AssetServiceSpec.scala
@@ -158,7 +158,7 @@ class AssetServiceSpec extends ZIntegrationMockSpec with AuthenticationConfig wi
       (assetStorage.find _).expects(*).once().returns(Future.successful(Some(asset)))
       (uriHelperMock.openInputStream _)
         .expects(*)
-        .twice()
+        .once()
         .onCall({ _: URI =>
           Success(new ByteArrayInputStream(testAssetContent))
         })


### PR DESCRIPTION
1. Send a video in a conversation.
2. Click on the video to play it.
3. The video fails to play the first time. It works the second time.
    
The reason of the bug was in that before playing the video we first check the sha (for security reasons). We calculate the sha by loading the whole input stream. The stream should be reset if the sha is valid, so it can be read again when we copy the video in order to play it afterwards.  And if the sha is invalid, the stream should be closed. Instead, we tried to open it for the second time if the sha comparison was successful.

While working on this bug I also simplified the code around it - it was difficult to spot it at first.