### PR TITLE
fix: version blacklist uri

### DIFF
--- a/zmessaging/src/main/scala/com/waz/sync/client/VersionBlacklistClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/VersionBlacklistClient.scala
@@ -46,6 +46,8 @@ class VersionBlacklistClientImpl(backendConfig: BackendConfig)
   }
 
   def blacklistsUrl: URL = {
-    new URL(backendConfig.blacklistHost.buildUpon.appendPath("android").build.toString)
+    val uri = backendConfig.blacklistHost
+    new URL(if (uri.getPath.endsWith("/android")) uri.toString
+    else uri.buildUpon.appendPath("android").build.toString)
   }
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

 - [AN-6258](https://wearezeta.atlassian.net/browse/AN-6258)
 - This PR fixes the blacklist url parsing code, which was adding a suffix unconditionally, causing the url to become invalid and blacklist loading to fail

### Testing

Testing both with and without the "/android" prefix was tested manually.
