### PR TITLE
Feature: add global preference for app lock

### DIFF
--- a/zmessaging/src/main/scala/com/waz/content/Preferences.scala
+++ b/zmessaging/src/main/scala/com/waz/content/Preferences.scala
@@ -387,6 +387,8 @@ object GlobalPreferences {
   // TODO: Remove after release 3.36
   lazy val ShouldWarnAndroid4Users = PrefKey[Boolean]( "should_warn_android_4_users", customDefault = true)
 
+  lazy val AppLockEnabled: PrefKey[Boolean] = PrefKey[Boolean]("app_lock_enabled", customDefault = false)
+
   //DEPRECATED!!! Use the UserPreferences instead!!
   lazy val _ShareContacts          = PrefKey[Boolean]("PREF_KEY_PRIVACY_CONTACTS")
   lazy val _DarkTheme              = PrefKey[Boolean]("DarkTheme")


### PR DESCRIPTION
## What's new in this PR?

This PR simply adds a global preference for enabling app lock. It will be used in the UI project to add a preference in the app settings. It is a global preference because the app lock is not a per-account feature.