### PR TITLE
fix: clearing conversations now clears failed msgs

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/MessagesStorage.scala
@@ -301,11 +301,15 @@ class MessagesStorageImpl(context:     Context,
     }
   }
 
-  private def clearUnsentMsgs(convId: ConvId)(implicit storage: DB): Unit =
-    MessageDataDao.iterating(MessageDataDao.listUnsentMsgs(convId)).foreach(_.map(_.id).foreach { id =>
-      MessageDataDao.delete(id)
-      MessageContentIndexDao.delete(id)
-    })
+  private def clearUnsentMsgs(convId: ConvId)(implicit storage: DB): Unit = {
+    val unsentMessages = MessageDataDao.listUnsentMsgs(convId)
+    MessageDataDao.iterating(unsentMessages).foreach(_.foreach(clearUnsentMsg))
+  }
+
+  private def clearUnsentMsg(data: MessageData)(implicit storage: DB): Unit = {
+    MessageDataDao.delete(data.id)
+    MessageContentIndexDao.delete(data.id)
+  }
 }
 
 object MessagesStorage {

--- a/zmessaging/src/main/scala/com/waz/model/MessageData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/MessageData.scala
@@ -372,6 +372,11 @@ object MessageData extends
     override def apply(implicit cursor: DBCursor): MessageData =
       MessageData(Id, Conv, Type, User, Content, Protos, FirstMessage, Members, Recipient, Email, Name, State, Time, LocalTime, EditTime, Ephemeral, ExpiryTime, Expired, Duration, AssetId, Quote.map(QuoteContent(_, QuoteValidity, None)), ForceReadReceipts)
 
+    def listUnsentMsgs(id: ConvId)(implicit db: DB) = {
+      import Message.Status._
+      MessageDataDao.findInSet(State, Set(FAILED, FAILED_READ, PENDING))
+    }
+
     def deleteForConv(id: ConvId)(implicit db: DB) = delete(Conv, id)
 
     def deleteUpTo(id: ConvId, upTo: RemoteInstant)(implicit db: DB) = db.delete(table.name, s"${Conv.name} = '${id.str}' AND ${Time.name} <= ${Time(upTo)}", null)


### PR DESCRIPTION
## What's new in this PR?

### Issues

 - Fixes [AN-6293](https://wearezeta.atlassian.net/browse/AN-6293)
 - This PR introduces an additional step to delete unsent(failed, pending) messages when clearing a conversation.

### Causes

Since (failed, pending) messages haven't been synced yet, they weren't being cleared, as the `lastEventTime` is used to set the cleared time, and this is only updated after a given message has been synced with the backend.

### Solutions

Since changing `lastEventTime` would result in other clients potentially losing messages, it was decided to simply delete all unsent messages when clearing, since this most closely matches what the user would expect

### Testing

It was tested manually, and clearing the conversation now deletes failed messages as expected