### PR TITLE
Feature: team logo

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/TeamsStorage.scala
+++ b/zmessaging/src/main/scala/com/waz/content/TeamsStorage.scala
@@ -19,7 +19,7 @@ package com.waz.content
 
 import android.content.Context
 import com.waz.log.BasicLogging.LogTag
-import com.waz.model.TeamData.TeamDataDoa
+import com.waz.model.TeamData.TeamDataDao
 import com.waz.model._
 import com.waz.utils.TrimmingLruCache.Fixed
 import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
@@ -27,5 +27,5 @@ import com.waz.utils.{CachedStorage, CachedStorageImpl, TrimmingLruCache}
 trait TeamsStorage extends CachedStorage[TeamId, TeamData]
 
 class TeamsStorageImpl(context: Context, storage: Database)
-  extends CachedStorageImpl[TeamId, TeamData](new TrimmingLruCache(context, Fixed(1024)), storage)(TeamDataDoa, LogTag("TeamStorage_Cached"))
+  extends CachedStorageImpl[TeamId, TeamData](new TrimmingLruCache(context, Fixed(1024)), storage)(TeamDataDao, LogTag("TeamStorage_Cached"))
     with TeamsStorage

--- a/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -27,7 +27,7 @@ import com.waz.db.migrate.AccountDataMigration
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
 import com.waz.model.AccountData.AccountDataDao
-import com.waz.model.TeamData.TeamDataDoa
+import com.waz.model.TeamData.TeamDataDao
 import com.waz.model.otr.ClientId
 import com.waz.model.{AccountId, UserId}
 import com.waz.service.tracking.TrackingService
@@ -55,7 +55,7 @@ object ZGlobalDB {
   val DbName = "ZGlobal.db"
   val DbVersion = 23
 
-  lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDoa)
+  lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDao)
 
   object Migrations {
 

--- a/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZGlobalDB.scala
@@ -53,7 +53,7 @@ class ZGlobalDB(context: Context, dbNameSuffix: String = "", tracking: TrackingS
 
 object ZGlobalDB {
   val DbName = "ZGlobal.db"
-  val DbVersion = 23
+  val DbVersion = 24
 
   lazy val daos = Seq(AccountDataDao, CacheEntryDao, TeamDataDao)
 
@@ -92,6 +92,21 @@ object ZGlobalDB {
       },
       Migration(22, 23) { db =>
         db.execSQL("ALTER TABLE ActiveAccounts ADD COLUMN sso_id TEXT DEFAULT NULL")
+      },
+      Migration(23, 24) { db =>
+        // Team icons are now public assets, so we no longer need icon_key. Sqlite doesn't support
+        // dropping columns, so we have to do it manually by renaming the table, recreating it,
+        // and finally restoring that data back into the table.
+
+        import TeamDataDao._
+        val TeamsTable = table.name
+        val BackupTable = "TeamsBackup"
+        val ColumnsToKeep = s"${Id.name}, ${Name.name}, ${Creator.name}, ${Icon.name}"
+
+        db.execSQL(s"ALTER TABLE $TeamsTable RENAME TO $BackupTable")
+        db.execSQL(s"${TeamDataDao.table.createSql}")
+        db.execSQL(s"INSERT INTO $TeamsTable SELECT $ColumnsToKeep FROM $BackupTable")
+        db.execSQL(s"DROP TABLE $BackupTable")
       }
     )
 

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -374,8 +374,7 @@ object ZMessagingDB {
       }
     },
     Migration(121, 122) { db =>
-      // Team icons are now public assets, so we no longer need the key.
-      db.execSQL(s"ALTER TABLE ${TeamDataDao.table.name} DROP COLUMN IF EXISTS icon_key")
+      // To fetch team data to display the logo.
       db.execSQL(s"UPDATE ${KeyValueDataDao.table.name} SET ${KeyValueDataDao.Value.name} = 'true' WHERE ${KeyValueDataDao.Key.name} = 'should_sync_teams'")
     }
   )

--- a/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
+++ b/zmessaging/src/main/scala/com/waz/db/ZMessagingDB.scala
@@ -38,6 +38,7 @@ import com.waz.model.NotificationData.NotificationDataDao
 import com.waz.model.PushNotificationEvents.PushNotificationEventsDao
 import com.waz.model.ReadReceipt.ReadReceiptDao
 import com.waz.model.SearchQueryCache.SearchQueryCacheDao
+import com.waz.model.TeamData.TeamDataDao
 import com.waz.model.UserData.UserDataDao
 import com.waz.model._
 import com.waz.model.otr.UserClients.UserClientsDao
@@ -62,7 +63,7 @@ class ZMessagingDB(context: Context, dbName: String, tracking: TrackingService) 
 }
 
 object ZMessagingDB {
-  val DbVersion = 121
+  val DbVersion = 122
 
   lazy val daos = Seq (
     UserDataDao, SearchQueryCacheDao, AssetDataDao, ConversationDataDao, ConversationMemberDataDao,
@@ -371,6 +372,11 @@ object ZMessagingDB {
             m
         }
       }
+    },
+    Migration(121, 122) { db =>
+      // Team icons are now public assets, so we no longer need the key.
+      db.execSQL(s"ALTER TABLE ${TeamDataDao.table.name} DROP COLUMN IF EXISTS icon_key")
+      db.execSQL(s"UPDATE ${KeyValueDataDao.table.name} SET ${KeyValueDataDao.Value.name} = 'true' WHERE ${KeyValueDataDao.Key.name} = 'should_sync_teams'")
     }
   )
 }

--- a/zmessaging/src/main/scala/com/waz/model/Event.scala
+++ b/zmessaging/src/main/scala/com/waz/model/Event.scala
@@ -358,7 +358,7 @@ object TeamEvent extends DerivedLogTag {
 
   case class Create(teamId: TeamId) extends TeamEvent
   case class Delete(teamId: TeamId) extends TeamEvent
-  case class Update(teamId: TeamId, name: Option[Name], icon: Option[RAssetId], iconKey: Option[AESKey]) extends TeamEvent
+  case class Update(teamId: TeamId, name: Option[Name], icon: AssetId) extends TeamEvent
 
   sealed trait MemberEvent extends TeamEvent {
     val userId: UserId
@@ -382,7 +382,7 @@ object TeamEvent extends DerivedLogTag {
       decodeString('type) match {
         case "team.create"              => Create('team)
         case "team.delete"              => Delete('team)
-        case "team.update"              => Update('team, decodeOptName('name)('data), decodeOptString('icon)('data).map(RAssetId), decodeOptString('icon_key)('data).map(AESKey))
+        case "team.update"              => Update('team, decodeOptName('name)('data), AssetId(decodeString('icon)('data)))
         case "team.member-join"         => MemberJoin ('team, UserId(decodeString('user)('data)))
         case "team.member-leave"        => MemberLeave('team, UserId(decodeString('user)('data)))
         case "team.member-update"       => MemberUpdate('team, UserId(decodeString('user)('data)))

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -44,7 +44,7 @@ object TeamData {
     TeamData(TeamId(id), Name(name), UserId(creator), AssetId(icon))
 
   import com.waz.db.Col._
-  implicit object TeamDataDoa extends Dao[TeamData, TeamId] {
+  implicit object TeamDataDao extends Dao[TeamData, TeamId] {
     val Id      = id[TeamId]      ('_id, "PRIMARY KEY").apply(_.id)
     val Name    = text[model.Name]('name, _.str, model.Name)(_.name)
     val Creator = id[UserId]      ('creator).apply(_.creator)

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -19,33 +19,29 @@ package com.waz.model
 
 import com.waz.db.Dao
 import com.waz.model
-import com.waz.utils.{Identifiable, JsonDecoder}
+import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.DBCursor
-import org.json.JSONObject
 
 case class TeamData(override val id: TeamId,
                     name:            Name,
                     creator:         UserId,
-                    icon:            Option[RAssetId] = None,
-                    iconKey:         Option[AESKey]  = None) extends Identifiable[TeamId]
+                    icon:            AssetId) extends Identifiable[TeamId]
 
 object TeamData {
 
-  def apply(id: String, name: String, creator: String, icon: Option[String], iconKey: Option[String]): TeamData =
-    TeamData(TeamId(id), Name(name), UserId(creator), icon.map(i => RAssetId(i)), iconKey.map(i => AESKey(i)))
-
+  def apply(id: String, name: String, creator: String, icon: String): TeamData =
+    TeamData(TeamId(id), Name(name), UserId(creator), AssetId(icon))
 
   import com.waz.db.Col._
   implicit object TeamDataDoa extends Dao[TeamData, TeamId] {
     val Id      = id[TeamId]      ('_id, "PRIMARY KEY").apply(_.id)
     val Name    = text[model.Name]('name, _.str, model.Name)(_.name)
     val Creator = id[UserId]      ('creator).apply(_.creator)
-    val Icon    = opt(id[RAssetId] ('icon))(_.icon)
-    val IconKey = opt(text[AESKey]('icon_key, _.str, AESKey))(_.iconKey)
+    val Icon    = id[AssetId]     ('icon).apply(_.icon)
 
     override val idCol = Id
-    override val table = Table("Teams", Id, Name, Creator, Icon, IconKey)
+    override val table = Table("Teams", Id, Name, Creator, Icon)
 
-    override def apply(implicit cursor: DBCursor): TeamData = new TeamData(Id, Name, Creator, Icon, IconKey)
+    override def apply(implicit cursor: DBCursor): TeamData = new TeamData(Id, Name, Creator, Icon)
   }
 }

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -19,13 +19,24 @@ package com.waz.model
 
 import com.waz.db.Dao
 import com.waz.model
+import com.waz.model.UserData.Picture
 import com.waz.utils.Identifiable
 import com.waz.utils.wrappers.DBCursor
 
 case class TeamData(override val id: TeamId,
                     name:            Name,
                     creator:         UserId,
-                    icon:            AssetId) extends Identifiable[TeamId]
+                    icon:            AssetId) extends Identifiable[TeamId] {
+
+  def picture: Option[Picture] = {
+    if (hasValidIconId) Some(Picture.Uploaded(icon))
+    else None
+  }
+
+  // Team icon is optional, but on backend it's not. A dummy value (less than 10 chars)
+  // signifies no team icon.
+  private def hasValidIconId: Boolean = icon.str.length >= 10
+}
 
 object TeamData {
 

--- a/zmessaging/src/main/scala/com/waz/model/TeamData.scala
+++ b/zmessaging/src/main/scala/com/waz/model/TeamData.scala
@@ -34,19 +34,6 @@ object TeamData {
   def apply(id: String, name: String, creator: String, icon: Option[String], iconKey: Option[String]): TeamData =
     TeamData(TeamId(id), Name(name), UserId(creator), icon.map(i => RAssetId(i)), iconKey.map(i => AESKey(i)))
 
-  implicit lazy val Decoder: JsonDecoder[TeamData] = new JsonDecoder[TeamData] {
-    override def apply(implicit js: JSONObject): TeamData = {
-      import JsonDecoder._
-      TeamData('id, 'name, 'creator, 'icon, decodeOptString('icon_key).map(AESKey))
-    }
-  }
-
-  implicit lazy val TeamBindingDecoder: JsonDecoder[(TeamData, Boolean)] = new JsonDecoder[(TeamData, Boolean)] {
-    override def apply(implicit js: JSONObject): (TeamData, Boolean) = {
-      import JsonDecoder._
-      (TeamData('id, 'name, 'creator, 'icon, decodeOptString('icon_key).map(AESKey)), decodeOptBoolean('binding).getOrElse(false))
-    }
-  }
 
   import com.waz.db.Col._
   implicit object TeamDataDoa extends Dao[TeamData, TeamId] {

--- a/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
+++ b/zmessaging/src/main/scala/com/waz/service/teams/TeamsService.scala
@@ -84,7 +84,7 @@ class TeamsServiceImpl(selfUser:           UserId,
     val convsCreated = events.collect { case ConversationCreate(_, id) => id }.toSet
     val convsDeleted = events.collect { case ConversationDelete(_, id) => id }.toSet
     for {
-      _ <- RichFuture.traverseSequential(events.collect { case e:Update => e}) { case Update(id, name, icon, iconKey) => onTeamUpdated(id, name, icon, iconKey) }
+      _ <- RichFuture.traverseSequential(events.collect { case e:Update => e}) { case Update(id, name, icon) => onTeamUpdated(id, name, icon) }
       _ <- onMembersJoined(membersJoined -- membersLeft)
       _ <- onMembersLeft(membersLeft -- membersJoined)
       _ <- onMembersUpdated(membersUpdated)
@@ -181,13 +181,12 @@ class TeamsServiceImpl(selfUser:           UserId,
         .map(_ => ())
   }
 
-  private def onTeamUpdated(id: TeamId, name: Option[Name], icon: Option[RAssetId], iconKey: Option[AESKey]) = {
-    verbose(l"onTeamUpdated: $id, name: $name, icon: $icon, iconKey: $iconKey")
+  private def onTeamUpdated(id: TeamId, name: Option[Name], icon: AssetId) = {
+    verbose(l"onTeamUpdated: $id, name: $name, icon: $icon")
     teamStorage.update(id, team => team.copy (
       name    = name.getOrElse(team.name),
-      icon    = icon.orElse(team.icon),
-      iconKey = iconKey.orElse(team.iconKey)
-    ))
+      icon    = icon)
+    )
   }
 
   private def onMembersJoined(members: Set[UserId]) = {

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -61,15 +61,9 @@ class TeamsClientImpl(implicit
 
   override def getTeamData(id: TeamId): ErrorOrResponse[TeamData] = {
     Request.Get(relativePath = teamPath(id))
-      .withResultType[TeamDataResponse]
+      .withResultType[TeamData]
       .withErrorType[ErrorResponse]
-      .executeSafe { response =>
-        TeamData(
-          response.id,
-          response.name,
-          response.creator,
-          response.icon)
-      }
+      .executeSafe
   }
 
   override def getPermissions(teamId: TeamId, userId: UserId): ErrorOrResponse[Option[PermissionsMasks]] = {
@@ -103,8 +97,6 @@ object TeamsClient {
   def teamPath(id: TeamId): String = s"$TeamsPath/${id.str}"
 
   def memberPath(teamId: TeamId, userId: UserId): String = s"${teamMembersPath(teamId)}/${userId.str}"
-
-  case class TeamDataResponse(id: String, name: String, creator: String, icon: String)
 
   case class TeamMembers(members: Seq[TeamMember])
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -68,8 +68,7 @@ class TeamsClientImpl(implicit
           response.id,
           response.name,
           response.creator,
-          Some(response.icon),
-          response.icon_key)
+          response.icon)
       }
   }
 
@@ -105,8 +104,7 @@ object TeamsClient {
 
   def memberPath(teamId: TeamId, userId: UserId): String = s"${teamMembersPath(teamId)}/${userId.str}"
 
-
-  case class TeamDataResponse(id: String, name: String, creator: String, icon: String, icon_key: Option[String])
+  case class TeamDataResponse(id: String, name: String, creator: String, icon: String)
 
   case class TeamMembers(members: Seq[TeamMember])
 

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -33,7 +33,6 @@ import scala.util.Try
 trait TeamsClient {
   def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]]
   def getTeamData(id: TeamId): ErrorOrResponse[TeamData]
-
   def getPermissions(teamId: TeamId, userId: UserId): ErrorOrResponse[Option[PermissionsMasks]]
   def getTeamMember(teamId: TeamId, userId: UserId): ErrorOrResponse[TeamMember]
 }
@@ -47,10 +46,6 @@ class TeamsClientImpl(implicit
   import HttpClient.AutoDerivation._
   import TeamsClient._
   import com.waz.threading.Threading.Implicits.Background
-
-  //TODO Remove after assets refactoring
-  private implicit val errorResponseDeserializer: RawBodyDeserializer[ErrorResponse] =
-    objectFromCirceJsonRawBodyDeserializer[ErrorResponse]
 
   override def getTeamMembers(id: TeamId): ErrorOrResponse[Seq[TeamMember]] = {
     Request.Get(relativePath = teamMembersPath(id))

--- a/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
+++ b/zmessaging/src/main/scala/com/waz/sync/client/TeamsClient.scala
@@ -105,21 +105,6 @@ object TeamsClient {
 
   def memberPath(teamId: TeamId, userId: UserId): String = s"${teamMembersPath(teamId)}/${userId.str}"
 
-  import JsonDecoder._
-
-  case class TeamBindingResponse(teams: Seq[(TeamData, Boolean)], hasMore: Boolean)
-
-  //TODO Remove after assets refactoring
-  object TeamBindingResponse extends DerivedLogTag {
-    def unapply(response: ResponseContent): Option[(Seq[(TeamData, Boolean)], Boolean)] =
-      response match {
-        case JsonObjectResponse(js) if js.has("teams") =>
-          Try(decodeSeq('teams)(js, TeamData.TeamBindingDecoder), decodeOptBoolean('has_more)(js).getOrElse(false)).toOption
-        case _ =>
-          warn(l"Unexpected response:")
-          None
-      }
-  }
 
   case class TeamDataResponse(id: String, name: String, creator: String, icon: String, icon_key: Option[String])
 

--- a/zmessaging/src/main/scala/com/waz/utils/CirceJSONSupport.scala
+++ b/zmessaging/src/main/scala/com/waz/utils/CirceJSONSupport.scala
@@ -18,8 +18,7 @@
 package com.waz.utils
 import java.net.{URI, URL}
 
-import com.waz.model.UserId
-import com.waz.model.{AssetId, AssetToken, RAssetId, Sha256}
+import com.waz.model.{AssetId, AssetToken, Name, RAssetId, Sha256, TeamId, UserId}
 import io.circe.generic.AutoDerivation
 import io.circe.{Decoder, Encoder}
 import org.threeten.bp.{Duration, Instant}
@@ -40,8 +39,12 @@ trait CirceJSONSupport extends AutoDerivation {
 
   implicit def InstantDecoder: Decoder[Instant] = Decoder[String].map(Instant.parse)
 
-  implicit def RAssetIdDecoder: Decoder[RAssetId] = Decoder[String].map(RAssetId.apply)
+  implicit def NameDecoder: Decoder[Name] = Decoder[String].map(Name.apply)
+
   implicit def UserIdDecoder: Decoder[UserId] = Decoder[String].map(UserId.apply)
+  implicit def TeamIdDecoder: Decoder[TeamId] = Decoder[String].map(TeamId.apply)
+
+  implicit def RAssetIdDecoder: Decoder[RAssetId] = Decoder[String].map(RAssetId.apply)
   implicit def AssetIdDecoder: Decoder[AssetId] = Decoder[String].map(AssetId.apply)
   implicit def AssetTokenDecoder: Decoder[AssetToken] = Decoder[String].map(AssetToken.apply)
 

--- a/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/client/TeamsClientSpec.scala
@@ -17,10 +17,11 @@
  */
 package com.waz.sync.client
 
-import com.waz.model.UserPermissions._
+import com.waz.model.TeamData
 import com.waz.model.UserPermissions.Permission._
+import com.waz.model.UserPermissions._
 import com.waz.specs.AndroidFreeSpec
-import com.waz.sync.client.TeamsClient.{TeamDataResponse, TeamMembers}
+import com.waz.sync.client.TeamsClient.TeamMembers
 import com.waz.utils.CirceJSONSupport
 
 //TODO Replace with integration test when AuthRequestInterceptor2 is introduced
@@ -61,14 +62,14 @@ class TeamsClientSpec extends AndroidFreeSpec with CirceJSONSupport {
     scenario("Team data response decoding") {
       import io.circe.parser._
       val response = "{\"creator\":\"d22b442c-8a91-4773-8655-4d72b49b8c70\",\"icon\":\"abc\",\"name\":\"Potato\",\"id\":\"ddaad665-9227-4bd3-93d6-a3450bfbbfc7\",\"binding\": true,\"icon_key\": \"abcdefg\"}"
-      val result = decode[TeamDataResponse](response)
+      val result = decode[TeamData](response)
 
-      result shouldEqual Right(TeamDataResponse(
+      result shouldEqual Right(TeamData(
         "ddaad665-9227-4bd3-93d6-a3450bfbbfc7",
         "Potato",
         "d22b442c-8a91-4773-8655-4d72b49b8c70",
-        "abc",
-        Some("abcdefg")))
+        "abc"
+      ))
     }
   }
 }

--- a/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/sync/handler/TeamsSyncHandlerSpec.scala
@@ -18,7 +18,7 @@
 package com.waz.sync.handler
 
 import com.waz.api.impl.ErrorResponse
-import com.waz.model.{TeamData, TeamId, UserId}
+import com.waz.model.{AssetId, TeamData, TeamId, UserId}
 import com.waz.service.teams.TeamsService
 import com.waz.specs.AndroidFreeSpec
 import com.waz.sync.SyncResult
@@ -41,7 +41,7 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
 
       val teamId = TeamId()
       val teams = Seq((teamId, true))
-      val teamData = TeamData(teamId, "name", UserId())
+      val teamData = TeamData(teamId, "name", UserId(), AssetId())
       val members = Seq(
         TeamMember(UserId(), Option(Permissions(0L, 0L)), None),
         TeamMember(UserId(), Option(Permissions(0L, 0L)), None)
@@ -58,7 +58,7 @@ class TeamsSyncHandlerSpec extends AndroidFreeSpec {
     scenario("Failed members download should fail entire sync") {
 
       val teamId = TeamId()
-      val teamData = TeamData(teamId, "name", UserId())
+      val teamData = TeamData(teamId, "name", UserId(), AssetId())
 
       val timeoutError = ErrorResponse(ErrorResponse.ConnectionErrorCode, s"Request failed with timeout", "connection-error")
 


### PR DESCRIPTION
## What's new in this PR?

This PR includes changes to `TeamData` required to display the team logo. Specifically, I have changed the type for `icon` from `RAssetId` to `AssetId` to be more aligned with the new way we process assets. Additionally, I've removed the `icon_key` property since team logos are now considered to be public assets, and therefore the key is no longer needed.

These changes required a migration for both the global and user databases. The migration in the user database is to simply switch a flag so that the team will sync on upgrade. The migration in the global database is to drop the column for `icon_key`.

### Testing

I manually tested the database migration, all is fine and no black screen of death 😄 