### PR TITLE
Add flag to global preferences for warning Android 4 users

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -384,6 +384,9 @@ object GlobalPreferences {
 
   lazy val RootDetected: PrefKey[Boolean] = PrefKey[Boolean]("root_detected", customDefault = false)
 
+  // TODO: Remove after release 3.36
+  lazy val ShouldWarnAndroid4Users = PrefKey[Boolean]( "should_warn_android_4_users", customDefault = true)
+
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts          = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")
   lazy val _DarkTheme              = PrefKey[Boolean]("DarkTheme")


### PR DESCRIPTION
## What's new in this PR?

Soon we will discontinue support for Android 4. This flag will be used to decide if we should present a dialog to warn the user.