### PR TITLE
fix: Ephemeral assets are not displayed

### DIFF
--- a/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
+++ b/zmessaging/src/main/scala/com/waz/service/messages/MessageEventProcessor.scala
@@ -17,17 +17,15 @@
  */
 package com.waz.service.messages
 
-import com.waz.api.{Message, Verification}
+import com.waz.api.Message.Type._
 import com.waz.content.MessagesStorage
 import com.waz.log.BasicLogging.LogTag.DerivedLogTag
 import com.waz.log.LogSE._
-import com.waz.model.GenericContent.{Asset, Calling, Cleared, DeliveryReceipt, Ephemeral, Knock, LastRead, Location, MsgDeleted, MsgEdit, MsgRecall, Reaction, Text}
+import com.waz.model.GenericContent.{Asset, Calling, Cleared, DeliveryReceipt, Ephemeral, Knock, LastRead, LinkPreview, Location, MsgDeleted, MsgEdit, MsgRecall, Reaction, Text}
 import com.waz.model.{GenericContent, _}
 import com.waz.service.EventScheduler
 import com.waz.service.assets2.{AssetService, AssetStatus, DownloadAsset, DownloadAssetStatus, DownloadAssetStorage, GeneralAsset, Asset => Asset2}
 import com.waz.service.conversation.{ConversationsContentUpdater, ConversationsService}
-import com.waz.service.otr.OtrService
-import com.waz.service.otr.VerificationStateUpdater.{ClientAdded, ClientUnverified, MemberAdded, VerificationChange}
 import com.waz.threading.Threading
 import com.waz.utils.crypto.ReplyHashing
 import com.waz.utils.events.EventContext
@@ -37,15 +35,13 @@ import scala.concurrent.Future
 
 class MessageEventProcessor(selfUserId:           UserId,
                             storage:              MessagesStorage,
-                            content:              MessagesContentUpdater,
+                            contentUpdater:       MessagesContentUpdater,
                             assets:               AssetService,
                             replyHashing:         ReplyHashing,
                             msgsService:          MessagesService,
                             convsService:         ConversationsService,
                             convs:                ConversationsContentUpdater,
-                            otr:                  OtrService,
                             downloadAssetStorage: DownloadAssetStorage) extends DerivedLogTag {
-
   import MessageEventProcessor._
   import Threading.Implicits.Background
   private implicit val ec = EventContext.Global
@@ -68,15 +64,13 @@ class MessageEventProcessor(selfUserId:           UserId,
       case e => conv.cleared.forall(_.isBefore(e.time))
     }
 
-    verbose(l"SYNC process events")
-
     for {
       eventData     <- Future.traverse(toProcess)(localDataForEvent)
-      modifications =  eventData.map(eald => createModifications(conv, isGroup, eald))
-      msgs          <- getModifiedMessages(modifications)
+      modifications =  eventData.map { case (event, asset) => createModifications(conv, isGroup, event, asset) }
+      msgs          <- checkReplyHashes(modifications.collect { case m if m.message != MessageData.Empty => m.message })
       _             =  verbose(l"SYNC messages from events: ${msgs.map(m => m.id -> m.msgType)}")
       _             <- addUnexpectedMembers(conv.id, events)
-      res           <- content.addMessages(conv.id, msgs)
+      res           <- contentUpdater.addMessages(conv.id, msgs)
       _             <- Future.traverse(modifications.flatMap(_.assets))(assets.save)
       _             <- updateLastReadFromOwnMessages(conv.id, msgs)
       _             <- deleteCancelled(modifications)
@@ -85,6 +79,162 @@ class MessageEventProcessor(selfUserId:           UserId,
       _             =  verbose(l"SYNC processing events finished")
     } yield res
   }
+
+  private def createModifications(conv: ConversationData,
+                                  isGroup: Boolean,
+                                  event: MessageEvent,
+                                  downloadAsset: Option[DownloadAsset]): EventModifications = {
+    lazy val id = MessageId()
+    event match {
+      case ConnectRequestEvent(_, time, from, text, recipient, name, email) =>
+        EventModifications(MessageData(id, conv.id, CONNECT_REQUEST, from, MessageData.textContent(text), recipient = Some(recipient), email = email, name = Some(name), time = time, localTime = event.localTime))
+      case RenameConversationEvent(_, time, from, name) =>
+        EventModifications(MessageData(id, conv.id, RENAME, from, name = Some(name), time = time, localTime = event.localTime))
+      case MessageTimerEvent(_, time, from, duration) =>
+        EventModifications(MessageData(id, conv.id, MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
+      case MemberJoinEvent(_, time, from, userIds, firstEvent) =>
+        EventModifications(MessageData(id, conv.id, MEMBER_JOIN, from, members = userIds.toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
+      case ConversationReceiptModeEvent(_, time, from, 0) =>
+        EventModifications(MessageData(id, conv.id, READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
+      case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>
+        EventModifications(MessageData(id, conv.id, READ_RECEIPTS_ON, from, time = time, localTime = event.localTime))
+      case MemberLeaveEvent(_, time, from, userIds) =>
+        EventModifications(MessageData(id, conv.id, MEMBER_LEAVE, from, members = userIds.toSet, time = time, localTime = event.localTime))
+      case OtrErrorEvent(_, time, from, IdentityChangedError(_, _)) =>
+        EventModifications(MessageData(id, conv.id, OTR_IDENTITY_CHANGED, from, time = time, localTime = event.localTime))
+      case OtrErrorEvent(_, time, from, _) =>
+        EventModifications(MessageData(id, conv.id, OTR_ERROR, from, time = time, localTime = event.localTime))
+      case GenericMessageEvent(_, time, from, proto) =>
+        verbose(l"generic message event")
+        val GenericMessage(uid, msgContent) = proto
+        content(MessageId(uid.str), conv.id, msgContent, from, event.localTime, time, conv.receiptMode.filter(_ => isGroup), downloadAsset, proto)
+      case _: CallMessageEvent =>
+        EventModifications.Empty
+      case _ =>
+        warn(l"Unexpected event for addMessage: $event")
+        EventModifications.Empty
+    }
+  }
+
+  private def content(id:                MessageId,
+                      convId:            ConvId,
+                      msgContent:        Any,
+                      from:              UserId,
+                      localTime:         LocalInstant,
+                      time:              RemoteInstant,
+                      forceReadReceipts: Option[Int],
+                      downloadAsset:     Option[DownloadAsset],
+                      proto:             GenericMessage
+                     ): EventModifications = msgContent match {
+    case Ephemeral(expiry, ct) =>
+      val modifications = content(id, convId, ct, from, localTime, time, forceReadReceipts, downloadAsset, proto)
+      modifications.copy(message = modifications.message.copy(ephemeral = expiry))
+    case Text(text, mentions, links, quote) =>
+      textEventModifications(id, convId, text, mentions, links, quote, from, localTime, time, forceReadReceipts, proto)
+    case asset: Asset =>
+      assetEventModifications(id, convId, asset, from, localTime, time, forceReadReceipts, downloadAsset, proto)
+    case _: Knock =>
+      EventModifications(MessageData(id, convId, KNOCK, from, time = time, localTime = localTime, protos = Seq(proto), forceReadReceipts = forceReadReceipts))
+    case _: Location =>
+      EventModifications(MessageData(id, convId, LOCATION, from, time = time, localTime = localTime, protos = Seq(proto), forceReadReceipts = forceReadReceipts))
+    case _: Reaction                   => EventModifications.Empty
+    case _: LastRead                   => EventModifications.Empty
+    case _: Cleared                    => EventModifications.Empty
+    case _: MsgDeleted                 => EventModifications.Empty
+    case _: MsgRecall                  => EventModifications.Empty
+    case _: MsgEdit                    => EventModifications.Empty
+    case DeliveryReceipt(_)            => EventModifications.Empty
+    case GenericContent.ReadReceipt(_) => EventModifications.Empty
+    case _: Calling                    => EventModifications.Empty
+    case _ =>
+      // TODO: this message should be processed again after app update, maybe future app version will understand it
+      EventModifications(MessageData(id, convId, UNKNOWN, from, time = time, localTime = localTime, protos = Seq(proto)))
+  }
+
+  /**
+    * Creates safe version of incoming message.
+    * Messages sent by malicious contacts might contain content intended to break the app. One example of that
+    * are very long text messages, backend doesn't restrict the size much to allow for assets and group messages,
+    * because of encryption it's also not possible to limit text messages there. On client such messages are handled
+    * inline, and will cause memory problems.
+    * We may need to do more involved checks in future.
+    */
+  private def textEventModifications(id:                MessageId,
+                                     convId:            ConvId,
+                                     originalText:      String,
+                                     mentions:          Seq[Mention],
+                                     linkPreviews:      Seq[LinkPreview],
+                                     quote:             Option[GenericContent.Quote],
+                                     from:              UserId,
+                                     localTime:         LocalInstant,
+                                     time:              RemoteInstant,
+                                     forceReadReceipts: Option[Int],
+                                     proto:             GenericMessage): EventModifications = {
+    val (text, links) =
+      if (originalText.length > MaxTextContentLength)
+        (originalText.take(MaxTextContentLength), linkPreviews.filter(p => p.url.length + p.urlOffset <= MaxTextContentLength))
+      else
+        (originalText, linkPreviews)
+    val (tpe, content) = MessageData.messageContent(text, mentions, links)
+    val quoteContent   = quote.map(q => QuoteContent(MessageId(q.quotedMessageId), validity = false, Some(Sha256(q.quotedMessageSha256))))
+    val asset          = links.find(lp => lp.image != null && lp.image.hasUploaded)
+      .map(lp => Asset2.create(DownloadAsset.create(lp.image), lp.image.getUploaded))
+    val messageData    = MessageData(
+      id, convId, tpe, from, content, time = time, localTime = localTime, protos = Seq(proto),
+      quote = quoteContent, forceReadReceipts = forceReadReceipts, assetId = asset.map(_.id)
+    )
+    EventModifications(messageData.adjustMentions(false).getOrElse(messageData), asset.map((_, None)))
+  }
+
+  private def assetEventModifications(id:                MessageId,
+                                      convId:            ConvId,
+                                      asset:             Asset,
+                                      from:              UserId,
+                                      localTime:         LocalInstant,
+                                      time:              RemoteInstant,
+                                      forceReadReceipts: Option[Int],
+                                      downloadAsset:     Option[DownloadAsset],
+                                      proto:             GenericMessage): EventModifications =
+    if (DownloadAsset.getStatus(asset) == DownloadAssetStatus.Cancelled) EventModifications.Empty else {
+      val tpe = Option(asset.original) match {
+        case None                      => UNKNOWN
+        case Some(org) if org.hasVideo => VIDEO_ASSET
+        case Some(org) if org.hasAudio => AUDIO_ASSET
+        case Some(org) if org.hasImage => ASSET
+        case Some(_)                   => ANY_ASSET
+      }
+
+      val assetAndPreview =
+        if (asset.hasUploaded) {
+          val preview = Option(asset.preview).map(Asset2.create)
+          val updatedDownloadAsset = downloadAsset.map(da => da.copy(preview = preview.map(_.id).orElse(da.preview), status = AssetStatus.Done))
+          val asset2 = Asset2.create(updatedDownloadAsset.getOrElse(DownloadAsset.create(asset)), asset.getUploaded)
+          verbose(l"Received asset v3 with preview")
+          Some((asset2, preview))
+        } else if (DownloadAsset.getStatus(asset) == DownloadAssetStatus.Failed && asset.original.hasImage) {
+          verbose(l"Received a message about a failed image upload: $id. Dropping")
+          None
+        } else if (DownloadAsset.getStatus(asset) == DownloadAssetStatus.Cancelled) {
+          verbose(l"Uploader cancelled asset: $id")
+          val asset2 = downloadAsset.map(_.copy(status = DownloadAssetStatus.Cancelled)).getOrElse(DownloadAsset.create(asset))
+          Some((asset2, None))
+        } else {
+          val preview = Option(asset.preview).map(Asset2.create)
+          val asset2 = downloadAsset
+            .map(da => da.copy(preview = preview.map(_.id).orElse(da.preview), status = DownloadAsset.getStatus(asset)))
+            .getOrElse(DownloadAsset.create(asset))
+          verbose(l"Received asset without remote data - we will expect another update")
+          Some((asset2, preview))
+        }
+
+      EventModifications(
+        MessageData(
+          id, convId, tpe, from, time = time, localTime = localTime, protos = Seq(proto),
+          forceReadReceipts = forceReadReceipts, assetId = assetAndPreview.map(_._1.id)
+        ),
+        assetAndPreview
+      )
+    }
 
   private def checkReplyHashes(msgs: Seq[MessageData]) = {
     val (standard, quotes) = msgs.partition(_.quote.isEmpty)
@@ -111,10 +261,7 @@ class MessageEventProcessor(selfUserId:           UserId,
         case Some(dId: DownloadAssetId) => downloadAssetStorage.find(dId)
         case _                          => Future.successful(None)
       }
-    } yield EventAndLocalData(event, message, asset)
-
-  private def getModifiedMessages(modifications: Seq[EventModifications]) =
-    checkReplyHashes(modifications.collect { case m if m.message != MessageData.Empty => m.message })
+    } yield (event, asset)
 
   private def addUnexpectedMembers(convId: ConvId, events: Seq[MessageEvent]) = {
     val potentiallyUnexpectedMembers = events.filter {
@@ -125,12 +272,13 @@ class MessageEventProcessor(selfUserId:           UserId,
   }
 
   private def applyRecalls(convId: ConvId, toProcess: Seq[MessageEvent]) = {
+    import com.waz.api.Message.Status.SENT
     val recalls = toProcess collect {
       case GenericMessageEvent(_, time, from, msg @ GenericMessage(_, MsgRecall(_))) => (msg, from, time)
     }
     Future.traverse(recalls) {
       case (GenericMessage(id, MsgRecall(ref)), user, time) =>
-        msgsService.recallMessage(convId, ref, user, MessageId(id.str), time, Message.Status.SENT)
+        msgsService.recallMessage(convId, ref, user, MessageId(id.str), time, SENT)
     }
   }
 
@@ -145,150 +293,9 @@ class MessageEventProcessor(selfUserId:           UserId,
     }
   }
 
-  private def updatedAssets(id: Uid, content: Any, downloadAsset: Option[DownloadAsset]): Seq[(GeneralAsset, Option[GeneralAsset])] = {
-    verbose(l"update asset for event: $id")
-
-    content match {
-
-      case asset: Asset if asset.hasUploaded =>
-        val preview = Option(asset.preview).map(Asset2.create)
-        val updatedDownloadAsset = downloadAsset.map(da => da.copy(preview = preview.map(_.id).orElse(da.preview), status = AssetStatus.Done))
-        val asset2 = Asset2.create(updatedDownloadAsset.getOrElse(DownloadAsset.create(asset)), asset.getUploaded)
-
-        verbose(l"Received asset v3 with preview")
-        List((asset2, preview))
-
-      case Text(_, _, linkPreviews, _) =>
-        linkPreviews
-          .collect { case lp if lp.image != null && lp.image.hasUploaded => lp }
-          .map { lp =>
-            val asset = Asset2.create(DownloadAsset.create(lp.image), lp.image.getUploaded)
-            verbose(l"Received link preview asset: ${asset.id}")
-            (asset, Option.empty[GeneralAsset])
-          }
-
-      case asset: Asset if DownloadAsset.getStatus(asset) == DownloadAssetStatus.Failed && asset.original.hasImage =>
-        verbose(l"Received a message about a failed image upload: $id. Dropping")
-        List.empty
-
-      case asset: Asset if DownloadAsset.getStatus(asset) == DownloadAssetStatus.Cancelled =>
-        verbose(l"Uploader cancelled asset: $id")
-        val asset2 = downloadAsset.map(_.copy(status = DownloadAssetStatus.Cancelled)).getOrElse(DownloadAsset.create(asset))
-        List((asset2, None))
-
-      case asset: Asset =>
-        val preview = Option(asset.preview).map(Asset2.create)
-        val updatedDownloadAsset = downloadAsset.map(da => da.copy(preview = preview.map(_.id).orElse(da.preview), status = DownloadAsset.getStatus(asset)))
-        val asset2 = updatedDownloadAsset.getOrElse(DownloadAsset.create(asset))
-        verbose(l"Received asset without remote data - we will expect another update")
-        List((asset2, preview))
-
-      case Ephemeral(_, content) =>
-        updatedAssets(id, content, downloadAsset)
-
-      case _ =>
-        List.empty
-    }
-  }
-
-  private def createModifications(conv: ConversationData, isGroup: Boolean, eventAndLocalData: EventAndLocalData): EventModifications = {
-    val convId = conv.id
-    val event = eventAndLocalData.event
-
-    def forceReceiptMode: Option[Int] = conv.receiptMode.filter(_ => isGroup)
-
-    //v3 assets go here
-    def content(id: MessageId, msgContent: Any, from: UserId, time: RemoteInstant, proto: GenericMessage): MessageData = msgContent match {
-      case Text(text, mentions, links, quote) =>
-        val (tpe, content) = MessageData.messageContent(text, mentions, links)
-        verbose(l"MessageData content: $content")
-        val quoteContent = quote.map(q => QuoteContent(MessageId(q.quotedMessageId), validity = false, Some(Sha256(q.quotedMessageSha256))))
-        val messageData = MessageData(id, conv.id, tpe, from, content, time = time, localTime = event.localTime, protos = Seq(proto), quote = quoteContent, forceReadReceipts = forceReceiptMode)
-          messageData.adjustMentions(false).getOrElse(messageData)
-      case Knock() =>
-        MessageData(id, conv.id, Message.Type.KNOCK, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case Reaction(_, _) => MessageData.Empty
-      case asset: Asset if asset.original == null =>
-        MessageData(id, convId, Message.Type.UNKNOWN, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case asset: Asset if DownloadAsset.getStatus(asset) == DownloadAssetStatus.Cancelled =>
-        MessageData.Empty
-      case asset: Asset if asset.original.hasVideo =>
-        MessageData(id, convId, Message.Type.VIDEO_ASSET, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case asset: Asset if asset.original.hasAudio =>
-        MessageData(id, convId, Message.Type.AUDIO_ASSET, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case asset: Asset if asset.original.hasImage =>
-        MessageData(id, convId, Message.Type.ASSET, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case _: Asset =>
-        MessageData(id, convId, Message.Type.ANY_ASSET, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case Location(_, _, _, _) =>
-        MessageData(id, convId, Message.Type.LOCATION, from, time = time, localTime = event.localTime, protos = Seq(proto), forceReadReceipts = forceReceiptMode)
-      case LastRead(_, _) => MessageData.Empty
-      case Cleared(_, _) => MessageData.Empty
-      case MsgDeleted(_, _) => MessageData.Empty
-      case MsgRecall(_) => MessageData.Empty
-      case MsgEdit(_, _) => MessageData.Empty
-      case DeliveryReceipt(_) => MessageData.Empty
-      case GenericContent.ReadReceipt(_) => MessageData.Empty
-      case Calling(_) => MessageData.Empty
-      case Ephemeral(expiry, ct) =>
-        content(id, ct, from, time, proto).copy(ephemeral = expiry)
-      case _ =>
-        error(l"unexpected generic message content for id: $id")
-        // TODO: this message should be processed again after app update, maybe future app version will understand it
-        MessageData(id, conv.id, Message.Type.UNKNOWN, from, time = time, localTime = event.localTime, protos = Seq(proto))
-    }
-
-    /**
-      * Creates safe version of incoming message.
-      * Messages sent by malicious contacts might contain content intended to break the app. One example of that
-      * are very long text messages, backend doesn't restrict the size much to allow for assets and group messages,
-      * because of encryption it's also not possible to limit text messages there. On client such messages are handled
-      * inline, and will cause memory problems.
-      * We may need to do more involved checks in future.
-      */
-    def sanitize(msg: GenericMessage): GenericMessage = msg match {
-      case GenericMessage(uid, t @ Text(text, mentions, links, quote)) if text.length > MaxTextContentLength =>
-        GenericMessage(uid, Text(text.take(MaxTextContentLength), mentions, links.filter { p => p.url.length + p.urlOffset <= MaxTextContentLength }, quote, t.expectsReadConfirmation))
-      case _ =>
-        msg
-    }
-
-    val id = MessageId()
-    event match {
-      case ConnectRequestEvent(_, time, from, text, recipient, name, email) =>
-        EventModifications(MessageData(id, convId, Message.Type.CONNECT_REQUEST, from, MessageData.textContent(text), recipient = Some(recipient), email = email, name = Some(name), time = time, localTime = event.localTime))
-      case RenameConversationEvent(_, time, from, name) =>
-        EventModifications(MessageData(id, convId, Message.Type.RENAME, from, name = Some(name), time = time, localTime = event.localTime))
-      case MessageTimerEvent(_, time, from, duration) =>
-        EventModifications(MessageData(id, convId, Message.Type.MESSAGE_TIMER, from, time = time, duration = duration, localTime = event.localTime))
-      case MemberJoinEvent(_, time, from, userIds, firstEvent) =>
-        EventModifications(MessageData(id, convId, Message.Type.MEMBER_JOIN, from, members = userIds.toSet, time = time, localTime = event.localTime, firstMessage = firstEvent))
-      case ConversationReceiptModeEvent(_, time, from, 0) =>
-        EventModifications(MessageData(id, convId, Message.Type.READ_RECEIPTS_OFF, from, time = time, localTime = event.localTime))
-      case ConversationReceiptModeEvent(_, time, from, receiptMode) if receiptMode > 0 =>
-        EventModifications(MessageData(id, convId, Message.Type.READ_RECEIPTS_ON, from, time = time, localTime = event.localTime))
-      case MemberLeaveEvent(_, time, from, userIds) =>
-        EventModifications(MessageData(id, convId, Message.Type.MEMBER_LEAVE, from, members = userIds.toSet, time = time, localTime = event.localTime))
-      case OtrErrorEvent(_, time, from, IdentityChangedError(_, _)) =>
-        EventModifications(MessageData(id, conv.id, Message.Type.OTR_IDENTITY_CHANGED, from, time = time, localTime = event.localTime))
-      case OtrErrorEvent(_, time, from, otrError) =>
-        EventModifications(MessageData(id, conv.id, Message.Type.OTR_ERROR, from, time = time, localTime = event.localTime))
-      case GenericMessageEvent(_, time, from, proto) =>
-        val sanitized @ GenericMessage(uid, msgContent) = sanitize(proto)
-        val id = MessageId(uid.str)
-        val assets = updatedAssets(uid, sanitized.getAsset, eventAndLocalData.asset)
-        val message = content(id, msgContent, from, time, sanitized).copy(assetId = assets.headOption.map(_._1.id))
-        EventModifications(message, assets)
-      case _: CallMessageEvent =>
-        EventModifications(MessageData.Empty)
-      case _ =>
-        warn(l"Unexpected event for addMessage: $event")
-        EventModifications(MessageData.Empty)}
-  }
-
   private def deleteCancelled(modifications: Seq[EventModifications]): Future[Unit] = {
-    val toRemove = modifications.filter { m =>
-      m.assetWithPreview.headOption match {
+    val toRemove = modifications.filter {
+      _.assetWithPreview match {
         case Some((asset: DownloadAsset, _)) => asset.status == DownloadAssetStatus.Cancelled
         case _ => false
       }
@@ -302,40 +309,21 @@ class MessageEventProcessor(selfUserId:           UserId,
 
   private def updateLastReadFromOwnMessages(convId: ConvId, msgs: Seq[MessageData]) =
     msgs.reverseIterator.find(_.userId == selfUserId).fold2(Future.successful(None), msg => convs.updateConversationLastRead(convId, msg.time))
-
-  def addMessagesAfterVerificationUpdate(updates: Seq[(ConversationData, ConversationData)], convUsers: Map[ConvId, Seq[UserData]], changes: Map[UserId, VerificationChange]) =
-    Future.traverse(updates) {
-      case (prev, up) if up.verified == Verification.VERIFIED => msgsService.addOtrVerifiedMessage(up.id)
-      case (prev, up) if prev.verified == Verification.VERIFIED =>
-        verbose(l"addMessagesAfterVerificationUpdate with prev=${prev.verified} and up=${up.verified}")
-        val convId = up.id
-        val changedUsers = convUsers(convId).filter(!_.isVerified).flatMap { u => changes.get(u.id).map(u.id -> _) }
-        val (users, change) =
-          if (changedUsers.forall(c => c._2 == ClientAdded)) (changedUsers map (_._1), ClientAdded)
-          else if (changedUsers.forall(c => c._2 == MemberAdded)) (changedUsers map (_._1), MemberAdded)
-          else (changedUsers collect { case (user, ClientUnverified) => user }, ClientUnverified)
-
-        val (self, other) = users.partition(_ == selfUserId)
-        for {
-          _ <- if (self.nonEmpty) msgsService.addOtrUnverifiedMessage(convId, Seq(selfUserId), change) else Future.successful(())
-          _ <- if (other.nonEmpty) msgsService.addOtrUnverifiedMessage(convId, other, change) else Future.successful(())
-        } yield ()
-      case _ =>
-        Future.successful(())
-    }
-
 }
 
 object MessageEventProcessor {
   val MaxTextContentLength = 8192
 
   case class EventModifications(message: MessageData,
-                                assetWithPreview: Seq[(GeneralAsset, Option[GeneralAsset])] = List.empty) {
-    val assets: Seq[GeneralAsset] = assetWithPreview.flatMap {
-      case (asset, Some(preview)) => List(asset, preview)
-      case (asset, None) => List(asset)
+                                assetWithPreview: Option[(GeneralAsset, Option[GeneralAsset])] = None) {
+    lazy val assets: List[GeneralAsset] = assetWithPreview match {
+      case Some((asset, Some(preview))) => List(asset, preview)
+      case Some((asset, None))          => List(asset)
+      case None                         => Nil
     }
   }
 
-  case class EventAndLocalData(event: MessageEvent, message: Option[MessageData], asset: Option[DownloadAsset])
+  object EventModifications {
+    val Empty = EventModifications(MessageData.Empty)
+  }
 }

--- a/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
+++ b/zmessaging/src/test/scala/com/waz/service/MessageEventProcessorSpec.scala
@@ -41,7 +41,6 @@ import scala.concurrent.duration._
 
 class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with DerivedLogTag {
 
-
   val selfUserId        = UserId("self")
   val storage           = mock[MessagesStorage]
   val convsStorage      = mock[ConversationStorage]
@@ -51,7 +50,6 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
   val replyHashing      = mock[ReplyHashing]
   val msgsService       = mock[MessagesService]
   val convs             = mock[ConversationsContentUpdater]
-  val otr               = mock[OtrService]
   val convsService      = mock[ConversationsService]
   val downloadStorage   = mock[DownloadAssetStorage]
   val prefs             = new TestGlobalPreferences()
@@ -195,7 +193,7 @@ class MessageEventProcessorSpec extends AndroidFreeSpec with Inside with Derived
     //often repeated mocks
     (deletions.getAll _).expects(*).anyNumberOfTimes().returning(Future.successful(Seq.empty))
 
-    new MessageEventProcessor(selfUserId, storage, content, assets, replyHashing, msgsService, convsService, convs, otr, downloadStorage)
+    new MessageEventProcessor(selfUserId, storage, content, assets, replyHashing, msgsService, convsService, convs, downloadStorage)
   }
 
 }


### PR DESCRIPTION
With new assets the message data was enlarged with a new field, `assetId: Option[AssetId]`.
So, instead of looking through assets for those having the given messageId, we use the fact
that we display at most one asset per message and we can simply store its id in the message.
`MessageEventProcessor` was modified, so that now it looks for assets and sets `assetId` when
creating `MessageData`. However, that part was broken for ephemeral messages: if a message
was ephemeral and having an asset, it was recognized first as having an asset, but then
the code failed to set the asset's id, because the type of the event was invalid.

I suspect the reason for that bug was that `MessageEventProcessor` became very complex. A lot
of changes was made to it during the last years, and it was never refactored. I decided to
rewrite most of it with focus on making it clear how the procedure of turning an event into
a message data looks like.