### PR TITLE
fix: accept websocket uri without path

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/push/WSPushService.scala
@@ -62,7 +62,10 @@ object WSPushServiceImpl {
             ev: AccountContext): WSPushServiceImpl = {
 
     val requestCreator = (token: AccessToken) => {
-      val uri = backend.websocketUrl.buildUpon.appendQueryParameter("client", clientId.str).build
+      val webSocketUri = if(backend.websocketUrl.getPath.startsWith("/await")) backend.websocketUrl
+        else backend.websocketUrl.buildUpon.appendPath("await").build
+
+      val uri = webSocketUri.buildUpon.appendQueryParameter("client", clientId.str).build
       val headers = token.headers ++ Map(
         "Accept-Encoding" -> "identity", // XXX: this is a hack for Backend In The Box problem: 'Accept-Encoding: gzip' header causes 500
         "User-Agent" -> client.userAgent()


### PR DESCRIPTION
What's new in this PR?

### Issues

iOS clients append the "/await" path to websocket uris automatically. On Android we need to add them ourselves. This was causing issues with using one config for both Android/iOS, so this PR changes the Android client to be able to accept both kinds of URIs, and append the required path when needed.

Fixes [AN-6312](https://wearezeta.atlassian.net/browse/AN-6312)
