### PR TITLE
Fix: bump macrosupport version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val macrosupport = project
   .enablePlugins(AutomateHeaderPlugin).settings(licenseHeaders)
   .settings(publishSettings: _*)
   .settings(
-    version := "3.2",
+    version := "3.3",
     crossPaths := false,
     exportJars := true,
     name := "zmessaging-android-macrosupport",


### PR DESCRIPTION
## What's new in this PR?

### Issues

`ZLog` was removed from the `macrosupport` module in https://github.com/wireapp/wire-android-sync-engine/pull/505. In the UI project, `macrosupport` is a transitive dependency, however it the UI project still had references to `ZLog` even though it still successfully compiled.

### Causes

The `macrosupport` version was bumped in https://github.com/wireapp/wire-android-sync-engine/pull/513 from 3.1 to 3.2. This PR was merged on June 7th. On Bintray, `macrosupport` version 3.2 was published on February 19th. I think what went wrong here is that the version published on Bintray was actually built before `ZLog` was removed, and somehow the version numbers went out of sync. Also, it seems that `macrosupport` was never built and release on Bintray since February, so all recent changes have been dormant.

### Solutions

I just bumped the version, then packaged it and released it to Bintray.

## Notes

Now that the new version of `macrosupport` is released, the UI project will fail to compile until all references to `ZLog` have been removed.