### PR TITLE
Feature: add root detected flag to global preferences

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -382,6 +382,7 @@ object GlobalPreferences {
 
   lazy val LogsEnabled: PrefKey[Boolean] = PrefKey[Boolean]("save_local_logs", customDefault = ZmsVersion.DEBUG)
 
+  lazy val RootDetected: PrefKey[Boolean] = PrefKey[Boolean]("root_detected", customDefault = false)
 
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts          = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")


### PR DESCRIPTION
## What's new in this PR?

This PR simply adds a flag to the global preferences. It stores whether the device was ever rooted while Wire was running.

## Notes

**This flag is used ONLY in the case that this feature has been enabled. By default, this feature is disabled. Furthermore, it can only be enabled for custom builds.**